### PR TITLE
Notes need to define CONTAINER_RUNTIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@
 Operator for packaging and managing a collection of arbitrary Kubernetes objects to install software on one or multiple clusters.
 
 ---
+Dev Note: Assure you have `export CONTAINER_RUNTIME=docker` or similar for `podman`, or you will get cryptic errors from
+mage that may lead you to think there is a problem with Kind cluster.


### PR DESCRIPTION
If `CONTAINER_RUNTIME` is undefined you will get messages like:
```
package-operator main $ bin/mage dev:setup
2022/09/26 15:18:45 "level"=0 "msg"="detected container-runtime" "container-runtime"="podman"
Error: initializing dev environment: getting existing kind clusters: exit status 1
```
This might send you off debugging in the wrong direction.

Adds a dev note to the README to alert dev users to define this env variable