### PR TITLE
Introduce InTransition condition

### DIFF
--- a/apis/core/v1alpha1/commonobjectset_types.go
+++ b/apis/core/v1alpha1/commonobjectset_types.go
@@ -66,6 +66,9 @@ const (
 	// Succeeded condition is only set once,
 	// after a ObjectSet became Available for the first time.
 	ObjectSetSucceeded = "Succeeded"
+	// InTransition condition is True when the ObjectSet is not in control of all objects defined in spec.
+	// This holds true during rollout of the first instance or while handing over objects between two ObjectSets.
+	ObjectSetInTransition = "InTransition"
 )
 
 type ObjectSetStatusPhase string
@@ -81,8 +84,6 @@ const (
 	ObjectSetStatusPhaseNotReady ObjectSetStatusPhase = "NotReady"
 	// Paused maps to the Paused condition.
 	ObjectSetStatusPhasePaused ObjectSetStatusPhase = "Paused"
-	// Deprecated is reported, when only a subset of object is paused.
-	ObjectSetStatusPhaseDeprecated ObjectSetStatusPhase = "Deprecated"
 	// Archived maps to the Archived condition.
 	ObjectSetStatusPhaseArchived ObjectSetStatusPhase = "Archived"
 )

--- a/integration/objectset_test.go
+++ b/integration/objectset_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Simple Setup, Pause and Teardown test.
+//nolint:maintidx
 func TestObjectSet_setupPauseTeardown(t *testing.T) {
 	defaultObjectSet := func(cm4, cm5 *corev1.ConfigMap) (*corev1alpha1.ObjectSet, error) {
 		cm4Obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm4)
@@ -165,11 +166,11 @@ func TestObjectSet_setupPauseTeardown(t *testing.T) {
 
 			// expect Succeeded condition to be not present
 			succeededCond := meta.FindStatusCondition(objectSet.Status.Conditions, corev1alpha1.ObjectSetSucceeded)
-			assert.Nil(t, succeededCond, "expected Succeeded condition to not be reported")
+			require.Nil(t, succeededCond, "expected Succeeded condition to not be reported")
 
 			// expect InTransition to be reported and True
 			inTransition := meta.IsStatusConditionTrue(objectSet.Status.Conditions, corev1alpha1.ObjectSetInTransition)
-			assert.True(t, inTransition, "expected InTransition to be reported and True")
+			require.True(t, inTransition, "expected InTransition to be reported and True")
 
 			// expect cm-4 to be present.
 			currentCM4 := &corev1.ConfigMap{}
@@ -191,11 +192,11 @@ func TestObjectSet_setupPauseTeardown(t *testing.T) {
 
 			// expect Succeeded condition to be True
 			isSucceeded := meta.IsStatusConditionTrue(objectSet.Status.Conditions, corev1alpha1.ObjectSetSucceeded)
-			assert.True(t, isSucceeded, "expected Succeeded condition to be True")
+			require.True(t, isSucceeded, "expected Succeeded condition to be True")
 
 			// expect InTransition condition to be not present
 			inTransitionCond := meta.FindStatusCondition(objectSet.Status.Conditions, corev1alpha1.ObjectSetInTransition)
-			assert.Nil(t, inTransitionCond, "expected InTransition condition to not be reported")
+			require.Nil(t, inTransitionCond, "expected InTransition condition to not be reported")
 
 			// expect cm-4 and cm-5 to be reported under "ControllerOf"
 			require.Equal(t, []corev1alpha1.ControlledObjectReference{

--- a/integration/objectset_test.go
+++ b/integration/objectset_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Simple Setup, Pause and Teardown test.
+//
 //nolint:maintidx
 func TestObjectSet_setupPauseTeardown(t *testing.T) {
 	defaultObjectSet := func(cm4, cm5 *corev1.ConfigMap) (*corev1alpha1.ObjectSet, error) {

--- a/internal/controllers/objectsets/objectsetphases_reconciler.go
+++ b/internal/controllers/objectsets/objectsetphases_reconciler.go
@@ -76,12 +76,12 @@ type phaseReconciler interface {
 func (r *objectSetPhasesReconciler) Reconcile(
 	ctx context.Context, objectSet genericObjectSet,
 ) (res ctrl.Result, err error) {
-	activeObjects, probingResult, err := r.reconcile(ctx, objectSet)
+	controllerOf, probingResult, err := r.reconcile(ctx, objectSet)
 	if err != nil {
 		return res, err
 	}
+	objectSet.SetStatusControllerOf(controllerOf)
 
-	objectSet.SetStatusControllerOf(activeObjects)
 	if !probingResult.IsZero() {
 		meta.SetStatusCondition(objectSet.GetConditions(), metav1.Condition{
 			Type:               corev1alpha1.ObjectSetAvailable,
@@ -94,14 +94,31 @@ func (r *objectSetPhasesReconciler) Reconcile(
 		return res, nil
 	}
 
+	inTransition := r.isObjectSetInTransition(objectSet, controllerOf)
+	if inTransition {
+		meta.SetStatusCondition(objectSet.GetConditions(), metav1.Condition{
+			Type:               corev1alpha1.ObjectSetInTransition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "InTransition",
+			Message:            "ObjectSet is still rolling out or is being replaced by a newer version.",
+			ObservedGeneration: objectSet.ClientObject().GetGeneration(),
+		})
+	} else {
+		meta.RemoveStatusCondition(objectSet.GetConditions(), corev1alpha1.ObjectSetInTransition)
+	}
+
 	if !meta.IsStatusConditionTrue(
-		*objectSet.GetConditions(), corev1alpha1.ObjectSetSucceeded) {
+		*objectSet.GetConditions(), corev1alpha1.ObjectSetSucceeded) &&
+		// we don't want to record Succeeded during transition,
+		// because the object may become Available due to external
+		// (e.g. other ObjectSets) involvement.
+		!inTransition {
 		// Remember that this rollout worked!
 		meta.SetStatusCondition(objectSet.GetConditions(), metav1.Condition{
 			Type:               corev1alpha1.ObjectSetSucceeded,
 			Status:             metav1.ConditionTrue,
-			Reason:             "AvailableOnce",
-			Message:            "Object was available once and passed all probes.",
+			Reason:             "RolloutSuccess",
+			Message:            "ObjectSet rolled out all objects successfully and was Available at least once.",
 			ObservedGeneration: objectSet.ClientObject().GetGeneration(),
 		})
 	}
@@ -131,24 +148,24 @@ func (r *objectSetPhasesReconciler) reconcile(
 		return nil, controllers.ProbingResult{}, fmt.Errorf("parsing probes: %w", err)
 	}
 
-	var activeObjects []corev1alpha1.ControlledObjectReference
+	var controllerOfAll []corev1alpha1.ControlledObjectReference
 	for _, phase := range objectSet.GetPhases() {
-		active, probingResult, err := r.reconcilePhase(
+		controllerOf, probingResult, err := r.reconcilePhase(
 			ctx, objectSet, phase, probe, previous)
 		if err != nil {
 			return nil, controllers.ProbingResult{}, err
 		}
 
-		// always gather all active objects
-		activeObjects = append(activeObjects, active...)
+		// always gather all objects we are controller of
+		controllerOfAll = append(controllerOfAll, controllerOf...)
 
 		if !probingResult.IsZero() {
 			// break on first failing probe
-			return activeObjects, probingResult, nil
+			return controllerOfAll, probingResult, nil
 		}
 	}
 
-	return activeObjects, controllers.ProbingResult{}, nil
+	return controllerOfAll, controllers.ProbingResult{}, nil
 }
 
 func (r *objectSetPhasesReconciler) reconcilePhase(
@@ -178,13 +195,13 @@ func (r *objectSetPhasesReconciler) reconcileLocalPhase(
 		return nil, probingResult, err
 	}
 
-	activeObjects, err := controllers.GetControllerOf(
+	controllerOf, err := controllers.GetControllerOf(
 		ctx, r.scheme, r.ownerStrategy,
 		objectSet.ClientObject(), actualObjects)
 	if err != nil {
 		return nil, controllers.ProbingResult{}, err
 	}
-	return activeObjects, probingResult, nil
+	return controllerOf, probingResult, nil
 }
 
 func (r *objectSetPhasesReconciler) Teardown(
@@ -222,4 +239,36 @@ func reverse[T any](s []T) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
+}
+
+// Checks if an ObjectSet is in transition.
+// An ObjectSet is in transition if it is not yet or no longer
+// controlling all objects from spec.
+// This state is true until the ObjectSet has finished a successful rollout
+// or from the moment a newer revision is taking ownership until it has been archived.
+func (r *objectSetPhasesReconciler) isObjectSetInTransition(
+	objectSet genericObjectSet,
+	controllerOf []corev1alpha1.ControlledObjectReference,
+) bool {
+	controlledIndex := map[corev1alpha1.ControlledObjectReference]struct{}{}
+	for _, controlled := range controllerOf {
+		controlledIndex[controlled] = struct{}{}
+	}
+
+	for _, phase := range objectSet.GetPhases() {
+		for _, obj := range phase.Objects {
+			gvk := obj.Object.GroupVersionKind()
+			ref := corev1alpha1.ControlledObjectReference{
+				Kind:      gvk.Kind,
+				Group:     gvk.Group,
+				Name:      obj.Object.GetName(),
+				Namespace: obj.Object.GetNamespace(),
+			}
+			if _, isControlledByThisInstance := controlledIndex[ref]; !isControlledByThisInstance {
+				// This object is not yet reconciled by this instance or has been taken somewhere else.
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
InTransition is set while an ObjectSet is not rolled out completely. This condition prevents ambeguity when looking at ObjectSet objects during an rollout process.
If an ObjectSet is InTransition, we will delay to report Succeeded until the rollout state is clean.

Signed-off-by: Nico Schieder <nschieder@redhat.com>