### PR TITLE
Implement preflight checks

### DIFF
--- a/cmd/package-operator-manager/main.go
+++ b/cmd/package-operator-manager/main.go
@@ -160,6 +160,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("ObjectSet"),
 		mgr.GetScheme(), dc, recorder,
+		mgr.GetRESTMapper(),
 	).SetupWithManager(mgr)); err != nil {
 		return fmt.Errorf("unable to create controller for ObjectSet: %w", err)
 	}
@@ -167,6 +168,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("ClusterObjectSet"),
 		mgr.GetScheme(), dc, recorder,
+		mgr.GetRESTMapper(),
 	).SetupWithManager(mgr)); err != nil {
 		return fmt.Errorf("unable to create controller for ClusterObjectSet: %w", err)
 	}
@@ -176,12 +178,14 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 	if err = (objectsetphases.NewSameClusterObjectSetPhaseController(
 		ctrl.Log.WithName("controllers").WithName("ObjectSetPhase"),
 		mgr.GetScheme(), dc, defaultObjectSetPhaseClass, mgr.GetClient(),
+		mgr.GetRESTMapper(),
 	).SetupWithManager(mgr)); err != nil {
 		return fmt.Errorf("unable to create controller for ObjectSetPhase: %w", err)
 	}
 	if err = (objectsetphases.NewSameClusterClusterObjectSetPhaseController(
 		ctrl.Log.WithName("controllers").WithName("ClusterObjectSetPhase"),
 		mgr.GetScheme(), dc, defaultObjectSetPhaseClass, mgr.GetClient(),
+		mgr.GetRESTMapper(),
 	).SetupWithManager(mgr)); err != nil {
 		return fmt.Errorf("unable to create controller for ClusterObjectSetPhase: %w", err)
 	}

--- a/internal/preflight/apis_exist.go
+++ b/internal/preflight/apis_exist.go
@@ -1,0 +1,46 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+// Prevents the use of APIs not registered into the kube-apiserver.
+type APIExistence struct {
+	restMapper meta.RESTMapper
+}
+
+var _ checker = (*APIExistence)(nil)
+
+func NewAPIExistence(restMapper meta.RESTMapper) *APIExistence {
+	return &APIExistence{
+		restMapper: restMapper,
+	}
+}
+
+func (p *APIExistence) Check(
+	ctx context.Context, owner client.Object,
+	phase corev1alpha1.ObjectSetTemplatePhase,
+) (violations []Violation, err error) {
+	for i, obj := range phase.Objects {
+		gvk := obj.Object.GroupVersionKind()
+		_, err := p.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if meta.IsNoMatchError(err) {
+			violations = append(violations, Violation{
+				Position: fmt.Sprintf("Phase %q, object No.%d", phase.Name, i),
+				Error:    fmt.Sprintf("%s not registered on the api server.", gvk),
+			})
+			continue
+		}
+		if err != nil {
+			return violations, err
+		}
+	}
+
+	return
+}

--- a/internal/preflight/namespace_escalation_protection.go
+++ b/internal/preflight/namespace_escalation_protection.go
@@ -1,0 +1,73 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+// Prevents namespace escalation from users specifying cluster-scoped resources or
+// resources in other namespaces in non-cluster-scoped APIs.
+type NamespaceEscalation struct {
+	restMapper meta.RESTMapper
+}
+
+var _ checker = (*NamespaceEscalation)(nil)
+
+func NewNamespaceEscalation(restMapper meta.RESTMapper) *NamespaceEscalation {
+	return &NamespaceEscalation{
+		restMapper: restMapper,
+	}
+}
+
+func (p *NamespaceEscalation) Check(
+	ctx context.Context, owner client.Object,
+	phase corev1alpha1.ObjectSetTemplatePhase,
+) (violations []Violation, err error) {
+	if len(owner.GetNamespace()) == 0 {
+		// Owner is cluster-scoped
+		// we allow objects in multiple namespaces :)
+		return
+	}
+
+	if len(phase.Class) > 0 {
+		// the plugin implementation has the final say, when class is set.
+		return
+	}
+
+	// ObjectDeployment/ObjectSet/ObjectSetPhase
+	// All objects need to be namespace-scoped and either have a namespace equal
+	// to their owner or empty so it can be defaulted.
+	for i, obj := range phase.Objects {
+		if len(obj.Object.GetNamespace()) > 0 &&
+			obj.Object.GetNamespace() != owner.GetNamespace() {
+			violations = append(violations, Violation{
+				Position: fmt.Sprintf("Phase %q, object No.%d", phase.Name, i),
+				Error:    "Must stay within the same namespace.",
+			})
+		}
+
+		gvk := obj.Object.GroupVersionKind()
+		mapping, err := p.restMapper.RESTMapping(
+			gvk.GroupKind(), gvk.Version)
+		if meta.IsNoMatchError(err) {
+			// covered by APIsExistence check
+			continue
+		}
+		if err != nil {
+			return violations, err
+		}
+
+		if mapping.Scope != meta.RESTScopeNamespace {
+			violations = append(violations, Violation{
+				Position: fmt.Sprintf("Phase %q, object No.%d", phase.Name, i),
+				Error:    "Must be namespaced scoped when part of an non-cluster-scoped API.",
+			})
+		}
+	}
+	return
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,46 @@
+// package preflight implements preflight checks for PKO APIs.
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+type Violation struct {
+	// Position the violation was found.
+	Position string
+	// Error describing the violation.
+	Error string
+}
+
+func (v *Violation) String() string {
+	return fmt.Sprintf("%s: %s", v.Position, v.Error)
+}
+
+type checker interface {
+	Check(
+		ctx context.Context, owner client.Object,
+		phase corev1alpha1.ObjectSetTemplatePhase,
+	) (violations []Violation, err error)
+}
+
+// Runs a list of preflight checks and aggregates the result into a single list of violations.
+type List []checker
+
+func (l List) Check(
+	ctx context.Context, owner client.Object,
+	phase corev1alpha1.ObjectSetTemplatePhase,
+) (violations []Violation, err error) {
+	for _, checker := range l {
+		v, err := checker.Check(ctx, owner, phase)
+		if err != nil {
+			return violations, err
+		}
+		violations = append(violations, v...)
+	}
+	return
+}


### PR DESCRIPTION
Introduced preflight checks ensure that users can't escalate their permissions by creating objects in other namespaces or cluster scoped when using namespace-scoped APIs.

A second preflight check ensures that APIs are registered in the cluster before attempting to create objects.

Signed-off-by: Nico Schieder <nschieder@redhat.com>