### PR TITLE
Remove ObjectDeployment revision annotation

### DIFF
--- a/internal/controllers/objectdeployments/adapter_objectset.go
+++ b/internal/controllers/objectdeployments/adapter_objectset.go
@@ -316,16 +316,8 @@ type objectSetsByRevisionAscending []genericObjectSet
 func (a objectSetsByRevisionAscending) Len() int      { return len(a) }
 func (a objectSetsByRevisionAscending) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a objectSetsByRevisionAscending) Less(i, j int) bool {
-	iClientObj := a[i].ClientObject()
-	jClientObj := a[j].ClientObject()
 	iObj := a[i]
 	jObj := a[j]
-
-	if iObj.GetRevision() == 0 ||
-		jObj.GetRevision() == 0 {
-		return iClientObj.GetCreationTimestamp().UTC().Before(
-			jClientObj.GetCreationTimestamp().UTC())
-	}
 
 	return iObj.GetRevision() < jObj.GetRevision()
 }

--- a/internal/controllers/objectdeployments/new_revision_reconciler_test.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler_test.go
@@ -31,10 +31,10 @@ func Test_new_revision_reconciler(t *testing.T) {
 			{
 				client: testutil.NewClient(),
 				prevRevisions: []corev1alpha1.ObjectSet{
-					makeObjectSet("rev3", "3", "abcd", false),
-					makeObjectSet("rev1", "1", "xyz", false),
-					makeObjectSet("rev2", "2", "pqr", false),
-					makeObjectSet("rev4", "4", "abc", true),
+					makeObjectSet("rev3", 3, "abcd", false),
+					makeObjectSet("rev1", 1, "xyz", false),
+					makeObjectSet("rev2", 2, "pqr", false),
+					makeObjectSet("rev4", 4, "abc", true),
 				},
 				deploymentGeneration:       5,
 				deploymentHash:             "test1",
@@ -45,15 +45,15 @@ func Test_new_revision_reconciler(t *testing.T) {
 			{
 				client: testutil.NewClient(),
 				prevRevisions: []corev1alpha1.ObjectSet{
-					makeObjectSet("rev3", "3", "abcd", false),
-					makeObjectSet("rev1", "1", "xyz", true),
-					makeObjectSet("rev2", "2", "pqr", false),
-					makeObjectSet("rev4", "4", "abc", false),
+					makeObjectSet("rev3", 3, "abcd", false),
+					makeObjectSet("rev1", 1, "xyz", true),
+					makeObjectSet("rev2", 2, "pqr", false),
+					makeObjectSet("rev4", 4, "abc", false),
 				},
 				deploymentGeneration:       5,
 				deploymentHash:             "xyz",
 				conflict:                   true,
-				conflictObject:             makeObjectSet("rev1", "1", "xyz", true),
+				conflictObject:             makeObjectSet("rev1", 1, "xyz", true),
 				expectedHashCollisionCount: 1,
 			},
 			// Object already present, but sanity check kicks in
@@ -61,15 +61,15 @@ func Test_new_revision_reconciler(t *testing.T) {
 			{
 				client: testutil.NewClient(),
 				prevRevisions: []corev1alpha1.ObjectSet{
-					makeObjectSet("rev3", "3", "abcd", false),
-					makeObjectSet("rev1", "1", "xyz", true),
-					makeObjectSet("rev2", "2", "pqr", false),
-					makeObjectSet("rev4", "4", "abc", false),
+					makeObjectSet("rev3", 3, "abcd", false),
+					makeObjectSet("rev1", 1, "xyz", true),
+					makeObjectSet("rev2", 2, "pqr", false),
+					makeObjectSet("rev4", 4, "abc", false),
 				},
 				deploymentGeneration:       4,
 				deploymentHash:             "abc",
 				conflict:                   true,
-				conflictObject:             makeObjectSet("rev4", "4", "abc", true),
+				conflictObject:             makeObjectSet("rev4", 4, "abc", true),
 				expectedHashCollisionCount: 0,
 			},
 		}
@@ -170,9 +170,6 @@ func assertObject(t *testing.T,
 	hash, ok1 := obj.Annotations[ObjectSetHashAnnotation]
 	require.True(t, ok1)
 	require.Equal(t, hash, expectedHash)
-	revision, ok2 := obj.Annotations[DeploymentRevisionAnnotation]
-	require.True(t, ok2)
-	require.Equal(t, revision, expectedRevision)
 	require.True(t, len(prevs) == len(obj.Spec.Previous))
 
 	objprevs := make([]string, len(obj.Spec.Previous))

--- a/internal/controllers/objectdeployments/objectdeployment_controller.go
+++ b/internal/controllers/objectdeployments/objectdeployment_controller.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	ObjectSetHashAnnotation      = "package-operator.run/hash"
-	DeploymentRevisionAnnotation = "package-operator.run/deployment-revision"
+	ObjectSetHashAnnotation = "package-operator.run/hash"
 )
 
 type reconciler interface {


### PR DESCRIPTION
Remove ObjectDeploymentRevision annotation and rely on revision count reporting from ObjectSets.
Previously ObjectDeployment.metadata.generation was used to track the latest ObjectSet revision number, but .metadata.generation will diverge from the revision generation counter if fields outside the .spec.template.spec (e.g. RevisionHistoryLimit) are changed.

This PR is also closing a few different race conditions that come from using only inaccurate timestamps for revision ordering or not waiting for all ObjectSets to report a revision number.

Signed-off-by: Nico Schieder <nschieder@redhat.com>