### PR TITLE
Implement PKO self-bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin
 .cache
 .deps
 config/static-deployment/deployment.yaml
+config/current-self-bootstrap-job.yaml
 
 # JetBrains IDEs (e.g. GoLand)
 .idea/

--- a/cmd/package-operator-manager/bootstrap.go
+++ b/cmd/package-operator-manager/bootstrap.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/package-operator/internal/controllers"
+	"package-operator.run/package-operator/internal/packages"
+)
+
+const (
+	packageOperatorClusterPackageName   = "package-operator"
+	packageOperatorPackageCheckInterval = 2 * time.Second
+)
+
+func runBootstrap(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
+	folderLoader := packages.NewFolderLoader(scheme)
+
+	ctx := logr.NewContext(context.Background(), log.WithName("bootstrap"))
+	res, err := folderLoader.Load(ctx, "/package", packages.FolderLoaderTemplateContext{})
+	if err != nil {
+		return err
+	}
+
+	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	// Install CRDs or the manager wont start
+	crdGK := schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}
+	for _, phase := range res.TemplateSpec.Phases {
+		for _, obj := range phase.Objects {
+			gk := obj.Object.GetObjectKind().GroupVersionKind().GroupKind()
+			if gk != crdGK {
+				continue
+			}
+
+			crd := &obj.Object
+
+			// Set cache label
+			labels := crd.GetLabels()
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			labels[controllers.DynamicCacheLabel] = "True"
+			crd.SetLabels(labels)
+
+			if err := c.Create(ctx, crd); err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+	}
+
+	packageOperatorPackage := &corev1alpha1.ClusterPackage{}
+	err = c.Get(ctx, client.ObjectKey{
+		Name: "package-operator",
+	}, packageOperatorPackage)
+	if err == nil && meta.IsStatusConditionTrue(packageOperatorPackage.Status.Conditions, corev1alpha1.PackageUnpacked) {
+		// Package Operator is already installed
+		log.Info("Package Operator already installed, updating via in-cluster Package Operator")
+		packageOperatorPackage.Spec.Image = opts.selfBootstrap
+		return c.Update(ctx, packageOperatorPackage)
+	}
+
+	if err != nil && !errors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+		return err
+	}
+
+	log.Info("Package Operator NOT installed, self-bootstrapping")
+
+	// Force Adoption of objects during initial bootstrap to take ownership of
+	// CRDs, Namespace, ServiceAccount and ClusterRoleBinding.
+	if err := os.Setenv("PKO_FORCE_ADOPTION", "1"); err != nil {
+		return err
+	}
+
+	// Create PackageOperator ClusterPackage
+	packageOperatorPackage.Name = packageOperatorClusterPackageName
+	packageOperatorPackage.Spec.Image = opts.selfBootstrap
+	if err := c.Create(ctx, packageOperatorPackage); err != nil {
+		return err
+	}
+
+	// Wait till PKO is ready.
+	go func() {
+		err := wait.PollImmediateUntilWithContext(
+			ctx, packageOperatorPackageCheckInterval,
+			func(ctx context.Context) (done bool, err error) {
+				packageOperatorPackage := &corev1alpha1.ClusterPackage{}
+				err = c.Get(ctx, client.ObjectKey{Name: packageOperatorClusterPackageName}, packageOperatorPackage)
+				if err != nil {
+					return done, err
+				}
+
+				if meta.IsStatusConditionTrue(packageOperatorPackage.Status.Conditions, corev1alpha1.PackageAvailable) {
+					return true, nil
+				}
+				return false, nil
+			})
+		if err != nil {
+			panic(err)
+		}
+
+		log.Info("Package Operator bootstrapped successfully!")
+		os.Exit(0)
+	}()
+
+	// Run Manager until it has bootstrapped itself.
+	return runManager(log, scheme, opts)
+}

--- a/config/packages/package-operator/.gitignore
+++ b/config/packages/package-operator/.gitignore
@@ -1,0 +1,1 @@
+package-operator-manager.Deployment.yaml

--- a/config/packages/package-operator/README.md
+++ b/config/packages/package-operator/README.md
@@ -1,0 +1,3 @@
+# Package Operator Package
+
+A package to install Package Operator via Package Operator!

--- a/config/packages/package-operator/crds/clusterobjectdeployments.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/clusterobjectdeployments.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,400 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: clusterobjectdeployments.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ClusterObjectDeployment
+    listKind: ClusterObjectDeploymentList
+    plural: clusterobjectdeployments
+    singular: clusterobjectdeployment
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterObjectDeployment is the Schema for the ClusterObjectDeployments
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterObjectDeploymentSpec defines the desired state of
+              a ClusterObjectDeployment.
+            properties:
+              revisionHistoryLimit:
+                default: 10
+                description: Number of old revisions in the form of archived ObjectSets
+                  to keep.
+                format: int32
+                type: integer
+              selector:
+                description: Selector targets ObjectSets managed by this Deployment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template to create new ObjectSets from.
+                properties:
+                  metadata:
+                    description: Common Object Metadata.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: ObjectSet specification.
+                    properties:
+                      availabilityProbes:
+                        description: Availability Probes check objects that are part
+                          of the package. All probes need to succeed for a package
+                          to be considered Available. Failing probes will prevent
+                          the reconciliation of objects in later phases.
+                        items:
+                          description: ObjectSetProbe define how ObjectSets check
+                            their children for their status.
+                          properties:
+                            probes:
+                              description: Probe configuration parameters.
+                              items:
+                                description: Defines probe parameters. Only one can
+                                  be filled.
+                                properties:
+                                  condition:
+                                    description: Checks whether or not the object
+                                      reports a condition with given type and status.
+                                    properties:
+                                      status:
+                                        default: "True"
+                                        description: Condition status to probe for.
+                                        type: string
+                                      type:
+                                        description: Condition type to probe for.
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  fieldsEqual:
+                                    description: Compares two fields specified by
+                                      JSON Paths.
+                                    properties:
+                                      fieldA:
+                                        description: First field for comparison.
+                                        type: string
+                                      fieldB:
+                                        description: Second field for comparison.
+                                        type: string
+                                    required:
+                                    - fieldA
+                                    - fieldB
+                                    type: object
+                                type: object
+                              type: array
+                            selector:
+                              description: Selector specifies which objects this probe
+                                should target.
+                              properties:
+                                kind:
+                                  description: Kind and API Group of the object to
+                                    probe.
+                                  properties:
+                                    group:
+                                      description: Object Group to apply a probe to.
+                                      type: string
+                                    kind:
+                                      description: Object Kind to apply a probe to.
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  type: object
+                                selector:
+                                  description: Further sub-selects objects based on
+                                    a Label Selector.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - kind
+                              type: object
+                          required:
+                          - probes
+                          - selector
+                          type: object
+                        type: array
+                      phases:
+                        description: Reconcile phase configuration for a ObjectSet.
+                          Phases will be reconciled in order and the contained objects
+                          checked against given probes before continuing with the
+                          next phase.
+                        items:
+                          description: ObjectSet reconcile phase.
+                          properties:
+                            class:
+                              description: If non empty, the ObjectSet controller
+                                will delegate phase reconciliation to another controller,
+                                by creating an ObjectSetPhase object. If set to the
+                                string "default" the built-in Package Operator ObjectSetPhase
+                                controller will reconcile the object in the same way
+                                the ObjectSet would. If set to any other string, an
+                                out-of-tree controller needs to be present to handle
+                                ObjectSetPhase objects.
+                              type: string
+                            name:
+                              description: Name of the reconcile phase. Must be unique
+                                within a ObjectSet.
+                              type: string
+                            objects:
+                              description: Objects belonging to this phase.
+                              items:
+                                description: An object that is part of the phase of
+                                  an ObjectSet.
+                                properties:
+                                  object:
+                                    type: object
+                                    x-kubernetes-embedded-resource: true
+                                    x-kubernetes-preserve-unknown-fields: true
+                                required:
+                                - object
+                                type: object
+                              type: array
+                          required:
+                          - name
+                          - objects
+                          type: object
+                        type: array
+                    required:
+                    - availabilityProbes
+                    - phases
+                    type: object
+                required:
+                - metadata
+                - spec
+                type: object
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: ClusterObjectDeploymentStatus defines the observed state
+              of a ClusterObjectDeployment.
+            properties:
+              collisionCount:
+                description: Count of hash collisions of the ClusterObjectDeployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: This field is not part of any API contract it will go
+                  away as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+              templateHash:
+                description: Computed TemplateHash.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/clusterobjectsetphases.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/clusterobjectsetphases.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,325 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: clusterobjectsetphases.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ClusterObjectSetPhase
+    listKind: ClusterObjectSetPhaseList
+    plural: clusterobjectsetphases
+    singular: clusterobjectsetphase
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterObjectSetPhase is an internal API, allowing a ClusterObjectSet
+          to delegate a single phase to another custom controller. ClusterObjectSets
+          will create subordinate ClusterObjectSetPhases when `.class` is set within
+          the phase specification.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterObjectSetPhaseSpec defines the desired state of a
+              ClusterObjectSetPhase.
+            properties:
+              availabilityProbes:
+                description: Availability Probes check objects that are part of the
+                  package. All probes need to succeed for a package to be considered
+                  Available. Failing probes will prevent the reconciliation of objects
+                  in later phases.
+                items:
+                  description: ObjectSetProbe define how ObjectSets check their children
+                    for their status.
+                  properties:
+                    probes:
+                      description: Probe configuration parameters.
+                      items:
+                        description: Defines probe parameters. Only one can be filled.
+                        properties:
+                          condition:
+                            description: Checks whether or not the object reports
+                              a condition with given type and status.
+                            properties:
+                              status:
+                                default: "True"
+                                description: Condition status to probe for.
+                                type: string
+                              type:
+                                description: Condition type to probe for.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          fieldsEqual:
+                            description: Compares two fields specified by JSON Paths.
+                            properties:
+                              fieldA:
+                                description: First field for comparison.
+                                type: string
+                              fieldB:
+                                description: Second field for comparison.
+                                type: string
+                            required:
+                            - fieldA
+                            - fieldB
+                            type: object
+                        type: object
+                      type: array
+                    selector:
+                      description: Selector specifies which objects this probe should
+                        target.
+                      properties:
+                        kind:
+                          description: Kind and API Group of the object to probe.
+                          properties:
+                            group:
+                              description: Object Group to apply a probe to.
+                              type: string
+                            kind:
+                              description: Object Kind to apply a probe to.
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          type: object
+                        selector:
+                          description: Further sub-selects objects based on a Label
+                            Selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                  required:
+                  - probes
+                  - selector
+                  type: object
+                type: array
+              class:
+                description: If non empty, the ObjectSet controller will delegate
+                  phase reconciliation to another controller, by creating an ObjectSetPhase
+                  object. If set to the string "default" the built-in Package Operator
+                  ObjectSetPhase controller will reconcile the object in the same
+                  way the ObjectSet would. If set to any other string, an out-of-tree
+                  controller needs to be present to handle ObjectSetPhase objects.
+                type: string
+              name:
+                description: Name of the reconcile phase. Must be unique within a
+                  ObjectSet.
+                type: string
+              objects:
+                description: Objects belonging to this phase.
+                items:
+                  description: An object that is part of the phase of an ObjectSet.
+                  properties:
+                    object:
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - object
+                  type: object
+                type: array
+              paused:
+                description: Disables reconciliation of the ClusterObjectSet. Only
+                  Status updates will still be propagated, but object changes will
+                  not be reconciled.
+                type: boolean
+              previous:
+                description: Previous revisions of the ClusterObjectSet to adopt objects
+                  from.
+                items:
+                  description: References a previous revision of an ObjectSet or ClusterObjectSet.
+                  properties:
+                    name:
+                      description: Name of a previous revision.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              revision:
+                description: Revision of the parent ObjectSet to use during object
+                  adoption.
+                format: int64
+                type: integer
+            required:
+            - availabilityProbes
+            - name
+            - objects
+            - revision
+            type: object
+          status:
+            description: ClusterObjectSetPhaseStatus defines the observed state of
+              a ClusterObjectSetPhase.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerOf:
+                description: References all objects controlled by this instance.
+                items:
+                  description: References an object controlled by this ObjectSet/ObjectSetPhase.
+                  properties:
+                    group:
+                      description: Object Group.
+                      type: string
+                    kind:
+                      description: Object Kind.
+                      type: string
+                    name:
+                      description: Object Name.
+                      type: string
+                    namespace:
+                      description: Object Namespace.
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/clusterobjectsets.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/clusterobjectsets.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,369 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: clusterobjectsets.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ClusterObjectSet
+    listKind: ClusterObjectSetList
+    plural: clusterobjectsets
+    singular: clusterobjectset
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterObjectSet reconciles a collection of objects through
+          ordered phases and aggregates their status. \n ClusterObjectSets behave
+          similarly to Kubernetes ReplicaSets, by managing a collection of objects
+          and being itself mostly immutable. This object type is able to suspend/pause
+          reconciliation of specific objects to facilitate the transition between
+          revisions. \n Archived ClusterObjectSets may stay on the cluster, to store
+          information about previous revisions. \n A Namespace-scoped version of this
+          API is available as ObjectSet."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterObjectSetSpec defines the desired state of a ClusterObjectSet.
+            properties:
+              availabilityProbes:
+                description: Availability Probes check objects that are part of the
+                  package. All probes need to succeed for a package to be considered
+                  Available. Failing probes will prevent the reconciliation of objects
+                  in later phases.
+                items:
+                  description: ObjectSetProbe define how ObjectSets check their children
+                    for their status.
+                  properties:
+                    probes:
+                      description: Probe configuration parameters.
+                      items:
+                        description: Defines probe parameters. Only one can be filled.
+                        properties:
+                          condition:
+                            description: Checks whether or not the object reports
+                              a condition with given type and status.
+                            properties:
+                              status:
+                                default: "True"
+                                description: Condition status to probe for.
+                                type: string
+                              type:
+                                description: Condition type to probe for.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          fieldsEqual:
+                            description: Compares two fields specified by JSON Paths.
+                            properties:
+                              fieldA:
+                                description: First field for comparison.
+                                type: string
+                              fieldB:
+                                description: Second field for comparison.
+                                type: string
+                            required:
+                            - fieldA
+                            - fieldB
+                            type: object
+                        type: object
+                      type: array
+                    selector:
+                      description: Selector specifies which objects this probe should
+                        target.
+                      properties:
+                        kind:
+                          description: Kind and API Group of the object to probe.
+                          properties:
+                            group:
+                              description: Object Group to apply a probe to.
+                              type: string
+                            kind:
+                              description: Object Kind to apply a probe to.
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          type: object
+                        selector:
+                          description: Further sub-selects objects based on a Label
+                            Selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                  required:
+                  - probes
+                  - selector
+                  type: object
+                type: array
+              lifecycleState:
+                default: Active
+                description: Specifies the lifecycle state of the ClusterObjectSet.
+                enum:
+                - Active
+                - Paused
+                - Archived
+                type: string
+              phases:
+                description: Reconcile phase configuration for a ObjectSet. Phases
+                  will be reconciled in order and the contained objects checked against
+                  given probes before continuing with the next phase.
+                items:
+                  description: ObjectSet reconcile phase.
+                  properties:
+                    class:
+                      description: If non empty, the ObjectSet controller will delegate
+                        phase reconciliation to another controller, by creating an
+                        ObjectSetPhase object. If set to the string "default" the
+                        built-in Package Operator ObjectSetPhase controller will reconcile
+                        the object in the same way the ObjectSet would. If set to
+                        any other string, an out-of-tree controller needs to be present
+                        to handle ObjectSetPhase objects.
+                      type: string
+                    name:
+                      description: Name of the reconcile phase. Must be unique within
+                        a ObjectSet.
+                      type: string
+                    objects:
+                      description: Objects belonging to this phase.
+                      items:
+                        description: An object that is part of the phase of an ObjectSet.
+                        properties:
+                          object:
+                            type: object
+                            x-kubernetes-embedded-resource: true
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - object
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - objects
+                  type: object
+                type: array
+              previous:
+                description: Previous revisions of the ClusterObjectSet to adopt objects
+                  from.
+                items:
+                  description: References a previous revision of an ObjectSet or ClusterObjectSet.
+                  properties:
+                    name:
+                      description: Name of a previous revision.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - availabilityProbes
+            - phases
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerOf:
+                description: References all objects controlled by this instance.
+                items:
+                  description: References an object controlled by this ObjectSet/ObjectSetPhase.
+                  properties:
+                    group:
+                      description: Object Group.
+                      type: string
+                    kind:
+                      description: Object Kind.
+                      type: string
+                    name:
+                      description: Object Name.
+                      type: string
+                    namespace:
+                      description: Object Namespace.
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                type: array
+              phase:
+                description: Phase is not part of any API contract it will go away
+                  as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+              remotePhases:
+                description: Remote phases aka ClusterObjectSetPhase objects.
+                items:
+                  description: References remote phases aka ObjectSetPhase/ClusterObjectSetPhase
+                    objects to which a phase is delegated.
+                  properties:
+                    name:
+                      type: string
+                    uid:
+                      description: UID is a type that holds unique ID values, including
+                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias
+                        to string.  Being a type captures intent and helps make sure
+                        that UIDs and names do not get conflated.
+                      type: string
+                  required:
+                  - name
+                  - uid
+                  type: object
+                type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/clusterpackages.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/clusterpackages.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: clusterpackages.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ClusterPackage
+    listKind: ClusterPackageList
+    plural: clusterpackages
+    singular: clusterpackage
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Package specification.
+            properties:
+              image:
+                description: the image containing the contents of the package this
+                  image will be unpacked by the package-loader to render the ObjectDeployment
+                  for propagating the installation of the package.
+                type: string
+            required:
+            - image
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: PackageStatus defines the observed state of a Package.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: This field is not part of any API contract it will go
+                  away as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/objectdeployments.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/objectdeployments.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,397 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: objectdeployments.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ObjectDeployment
+    listKind: ObjectDeploymentList
+    plural: objectdeployments
+    singular: objectdeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ObjectDeployment is the Schema for the ObjectDeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObjectDeploymentSpec defines the desired state of a ObjectDeployment.
+            properties:
+              revisionHistoryLimit:
+                default: 10
+                description: Number of old revisions in the form of archived ObjectSets
+                  to keep.
+                format: int32
+                type: integer
+              selector:
+                description: Selector targets ObjectSets managed by this Deployment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template to create new ObjectSets from.
+                properties:
+                  metadata:
+                    description: Common Object Metadata.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: ObjectSet specification.
+                    properties:
+                      availabilityProbes:
+                        description: Availability Probes check objects that are part
+                          of the package. All probes need to succeed for a package
+                          to be considered Available. Failing probes will prevent
+                          the reconciliation of objects in later phases.
+                        items:
+                          description: ObjectSetProbe define how ObjectSets check
+                            their children for their status.
+                          properties:
+                            probes:
+                              description: Probe configuration parameters.
+                              items:
+                                description: Defines probe parameters. Only one can
+                                  be filled.
+                                properties:
+                                  condition:
+                                    description: Checks whether or not the object
+                                      reports a condition with given type and status.
+                                    properties:
+                                      status:
+                                        default: "True"
+                                        description: Condition status to probe for.
+                                        type: string
+                                      type:
+                                        description: Condition type to probe for.
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  fieldsEqual:
+                                    description: Compares two fields specified by
+                                      JSON Paths.
+                                    properties:
+                                      fieldA:
+                                        description: First field for comparison.
+                                        type: string
+                                      fieldB:
+                                        description: Second field for comparison.
+                                        type: string
+                                    required:
+                                    - fieldA
+                                    - fieldB
+                                    type: object
+                                type: object
+                              type: array
+                            selector:
+                              description: Selector specifies which objects this probe
+                                should target.
+                              properties:
+                                kind:
+                                  description: Kind and API Group of the object to
+                                    probe.
+                                  properties:
+                                    group:
+                                      description: Object Group to apply a probe to.
+                                      type: string
+                                    kind:
+                                      description: Object Kind to apply a probe to.
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  type: object
+                                selector:
+                                  description: Further sub-selects objects based on
+                                    a Label Selector.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - kind
+                              type: object
+                          required:
+                          - probes
+                          - selector
+                          type: object
+                        type: array
+                      phases:
+                        description: Reconcile phase configuration for a ObjectSet.
+                          Phases will be reconciled in order and the contained objects
+                          checked against given probes before continuing with the
+                          next phase.
+                        items:
+                          description: ObjectSet reconcile phase.
+                          properties:
+                            class:
+                              description: If non empty, the ObjectSet controller
+                                will delegate phase reconciliation to another controller,
+                                by creating an ObjectSetPhase object. If set to the
+                                string "default" the built-in Package Operator ObjectSetPhase
+                                controller will reconcile the object in the same way
+                                the ObjectSet would. If set to any other string, an
+                                out-of-tree controller needs to be present to handle
+                                ObjectSetPhase objects.
+                              type: string
+                            name:
+                              description: Name of the reconcile phase. Must be unique
+                                within a ObjectSet.
+                              type: string
+                            objects:
+                              description: Objects belonging to this phase.
+                              items:
+                                description: An object that is part of the phase of
+                                  an ObjectSet.
+                                properties:
+                                  object:
+                                    type: object
+                                    x-kubernetes-embedded-resource: true
+                                    x-kubernetes-preserve-unknown-fields: true
+                                required:
+                                - object
+                                type: object
+                              type: array
+                          required:
+                          - name
+                          - objects
+                          type: object
+                        type: array
+                    required:
+                    - availabilityProbes
+                    - phases
+                    type: object
+                required:
+                - metadata
+                - spec
+                type: object
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
+            properties:
+              collisionCount:
+                description: Count of hash collisions of the ObjectDeployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: This field is not part of any API contract it will go
+                  away as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+              templateHash:
+                description: Computed TemplateHash.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/objectsetphases.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/objectsetphases.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,322 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: objectsetphases.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ObjectSetPhase
+    listKind: ObjectSetPhaseList
+    plural: objectsetphases
+    singular: objectsetphase
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ObjectSetPhase is an internal API, allowing an ObjectSet to delegate
+          a single phase to another custom controller. ObjectSets will create subordinate
+          ObjectSetPhases when `.class` within the phase specification is set.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObjectSetPhaseSpec defines the desired state of a ObjectSetPhase.
+            properties:
+              availabilityProbes:
+                description: Availability Probes check objects that are part of the
+                  package. All probes need to succeed for a package to be considered
+                  Available. Failing probes will prevent the reconciliation of objects
+                  in later phases.
+                items:
+                  description: ObjectSetProbe define how ObjectSets check their children
+                    for their status.
+                  properties:
+                    probes:
+                      description: Probe configuration parameters.
+                      items:
+                        description: Defines probe parameters. Only one can be filled.
+                        properties:
+                          condition:
+                            description: Checks whether or not the object reports
+                              a condition with given type and status.
+                            properties:
+                              status:
+                                default: "True"
+                                description: Condition status to probe for.
+                                type: string
+                              type:
+                                description: Condition type to probe for.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          fieldsEqual:
+                            description: Compares two fields specified by JSON Paths.
+                            properties:
+                              fieldA:
+                                description: First field for comparison.
+                                type: string
+                              fieldB:
+                                description: Second field for comparison.
+                                type: string
+                            required:
+                            - fieldA
+                            - fieldB
+                            type: object
+                        type: object
+                      type: array
+                    selector:
+                      description: Selector specifies which objects this probe should
+                        target.
+                      properties:
+                        kind:
+                          description: Kind and API Group of the object to probe.
+                          properties:
+                            group:
+                              description: Object Group to apply a probe to.
+                              type: string
+                            kind:
+                              description: Object Kind to apply a probe to.
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          type: object
+                        selector:
+                          description: Further sub-selects objects based on a Label
+                            Selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                  required:
+                  - probes
+                  - selector
+                  type: object
+                type: array
+              class:
+                description: If non empty, the ObjectSet controller will delegate
+                  phase reconciliation to another controller, by creating an ObjectSetPhase
+                  object. If set to the string "default" the built-in Package Operator
+                  ObjectSetPhase controller will reconcile the object in the same
+                  way the ObjectSet would. If set to any other string, an out-of-tree
+                  controller needs to be present to handle ObjectSetPhase objects.
+                type: string
+              name:
+                description: Name of the reconcile phase. Must be unique within a
+                  ObjectSet.
+                type: string
+              objects:
+                description: Objects belonging to this phase.
+                items:
+                  description: An object that is part of the phase of an ObjectSet.
+                  properties:
+                    object:
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - object
+                  type: object
+                type: array
+              paused:
+                description: Disables reconciliation of the ObjectSet. Only Status
+                  updates will still be propagated, but object changes will not be
+                  reconciled.
+                type: boolean
+              previous:
+                description: Previous revisions of the ObjectSet to adopt objects
+                  from.
+                items:
+                  description: References a previous revision of an ObjectSet or ClusterObjectSet.
+                  properties:
+                    name:
+                      description: Name of a previous revision.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              revision:
+                description: Revision of the parent ObjectSet to use during object
+                  adoption.
+                format: int64
+                type: integer
+            required:
+            - availabilityProbes
+            - name
+            - objects
+            - revision
+            type: object
+          status:
+            description: ObjectSetPhaseStatus defines the observed state of a ObjectSetPhase.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerOf:
+                description: References all objects controlled by this instance.
+                items:
+                  description: References an object controlled by this ObjectSet/ObjectSetPhase.
+                  properties:
+                    group:
+                      description: Object Group.
+                      type: string
+                    kind:
+                      description: Object Kind.
+                      type: string
+                    name:
+                      description: Object Name.
+                      type: string
+                    namespace:
+                      description: Object Namespace.
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/objectsets.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/objectsets.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,368 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: objectsets.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: ObjectSet
+    listKind: ObjectSetList
+    plural: objectsets
+    singular: objectset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ObjectSet reconciles a collection of objects through ordered
+          phases and aggregates their status. \n ObjectSets behave similarly to Kubernetes
+          ReplicaSets, by managing a collection of objects and being itself mostly
+          immutable. This object type is able to suspend/pause reconciliation of specific
+          objects to facilitate the transition between revisions. \n Archived ObjectSets
+          may stay on the cluster, to store information about previous revisions.
+          \n A Cluster-scoped version of this API is available as ClusterObjectSet."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObjectSetSpec defines the desired state of a ObjectSet.
+            properties:
+              availabilityProbes:
+                description: Availability Probes check objects that are part of the
+                  package. All probes need to succeed for a package to be considered
+                  Available. Failing probes will prevent the reconciliation of objects
+                  in later phases.
+                items:
+                  description: ObjectSetProbe define how ObjectSets check their children
+                    for their status.
+                  properties:
+                    probes:
+                      description: Probe configuration parameters.
+                      items:
+                        description: Defines probe parameters. Only one can be filled.
+                        properties:
+                          condition:
+                            description: Checks whether or not the object reports
+                              a condition with given type and status.
+                            properties:
+                              status:
+                                default: "True"
+                                description: Condition status to probe for.
+                                type: string
+                              type:
+                                description: Condition type to probe for.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          fieldsEqual:
+                            description: Compares two fields specified by JSON Paths.
+                            properties:
+                              fieldA:
+                                description: First field for comparison.
+                                type: string
+                              fieldB:
+                                description: Second field for comparison.
+                                type: string
+                            required:
+                            - fieldA
+                            - fieldB
+                            type: object
+                        type: object
+                      type: array
+                    selector:
+                      description: Selector specifies which objects this probe should
+                        target.
+                      properties:
+                        kind:
+                          description: Kind and API Group of the object to probe.
+                          properties:
+                            group:
+                              description: Object Group to apply a probe to.
+                              type: string
+                            kind:
+                              description: Object Kind to apply a probe to.
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          type: object
+                        selector:
+                          description: Further sub-selects objects based on a Label
+                            Selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                  required:
+                  - probes
+                  - selector
+                  type: object
+                type: array
+              lifecycleState:
+                default: Active
+                description: Specifies the lifecycle state of the ObjectSet.
+                enum:
+                - Active
+                - Paused
+                - Archived
+                type: string
+              phases:
+                description: Reconcile phase configuration for a ObjectSet. Phases
+                  will be reconciled in order and the contained objects checked against
+                  given probes before continuing with the next phase.
+                items:
+                  description: ObjectSet reconcile phase.
+                  properties:
+                    class:
+                      description: If non empty, the ObjectSet controller will delegate
+                        phase reconciliation to another controller, by creating an
+                        ObjectSetPhase object. If set to the string "default" the
+                        built-in Package Operator ObjectSetPhase controller will reconcile
+                        the object in the same way the ObjectSet would. If set to
+                        any other string, an out-of-tree controller needs to be present
+                        to handle ObjectSetPhase objects.
+                      type: string
+                    name:
+                      description: Name of the reconcile phase. Must be unique within
+                        a ObjectSet.
+                      type: string
+                    objects:
+                      description: Objects belonging to this phase.
+                      items:
+                        description: An object that is part of the phase of an ObjectSet.
+                        properties:
+                          object:
+                            type: object
+                            x-kubernetes-embedded-resource: true
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - object
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - objects
+                  type: object
+                type: array
+              previous:
+                description: Previous revisions of the ObjectSet to adopt objects
+                  from.
+                items:
+                  description: References a previous revision of an ObjectSet or ClusterObjectSet.
+                  properties:
+                    name:
+                      description: Name of a previous revision.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - availabilityProbes
+            - phases
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: ObjectSetStatus defines the observed state of a ObjectSet.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerOf:
+                description: References all objects controlled by this instance.
+                items:
+                  description: References an object controlled by this ObjectSet/ObjectSetPhase.
+                  properties:
+                    group:
+                      description: Object Group.
+                      type: string
+                    kind:
+                      description: Object Kind.
+                      type: string
+                    name:
+                      description: Object Name.
+                      type: string
+                    namespace:
+                      description: Object Namespace.
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                type: array
+              phase:
+                description: Phase is not part of any API contract it will go away
+                  as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+              remotePhases:
+                description: Remote phases aka ObjectSetPhase objects.
+                items:
+                  description: References remote phases aka ObjectSetPhase/ClusterObjectSetPhase
+                    objects to which a phase is delegated.
+                  properties:
+                    name:
+                      type: string
+                    uid:
+                      description: UID is a type that holds unique ID values, including
+                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias
+                        to string.  Being a type captures intent and helps make sure
+                        that UIDs and names do not get conflated.
+                      type: string
+                  required:
+                  - name
+                  - uid
+                  type: object
+                type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/crds/packages.package-operator.run.CustomResourceDefinition.yaml
+++ b/config/packages/package-operator/crds/packages.package-operator.run.CustomResourceDefinition.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+    package-operator.run/phase: crds
+  creationTimestamp: null
+  name: packages.package-operator.run
+spec:
+  group: package-operator.run
+  names:
+    kind: Package
+    listKind: PackageList
+    plural: packages
+    singular: package
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Package specification.
+            properties:
+              image:
+                description: the image containing the contents of the package this
+                  image will be unpacked by the package-loader to render the ObjectDeployment
+                  for propagating the installation of the package.
+                type: string
+            required:
+            - image
+            type: object
+          status:
+            default:
+              phase: Pending
+            description: PackageStatus defines the observed state of a Package.
+            properties:
+              conditions:
+                description: Conditions is a list of status conditions ths object
+                  is in.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: This field is not part of any API contract it will go
+                  away as soon as kubectl can print conditions! When evaluating object
+                  state in code, use .Conditions instead.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/packages/package-operator/manifest.yaml
+++ b/config/packages/package-operator/manifest.yaml
@@ -1,0 +1,32 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: package-operator
+spec:
+  scopes:
+  - Cluster
+  phases:
+  - name: crds
+  - name: namespace
+  - name: rbac
+  - name: deploy
+  availabilityProbes:
+  - probes:
+    - condition:
+        type: Available
+        status: "True"
+    - fieldsEqual:
+        fieldA: .status.updatedReplicas
+        fieldB: .status.replicas
+    selector:
+      kind:
+        group: apps
+        kind: Deployment
+  - probes:
+    - condition:
+        type: Established
+        status: "True"
+    selector:
+      kind:
+        group: apiextensions.k8s.io
+        kind: CustomResourceDefinition

--- a/config/packages/package-operator/package-operator-system.Namespace.yaml
+++ b/config/packages/package-operator/package-operator-system.Namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    package-operator.run/phase: namespace
+  name: package-operator-system

--- a/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: package-operator
+  namespace: package-operator-system

--- a/config/packages/package-operator/rbac/package-operator.Role.yaml
+++ b/config/packages/package-operator/rbac/package-operator.Role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: package-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/packages/package-operator/rbac/package-operator.RoleBinding.yaml
+++ b/config/packages/package-operator/rbac/package-operator.RoleBinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: package-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: package-operator
+subjects:
+- kind: ServiceAccount
+  name: package-operator

--- a/config/packages/package-operator/rbac/package-operator.ServiceAccount.yaml
+++ b/config/packages/package-operator/rbac/package-operator.ServiceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: package-operator-system

--- a/config/self-bootstrap-job.yaml
+++ b/config/self-bootstrap-job.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: package-operator-system
+  labels:
+    package-operator.run/cache: "True"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: package-operator
+  namespace: package-operator-system
+  labels:
+    package-operator.run/cache: "True"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: package-operator
+  labels:
+    package-operator.run/cache: "True"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: package-operator
+  namespace: package-operator-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: package-operator-bootstrap
+  namespace: package-operator-system
+spec:
+  # delete right after completion
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: package-operator
+      initContainers:
+      - name: prepare
+        image: quay.io/package-operator/package-operator-manager:latest
+        args: ["-copy-to=/bootstrap-bin/pko"]
+        volumeMounts:
+        - name: shared-dir
+          mountPath: /bootstrap-bin
+      containers:
+      - name: package-operator
+        image: quay.io/package-operator/package-operator-package:latest
+        command: ["/.bootstrap-bin/pko",  "-self-bootstrap=quay.io/package-operator/package-operator-package:latest"]
+        env:
+        - name: PKO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_IMAGE
+          value: "quay.io/package-operator/package-operator-manager:latest"
+        volumeMounts:
+        - name: shared-dir
+          mountPath: /.bootstrap-bin
+      volumes:
+      - name: "shared-dir"
+        emptyDir: {}
+  backoffLimit: 3

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -438,6 +439,10 @@ func (c *defaultAdoptionChecker) Check(
 	ctx context.Context, owner PhaseObjectOwner, obj client.Object,
 	previous []PreviousObjectSet,
 ) (needsAdoption bool, err error) {
+	if len(os.Getenv("PKO_FORCE_ADOPTION")) > 0 {
+		return true, nil
+	}
+
 	if c.ownerStrategy.IsController(owner.ClientObject(), obj) {
 		// already owner, nothing to do.
 		return false, nil
@@ -533,6 +538,10 @@ const (
 func getObjectRevision(obj client.Object) (int64, error) {
 	a := obj.GetAnnotations()
 	if a == nil {
+		return 0, nil
+	}
+
+	if len(a[revisionAnnotation]) == 0 {
 		return 0, nil
 	}
 

--- a/internal/packages/folderloadoperation.go
+++ b/internal/packages/folderloadoperation.go
@@ -138,15 +138,14 @@ func (l *folderLoadOperation) loadKubernetesObjectsFromBytes(fileYaml []byte) ([
 				"executing template from yaml document at index %d: %w", i, err)
 		}
 
-		docTrimmed := bytes.TrimSpace(doc.Bytes())
-		if len(docTrimmed) == 0 {
-			continue
-		}
-
 		obj := unstructured.Unstructured{}
-		if err := yaml.Unmarshal(docTrimmed, &obj); err != nil {
+		if err := yaml.Unmarshal(doc.Bytes(), &obj); err != nil {
 			return nil, fmt.Errorf(
 				"unmarshalling yaml document at index %d: %w", i, err)
+		}
+
+		if len(obj.Object) == 0 {
+			continue
 		}
 
 		objects = append(objects, obj)


### PR DESCRIPTION
Implement capability to let PKO install itself from a Package.

Still needs some polish.

To check it out:
```sh
# make sure to start with an empty cluster
./mage dev:teardown
# create a new local cluster
./mage dev:setup
# just build load images into the cluster
./mage dev:load

# Now edit config/self-bootstrap-job.yaml with the new image tag printed by the dev:load target.
vim config/self-bootstrap-job.yaml

# Let PKO install itself:
kubectl create -f config/self-bootstrap-job.yaml

# Checkout PKOs ClusterPackage
kubectl get clusterpackage
NAME               STATUS      AGE
package-operator   Available   9m32s
```

Signed-off-by: Nico Schieder <nschieder@redhat.com>