### PR TITLE
Implement tree command to inspect package contents

### DIFF
--- a/cmd/kubectl-package/command/command.go
+++ b/cmd/kubectl-package/command/command.go
@@ -46,6 +46,7 @@ func CobraRoot() *cobra.Command {
 		(&Build{}).CobraCommand(),
 		(&Validate{}).CobraCommand(),
 		(&Version{}).CobraCommand(),
+		(&Tree{}).CobraCommand(),
 	)
 
 	return cmd

--- a/cmd/kubectl-package/command/tree.go
+++ b/cmd/kubectl-package/command/tree.go
@@ -1,0 +1,135 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/disiqueira/gotree"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pkoapis "package-operator.run/apis"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+	"package-operator.run/package-operator/internal/packages/packagebytes"
+	"package-operator.run/package-operator/internal/packages/packagestructure"
+)
+
+const (
+	treeUse             = "tree source_path"
+	treeShort           = "outputs a logical tree view of the package contents"
+	treeLong            = "outputs a logical tree view of the package by printing root->phases->objects"
+	treeClusterScopeUse = "render package in cluster scope"
+)
+
+var (
+	treeScheme = runtime.NewScheme()
+)
+
+func init() {
+	if err := pkoapis.AddToScheme(treeScheme); err != nil {
+		panic(err)
+	}
+}
+
+type Tree struct {
+	SourcePath   string
+	ClusterScope bool
+}
+
+func (t *Tree) Complete(args []string) error {
+	switch {
+	case len(args) != 1:
+		return fmt.Errorf("%w: got %v positional args. Need one argument containing the source path", ErrInvalidArgs, len(args))
+	case args[0] == "":
+		return fmt.Errorf("%w: source path empty", ErrInvalidArgs)
+	}
+
+	t.SourcePath = args[0]
+	return nil
+}
+
+func (t *Tree) Run(ctx context.Context, out io.Writer) error {
+	verboseLog := logr.FromContextOrDiscard(ctx).V(1)
+	verboseLog.Info("loading source from disk", "path", t.SourcePath)
+
+	templateContext := packagebytes.TemplateContext{
+		Package: packagebytes.PackageTemplateContext{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "<name>",
+				Namespace: "<namespace>",
+			},
+		},
+	}
+	pkgPrefix := "Package"
+	scope := manifestsv1alpha1.PackageManifestScopeNamespaced
+	if t.ClusterScope {
+		scope = manifestsv1alpha1.PackageManifestScopeCluster
+		templateContext.Package.Namespace = ""
+		pkgPrefix = "ClusterPackage"
+	}
+
+	l := packagestructure.NewLoader(treeScheme,
+		packagestructure.WithManifestValidators(
+			packagestructure.PackageScopeValidator(scope),
+			&packagestructure.ObjectPhaseAnnotationValidator{},
+		),
+		packagestructure.WithByteTransformers(
+			&packagebytes.TemplateTransformer{
+				TemplateContext: templateContext,
+			},
+		),
+	)
+
+	packageContent, err := l.LoadFromPath(ctx, t.SourcePath)
+	if err != nil {
+		return fmt.Errorf("loading package contents: %w", err)
+	}
+	spec := packageContent.ToTemplateSpec()
+
+	pkg := gotree.New(
+		fmt.Sprintf("%s\n%s %s",
+			packageContent.PackageManifest.Name,
+			pkgPrefix, client.ObjectKey{
+				Name:      templateContext.Package.Name,
+				Namespace: templateContext.Package.Namespace,
+			}))
+	for _, phase := range spec.Phases {
+		treePhase := pkg.Add(fmt.Sprintf("Phase %s", phase.Name))
+
+		for _, obj := range phase.Objects {
+			treePhase.Add(
+				fmt.Sprintf("%s %s",
+					obj.Object.GroupVersionKind(),
+					client.ObjectKeyFromObject(&obj.Object)))
+		}
+	}
+	fmt.Fprint(out, pkg.Print())
+
+	return nil
+}
+
+func (t *Tree) CobraCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   treeUse,
+		Short: treeShort,
+		Long:  treeLong,
+	}
+	f := cmd.Flags()
+	f.BoolVar(&t.ClusterScope, "cluster", false, treeClusterScopeUse)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
+		if err := t.Complete(args); err != nil {
+			return err
+		}
+		logOut := cmd.ErrOrStderr()
+		log := funcr.New(func(p, a string) { fmt.Fprintln(logOut, p, a) }, funcr.Options{})
+		return t.Run(logr.NewContext(cmd.Context(), log), cmd.OutOrStdout())
+	}
+
+	return cmd
+}

--- a/cmd/kubectl-package/command/tree_test.go
+++ b/cmd/kubectl-package/command/tree_test.go
@@ -1,0 +1,59 @@
+package command_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"package-operator.run/package-operator/cmd/kubectl-package/command"
+)
+
+func TestTree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namespace scoped", func(t *testing.T) {
+		cmd := command.CobraRoot()
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+		cmd.SetArgs([]string{"tree", "testdata"})
+
+		err := cmd.Execute()
+
+		require.Nil(t, err)
+		require.Len(t, stderr.String(), 0)
+
+		const expectedOutput = `test-stub
+Package <namespace>/<name>
+└── Phase deploy
+    └── apps/v1, Kind=Deployment /test-stub-<name>
+`
+		assert.Equal(t, expectedOutput, stdout.String())
+	})
+
+	t.Run("cluster scoped", func(t *testing.T) {
+		cmd := command.CobraRoot()
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+		cmd.SetArgs([]string{"tree", "testdata", "--cluster"})
+
+		err := cmd.Execute()
+
+		require.Nil(t, err)
+		require.Len(t, stderr.String(), 0)
+
+		const expectedOutput = `test-stub
+ClusterPackage /<name>
+└── Phase namespace
+│   ├── /v1, Kind=Namespace /<name>
+└── Phase deploy
+    └── apps/v1, Kind=Deployment <name>/test-stub-<name>
+`
+		assert.Equal(t, expectedOutput, stdout.String())
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/disiqueira/gotree v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-containerregistry v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
+github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
 github.com/docker/cli v20.10.20+incompatible h1:lWQbHSHUFs7KraSN2jOJK7zbMS2jNCHI4mt4xUFUVQ4=
 github.com/docker/cli v20.10.20+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=


### PR DESCRIPTION
Introducing a tree command to quickly see the logical structure of a package after templating and assembly into phases.

Example Outputs
```
$ go run ./cmd/kubectl-package tree ./config/packages/test-stub          
Package <namespace>/<name>
└── Phase deploy
    └── apps/v1, Kind=Deployment /test-stub-<name>

$ go run ./cmd/kubectl-package tree ./config/packages/test-stub --cluster
ClusterPackage /<name>
└── Phase namespace
    └── /v1, Kind=Namespace /<name>
└── Phase deploy
    └── apps/v1, Kind=Deployment <name>/test-stub-<name>

# when removing a phase annotation
$ go run ./cmd/kubectl-package tree ./config/packages/test-stub --cluster
Error: loading package contents: Package validation errors:
- Missing package-operator.run/phase Annotation in deployment.yaml#0
```

Signed-off-by: Nico Schieder <nschieder@redhat.com>