### PR TITLE
Raise an error message when running ./mage deploy without VERSION env

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -192,6 +192,10 @@ func includeInPackageOperatorPackage(file string) {
 }
 
 func Deploy(ctx context.Context) {
+	if _, ok := os.LookupEnv("VERSION"); ok {
+		panic("VERSION environment variable not set, please set an explicit version to deploy")
+	}
+
 	cluster, err := dev.NewCluster(filepath.Join(cacheDir, "deploy"), dev.WithKubeconfigPath(os.Getenv("KUBECONFIG")))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Followup to #81 

Signed-off-by: Nico Schieder <nschieder@redhat.com>