### PR TITLE
Fix: Support long HyperShift HCP namespace names

### DIFF
--- a/internal/controllers/packages/job_reconciler.go
+++ b/internal/controllers/packages/job_reconciler.go
@@ -20,6 +20,10 @@ import (
 const (
 	// Hash used to determine if the job is still up-to-date.
 	packageSpecHashAnnotation = "package-operator.run/package-spec-hash"
+	// Name of the Package object the loader job belongs to.
+	packageNameLabel = "package-operator.run/pkg-name"
+	// Namespace of the Package object the loader job belongs to.
+	packageNamespaceLabel = "package-operator.run/pkg-namespace"
 )
 
 type jobReconciler struct {
@@ -146,6 +150,8 @@ func desiredJob(pkg genericPackage, pkoNamespace, pkoImage string) *batchv1.Job 
 			},
 			Labels: map[string]string{
 				controllers.DynamicCacheLabel: "True",
+				packageNameLabel:              pkg.ClientObject().GetName(),
+				packageNamespaceLabel:         pkg.ClientObject().GetNamespace(),
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -200,10 +206,5 @@ func desiredJob(pkg genericPackage, pkoNamespace, pkoImage string) *batchv1.Job 
 }
 
 func jobName(pkg genericPackage) string {
-	name := pkg.ClientObject().GetName()
-	ns := pkg.ClientObject().GetNamespace()
-	if len(ns) == 0 {
-		return name + "-loader"
-	}
-	return fmt.Sprintf("%s-%s-loader", ns, name)
+	return "loader-" + string(pkg.ClientObject().GetUID())
 }


### PR DESCRIPTION
The loader job-name was glued together from package name, namespace and a "-loader" suffix. If Package name or namespace was very long, this prevented the Package controller from creating the loader job.

This commit replaces the old loader job naming with UID based job names which will always be constant in length. Package name and namespace are set as labels to help debugging.

Signed-off-by: Nico Schieder <nschieder@redhat.com>