### PR TITLE
Move image building and pushing functionality to DevKube

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-containerregistry v0.13.0
 	github.com/magefile/mage v1.14.0
-	github.com/mt-sre/devkube v0.5.2
+	github.com/mt-sre/devkube v0.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mt-sre/devkube v0.5.2 h1:yqrTuLSmBJdDK7GEvoAiNzzu1Gy3FbVHGs+oKrgFomI=
-github.com/mt-sre/devkube v0.5.2/go.mod h1:fNaVLv4NoSN42+eXdqCSoEp+CBivYeC7Ic8mrZqq8T4=
+github.com/mt-sre/devkube v0.6.0 h1:Je3WDMtRpsqyIbswJVsyuNjfEE8oGP7Lgq7vz7VvWME=
+github.com/mt-sre/devkube v0.6.0/go.mod h1:fNaVLv4NoSN42+eXdqCSoEp+CBivYeC7Ic8mrZqq8T4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/magefile.go
+++ b/magefile.go
@@ -37,7 +37,7 @@ import (
 // Constants that define build behaviour.
 const (
 	module                 = "package-operator.run/package-operator"
-	defaultImageOrg        = "quay.io/pbabic"
+	defaultImageOrg        = "quay.io/package-operator"
 	clusterName            = "package-operator-dev"
 	cliCmdName             = "kubectl-package"
 	pkoPackageName         = "package-operator-package"

--- a/magefile.go
+++ b/magefile.go
@@ -1,8 +1,6 @@
 //go:build mage
 // +build mage
 
-// TODO
-
 package main
 
 import (


### PR DESCRIPTION
## What
This PR removes generic image building and pushing functionality from `magefile.go` and uses functions provided by DevKube instead (added by this PR: [#23](https://github.com/mt-sre/devkube/pull/23)).

## Jira
[MTSRE-777](https://issues.redhat.com/browse/MTSRE-777)