### PR TITLE
Use strategic merge strategy

### DIFF
--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -475,7 +475,7 @@ func (p *defaultPatcher) Patch(
 			return fmt.Errorf("creating patch: %w", err)
 		}
 		if err := p.writer.Patch(ctx, updatedObj, client.RawPatch(
-			types.MergePatchType, objectPatch)); err != nil {
+			types.StrategicMergePatchType, objectPatch)); err != nil {
 			return fmt.Errorf("patching object: %w", err)
 		}
 	}


### PR DESCRIPTION
Change object patching behaviour to strategic merge to better support mutating integrations and better conform to our documentation about "if you don't specify a field, PKO won't touch it"

https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch

Signed-off-by: Nico Schieder <nschieder@redhat.com>