### PR TITLE
Remote Phase Manager lacks ObjectSet permissions

### DIFF
--- a/apis/core/v1alpha1/clusterobjectsetphase_types.go
+++ b/apis/core/v1alpha1/clusterobjectsetphase_types.go
@@ -42,7 +42,7 @@ type ClusterObjectSetPhaseSpec struct {
 	// Availability Probes check objects that are part of the package.
 	// All probes need to succeed for a package to be considered Available.
 	// Failing probes will prevent the reconciliation of objects in later phases.
-	AvailabilityProbes []ObjectSetProbe `json:"availabilityProbes"`
+	AvailabilityProbes []ObjectSetProbe `json:"availabilityProbes,omitempty"`
 
 	// Objects belonging to this phase.
 	Objects []ObjectSetObject `json:"objects"`

--- a/apis/core/v1alpha1/objectsetphase_types.go
+++ b/apis/core/v1alpha1/objectsetphase_types.go
@@ -41,7 +41,7 @@ type ObjectSetPhaseSpec struct {
 	// Availability Probes check objects that are part of the package.
 	// All probes need to succeed for a package to be considered Available.
 	// Failing probes will prevent the reconciliation of objects in later phases.
-	AvailabilityProbes []ObjectSetProbe `json:"availabilityProbes"`
+	AvailabilityProbes []ObjectSetProbe `json:"availabilityProbes,omitempty"`
 
 	// Objects belonging to this phase.
 	Objects []ObjectSetObject `json:"objects"`

--- a/config/crds/package-operator.run_clusterobjectsetphases.yaml
+++ b/config/crds/package-operator.run_clusterobjectsetphases.yaml
@@ -214,7 +214,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object

--- a/config/crds/package-operator.run_objectsetphases.yaml
+++ b/config/crds/package-operator.run_objectsetphases.yaml
@@ -212,7 +212,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object

--- a/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
@@ -214,7 +214,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object

--- a/config/static-deployment/1-package-operator.run_objectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsetphases.yaml
@@ -212,7 +212,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object

--- a/config/static-deployment/20-rbac.yaml
+++ b/config/static-deployment/20-rbac.yaml
@@ -67,6 +67,10 @@ rules:
     - objectsetphases/status
     - clusterobjectsetphases
     - clusterobjectsetphases/status
+    - objectsets
+    - objectsets/status
+    - clusterobjectsets
+    - clusterobjectsets/status
   verbs:
     - get
     - list

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -560,7 +560,7 @@ ClusterObjectSetPhaseSpec defines the desired state of a ClusterObjectSetPhase.
 | `paused` <br><a href="#bool">bool</a> | Disables reconciliation of the ClusterObjectSet.<br>Only Status updates will still be propagated, but object changes will not be reconciled. |
 | `revision` <b>required</b><br>int64 | Revision of the parent ObjectSet to use during object adoption. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ClusterObjectSet to adopt objects from. |
-| `availabilityProbes` <b>required</b><br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
+| `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `objects` <b>required</b><br><a href="#objectsetobject">[]ObjectSetObject</a> | Objects belonging to this phase. |
 
 
@@ -706,7 +706,7 @@ ObjectSetPhaseSpec defines the desired state of a ObjectSetPhase.
 | `paused` <br><a href="#bool">bool</a> | Disables reconciliation of the ObjectSet.<br>Only Status updates will still be propagated, but object changes will not be reconciled. |
 | `revision` <b>required</b><br>int64 | Revision of the parent ObjectSet to use during object adoption. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ObjectSet to adopt objects from. |
-| `availabilityProbes` <b>required</b><br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
+| `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `objects` <b>required</b><br><a href="#objectsetobject">[]ObjectSetObject</a> | Objects belonging to this phase. |
 
 

--- a/install.yaml
+++ b/install.yaml
@@ -632,7 +632,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object
@@ -1964,7 +1963,6 @@ spec:
                 format: int64
                 type: integer
             required:
-            - availabilityProbes
             - objects
             - revision
             type: object
@@ -2739,6 +2737,10 @@ rules:
     - objectsetphases/status
     - clusterobjectsetphases
     - clusterobjectsetphases/status
+    - objectsets
+    - objectsets/status
+    - clusterobjectsets
+    - clusterobjectsets/status
   verbs:
     - get
     - list

--- a/integration/hypershift_test.go
+++ b/integration/hypershift_test.go
@@ -89,7 +89,6 @@ func TestHyperShift(t *testing.T) {
 	// longer timeout because PKO is restarting to enable HyperShift integration and needs a few seconds for leader election.
 	require.NoError(t,
 		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageAvailable, metav1.ConditionTrue, dev.WithTimeout(100*time.Second)))
-
 	// Test ObjectSetPhase integration
 	t.Run("ObjectSetSetupPauseTeardown", func(t *testing.T) {
 		runObjectSetSetupPauseTeardownTest(t, ns.Name, "hosted-cluster")

--- a/integration/objectset_test.go
+++ b/integration/objectset_test.go
@@ -326,7 +326,8 @@ func defaultObjectSetRev1(cm1, cm2 *corev1.ConfigMap, namespace, class string) (
 			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
 				Phases: []corev1alpha1.ObjectSetTemplatePhase{
 					{
-						Name: "phase-1",
+						Name:  "phase-1",
+						Class: class,
 						Objects: []corev1alpha1.ObjectSetObject{
 							{
 								Object: unstructured.Unstructured{Object: cm1Obj},
@@ -334,7 +335,8 @@ func defaultObjectSetRev1(cm1, cm2 *corev1.ConfigMap, namespace, class string) (
 						},
 					},
 					{
-						Name: "phase-2",
+						Name:  "phase-2",
+						Class: class,
 						Objects: []corev1alpha1.ObjectSetObject{
 							{
 								Object: unstructured.Unstructured{Object: cm2Obj},
@@ -371,7 +373,8 @@ func defaultObjectSetRev2(cm1, cm3 *corev1.ConfigMap, rev1 *corev1alpha1.ObjectS
 			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
 				Phases: []corev1alpha1.ObjectSetTemplatePhase{
 					{
-						Name: "phase-1",
+						Name:  "phase-1",
+						Class: class,
 						Objects: []corev1alpha1.ObjectSetObject{
 							{
 								Object: unstructured.Unstructured{Object: cm3Obj}, // replaces cm2
@@ -379,7 +382,8 @@ func defaultObjectSetRev2(cm1, cm3 *corev1.ConfigMap, rev1 *corev1alpha1.ObjectS
 						},
 					},
 					{
-						Name: "phase-2",
+						Name:  "phase-2",
+						Class: class,
 						Objects: []corev1alpha1.ObjectSetObject{
 							{
 								Object: unstructured.Unstructured{Object: cm1Obj}, // moved between phases

--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -36,6 +36,7 @@ type ownerStrategy interface {
 	ReleaseController(obj metav1.Object)
 	RemoveOwner(owner, obj metav1.Object)
 	SetControllerReference(owner, obj metav1.Object) error
+	OwnerPatch(owner metav1.Object) ([]byte, error)
 	EnqueueRequestForOwner(
 		ownerType client.Object, isController bool,
 	) handler.EventHandler

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -299,6 +299,9 @@ func TestPhaseReconciler_reconcileObject_update(t *testing.T) {
 	ownerStrategy.
 		On("IsController", mock.Anything, mock.Anything).
 		Return(true)
+	ownerStrategy.
+		On("OwnerPatch", mock.Anything).
+		Return([]byte(nil), nil)
 
 	testClient.
 		On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).

--- a/internal/ownerhandling/common.go
+++ b/internal/ownerhandling/common.go
@@ -13,6 +13,7 @@ type ownerStrategy interface {
 	RemoveOwner(owner, obj metav1.Object)
 	SetControllerReference(owner, obj metav1.Object) error
 	EnqueueRequestForOwner(ownerType client.Object, isController bool) handler.EventHandler
+	OwnerPatch(owner metav1.Object) ([]byte, error)
 }
 
 // Removes the given index from the slice.

--- a/internal/ownerhandling/native.go
+++ b/internal/ownerhandling/native.go
@@ -1,6 +1,7 @@
 package ownerhandling
 
 import (
+	"encoding/json"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,15 @@ func NewNative(scheme *runtime.Scheme) *OwnerStrategyNative {
 	return &OwnerStrategyNative{
 		scheme: scheme,
 	}
+}
+
+func (s *OwnerStrategyNative) OwnerPatch(owner metav1.Object) ([]byte, error) {
+	patchMetadata := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"ownerReferences": owner.GetOwnerReferences(),
+		},
+	}
+	return json.Marshal(patchMetadata)
 }
 
 func (s *OwnerStrategyNative) IsOwner(owner, obj metav1.Object) bool {

--- a/internal/ownerhandling/native_test.go
+++ b/internal/ownerhandling/native_test.go
@@ -148,3 +148,17 @@ func TestOwnerStrategyNative_ReleaseController(t *testing.T) {
 		assert.Nil(t, ownerRefs[0].Controller)
 	}
 }
+
+func TestOwnerStrategyNative_OwnerPatch(t *testing.T) {
+	s := NewNative(testScheme)
+	obj := testutil.NewSecret()
+	owner := testutil.NewConfigMap()
+	owner.Namespace = obj.Namespace
+	err := s.SetControllerReference(owner, obj)
+	require.NoError(t, err)
+
+	patch, err := s.OwnerPatch(obj)
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"metadata":{"ownerReferences":[{"apiVersion":"v1","kind":"ConfigMap","name":"cm","uid":"asdfjkl","controller":true,"blockOwnerDeletion":true}]}}`, string(patch))
+}

--- a/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
+++ b/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
@@ -11,6 +11,11 @@ type OwnerStrategyMock struct {
 	mock.Mock
 }
 
+func (m *OwnerStrategyMock) OwnerPatch(obj metav1.Object) ([]byte, error) {
+	args := m.Called(obj)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (m *OwnerStrategyMock) IsController(owner, obj metav1.Object) bool {
 	args := m.Called(owner, obj)
 	return args.Bool(0)


### PR DESCRIPTION
The remote phase manager lacked permissions to access ObjectSet APIs. This access is required to lookup previous revisions to feed the adoption checker that prevents us from working on objects already under ownership of other Packages or controllers.

During fixing this bug, I've also found that the integration tests that should have prevented this issue are not executed correctly skipping the remote-phase manager.

With the problems in the integration test suite patched, we can be sure that regressions are detected in the future :)