### PR TITLE
Use custom workflow for go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,8 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   reviewers: [ eqrx ]
-  open-pull-requests-limit: 100
-  labels:
-  - dependencies
-  - ok-to-test
+  open-pull-requests-limit: 0
+  labels: [ dependencies, ok-to-test]
 - package-ecosystem: gomod
   directory: /apis
   schedule:
@@ -22,15 +20,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   reviewers: [ eqrx ]
-  open-pull-requests-limit: 100
-  labels:
-  - dependencies
-  - ok-to-test
+  open-pull-requests-limit: 0
+  labels: [ dependencies, ok-to-test]
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
-  open-pull-requests-limit: 100
-  labels:
-  - dependencies
-  - ok-to-test
+  open-pull-requests-limit: 0
+  labels: [ dependencies, ok-to-test]

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,42 @@
+name: Update project dependencies
+on:
+  workflow_dispatch: ~
+permissions:
+  pull-requests: write
+jobs:
+  go:
+    if: github.repository_owner == 'package-operator'
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '>=1.20.0'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/package-operator
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - run: |
+        go get -u ./...
+        go mod tidy
+      working-directory: .
+    - run: |
+        go get -u ./...
+        go mod tidy
+      working-directory: ./apis
+    - uses: peter-evans/create-pull-request@v4
+      with:
+        title: Update go dependencies
+        commit-message: Update go dependencies
+        body: Update go dependencies
+        labels: ok-to-test, tide/merge-method-squash
+        branch: deps
+        delete-branch: true
+        assignees: eqrx
+        reviewers: eqrx

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,3 @@ bin
 
 # JetBrains IDEs (e.g. GoLand)
 .idea/
-
-# go.work.sum is a aggregated version of all go.sum files in the repo
-# ... and sometimes contains even more than the sum.
-go.work.sum

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,2 @@
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=


### PR DESCRIPTION
Dependabots has problems with go workspaces and creates broken PRs. This commit creates a scheduled workflow that runs `go get` appropriately and actually cleans up.