### PR TITLE
Use service-network kubeconfig in HyperShift

### DIFF
--- a/config/remote-phase-static-deployment/2-secret.yaml.tpl
+++ b/config/remote-phase-static-deployment/2-secret.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: admin-kubeconfig
+  name: service-network-admin-kubeconfig
   namespace: package-operator-system
   labels:
     app.kubernetes.io/name: remote-phase-operator

--- a/config/remote-phase-static-deployment/deployment.yaml.tpl
+++ b/config/remote-phase-static-deployment/deployment.yaml.tpl
@@ -19,7 +19,7 @@ spec:
       volumes:
       - name: kubeconfig
         secret:
-          secretName: admin-kubeconfig
+          secretName: service-network-admin-kubeconfig
           optional: false
       containers:
       - name: manager

--- a/integration/hypershift_test.go
+++ b/integration/hypershift_test.go
@@ -56,15 +56,15 @@ func TestHyperShift(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanupOnSuccess(ctx, t, ns)
 
-	// copy admin-kubeconfig from default namespace
+	// copy service-network-admin-kubeconfig from default namespace
 	defaultSecret := &corev1.Secret{}
 	require.NoError(t, Client.Get(ctx, client.ObjectKey{
-		Name:      "admin-kubeconfig",
+		Name:      "service-network-admin-kubeconfig",
 		Namespace: "default",
 	}, defaultSecret))
 	hcSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "admin-kubeconfig",
+			Name:      "service-network-admin-kubeconfig",
 			Namespace: ns.Name,
 		},
 		Data: defaultSecret.Data,

--- a/magefile.go
+++ b/magefile.go
@@ -1021,7 +1021,7 @@ func (d Dev) deployTargetKubeConfig(ctx context.Context, cluster *dev.Cluster) {
 	// Create a new secret for the kubeconfig
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "admin-kubeconfig",
+			Name:      "service-network-admin-kubeconfig",
 			Namespace: "default",
 		},
 		Data: map[string][]byte{


### PR DESCRIPTION
Use service-network kubeconfig in HyperShift to use internal network connectivity and don't access HostedCluster kube-apiservers using external LoadBalancers.