### PR TITLE
Pko advanced self config

### DIFF
--- a/config/local-registry.yaml
+++ b/config/local-registry.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev-registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-registry
+  namespace: dev-registry
+  labels:
+    app: dev-registry
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dev-registry
+  template:
+    metadata:
+      labels:
+        app: dev-registry
+    spec:
+      containers:
+      - image: registry:2
+        name: dev-registry
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5000
+          hostPort: 5001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dev-registry
+  name: dev-registry
+  namespace: dev-registry
+spec:
+  ports:
+  - port: 5001
+    protocol: TCP
+    targetPort: 5000
+    nodePort: 31320
+  selector:
+    app: dev-registry
+  type: NodePort

--- a/config/packages/package-operator/manifest.yaml
+++ b/config/packages/package-operator/manifest.yaml
@@ -30,3 +30,876 @@ spec:
       kind:
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  config:
+    openAPIV3Schema:
+      properties:
+        affinity:
+          description: Affinity is a group of affinity scheduling rules.
+          properties:
+            nodeAffinity:
+              description: Describes node affinity scheduling rules for the
+                pod.
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  description: The scheduler will prefer to schedule pods to
+                    nodes that satisfy the affinity expressions specified by
+                    this field, but it may choose a node that violates one or
+                    more of the expressions. The node that is most preferred
+                    is the one with the greatest sum of weights, i.e. for each
+                    node that meets all of the scheduling requirements (resource
+                    request, requiredDuringScheduling affinity expressions,
+                    etc.), compute a sum by iterating through the elements of
+                    this field and adding "weight" to the sum if the node matches
+                    the corresponding matchExpressions; the node(s) with the
+                    highest sum are the most preferred.
+                  items:
+                    description: An empty preferred scheduling term matches
+                      all objects with implicit weight 0 (i.e. it's a no-op).
+                      A null preferred scheduling term matches no objects (i.e.
+                      is also a no-op).
+                    properties:
+                      preference:
+                        description: A node selector term, associated with the
+                          corresponding weight.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements
+                              by node's labels.
+                            items:
+                              description: A node selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists, DoesNotExist. Gt, and
+                                    Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If
+                                    the operator is In or NotIn, the values
+                                    array must be non-empty. If the operator
+                                    is Exists or DoesNotExist, the values array
+                                    must be empty. If the operator is Gt or
+                                    Lt, the values array must have a single
+                                    element, which will be interpreted as an
+                                    integer. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements
+                              by node's fields.
+                            items:
+                              description: A node selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists, DoesNotExist. Gt, and
+                                    Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If
+                                    the operator is In or NotIn, the values
+                                    array must be non-empty. If the operator
+                                    is Exists or DoesNotExist, the values array
+                                    must be empty. If the operator is Gt or
+                                    Lt, the values array must have a single
+                                    element, which will be interpreted as an
+                                    integer. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      weight:
+                        description: Weight associated with matching the corresponding
+                          nodeSelectorTerm, in the range 1-100.
+                        format: int32
+                        type: integer
+                    required:
+                    - preference
+                    - weight
+                    type: object
+                  type: array
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  description: If the affinity requirements specified by this
+                    field are not met at scheduling time, the pod will not be
+                    scheduled onto the node. If the affinity requirements specified
+                    by this field cease to be met at some point during pod execution
+                    (e.g. due to an update), the system may or may not try to
+                    eventually evict the pod from its node.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms.
+                        The terms are ORed.
+                      items:
+                        description: A null or empty node selector term matches
+                          no objects. The requirements of them are ANDed. The
+                          TopologySelectorTerm type implements a subset of the
+                          NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements
+                              by node's labels.
+                            items:
+                              description: A node selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists, DoesNotExist. Gt, and
+                                    Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If
+                                    the operator is In or NotIn, the values
+                                    array must be non-empty. If the operator
+                                    is Exists or DoesNotExist, the values array
+                                    must be empty. If the operator is Gt or
+                                    Lt, the values array must have a single
+                                    element, which will be interpreted as an
+                                    integer. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements
+                              by node's fields.
+                            items:
+                              description: A node selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists, DoesNotExist. Gt, and
+                                    Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If
+                                    the operator is In or NotIn, the values
+                                    array must be non-empty. If the operator
+                                    is Exists or DoesNotExist, the values array
+                                    must be empty. If the operator is Gt or
+                                    Lt, the values array must have a single
+                                    element, which will be interpreted as an
+                                    integer. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+                  x-kubernetes-map-type: atomic
+              type: object
+            podAffinity:
+              description: Describes pod affinity scheduling rules (e.g. co-locate
+                this pod in the same node, zone, etc. as some other pod(s)).
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  description: The scheduler will prefer to schedule pods to
+                    nodes that satisfy the affinity expressions specified by
+                    this field, but it may choose a node that violates one or
+                    more of the expressions. The node that is most preferred
+                    is the one with the greatest sum of weights, i.e. for each
+                    node that meets all of the scheduling requirements (resource
+                    request, requiredDuringScheduling affinity expressions,
+                    etc.), compute a sum by iterating through the elements of
+                    this field and adding "weight" to the sum if the node has
+                    pods which matches the corresponding podAffinityTerm; the
+                    node(s) with the highest sum are the most preferred.
+                  items:
+                    description: The weights of all of the matched WeightedPodAffinityTerm
+                      fields are added per-node to find the most preferred node(s)
+                    properties:
+                      podAffinityTerm:
+                        description: Required. A pod affinity term, associated
+                          with the corresponding weight.
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources,
+                              in this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label
+                                  selector requirements. The requirements are
+                                  ANDed.
+                                items:
+                                  description: A label selector requirement
+                                    is a selector that contains values, a key,
+                                    and an operator that relates the key and
+                                    values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that
+                                        the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's
+                                        relationship to a set of values. Valid
+                                        operators are In, NotIn, Exists and
+                                        DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string
+                                        values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
+                                        If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This
+                                        array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value}
+                                  pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions,
+                                  whose key field is "key", the operator is
+                                  "In", and the values array contains only "value".
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          namespaceSelector:
+                            description: A label query over the set of namespaces
+                              that the term applies to. The term is applied
+                              to the union of the namespaces selected by this
+                              field and the ones listed in the namespaces field.
+                              null selector and null or empty namespaces list
+                              means "this pod's namespace". An empty selector
+                              ({}) matches all namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label
+                                  selector requirements. The requirements are
+                                  ANDed.
+                                items:
+                                  description: A label selector requirement
+                                    is a selector that contains values, a key,
+                                    and an operator that relates the key and
+                                    values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that
+                                        the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's
+                                        relationship to a set of values. Valid
+                                        operators are In, NotIn, Exists and
+                                        DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string
+                                        values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
+                                        If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This
+                                        array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value}
+                                  pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions,
+                                  whose key field is "key", the operator is
+                                  "In", and the values array contains only "value".
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          namespaces:
+                            description: namespaces specifies a static list
+                              of namespace names that the term applies to. The
+                              term is applied to the union of the namespaces
+                              listed in this field and the ones selected by
+                              namespaceSelector. null or empty namespaces list
+                              and null namespaceSelector means "this pod's namespace".
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods
+                              matching the labelSelector in the specified namespaces,
+                              where co-located is defined as running on a node
+                              whose value of the label with key topologyKey
+                              matches that of any node on which any of the selected
+                              pods is running. Empty topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      weight:
+                        description: weight associated with matching the corresponding
+                          podAffinityTerm, in the range 1-100.
+                        format: int32
+                        type: integer
+                    required:
+                    - podAffinityTerm
+                    - weight
+                    type: object
+                  type: array
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  description: If the affinity requirements specified by this
+                    field are not met at scheduling time, the pod will not be
+                    scheduled onto the node. If the affinity requirements specified
+                    by this field cease to be met at some point during pod execution
+                    (e.g. due to a pod label update), the system may or may
+                    not try to eventually evict the pod from its node. When
+                    there are multiple elements, the lists of nodes corresponding
+                    to each podAffinityTerm are intersected, i.e. all terms
+                    must be satisfied.
+                  items:
+                    description: Defines a set of pods (namely those matching
+                      the labelSelector relative to the given namespace(s))
+                      that this pod should be co-located (affinity) or not co-located
+                      (anti-affinity) with, where co-located is defined as running
+                      on a node whose value of the label with key <topologyKey>
+                      matches that of any node on which a pod of the set of
+                      pods is running
+                    properties:
+                      labelSelector:
+                        description: A label query over a set of resources,
+                          in this case pods.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label
+                              selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the
+                                    selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string
+                                    values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the
+                                    operator is Exists or DoesNotExist, the
+                                    values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value}
+                              pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In",
+                              and the values array contains only "value". The
+                              requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaceSelector:
+                        description: A label query over the set of namespaces
+                          that the term applies to. The term is applied to the
+                          union of the namespaces selected by this field and
+                          the ones listed in the namespaces field. null selector
+                          and null or empty namespaces list means "this pod's
+                          namespace". An empty selector ({}) matches all namespaces.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label
+                              selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the
+                                    selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string
+                                    values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the
+                                    operator is Exists or DoesNotExist, the
+                                    values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value}
+                              pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In",
+                              and the values array contains only "value". The
+                              requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: namespaces specifies a static list of namespace
+                          names that the term applies to. The term is applied
+                          to the union of the namespaces listed in this field
+                          and the ones selected by namespaceSelector. null or
+                          empty namespaces list and null namespaceSelector means
+                          "this pod's namespace".
+                        items:
+                          type: string
+                        type: array
+                      topologyKey:
+                        description: This pod should be co-located (affinity)
+                          or not co-located (anti-affinity) with the pods matching
+                          the labelSelector in the specified namespaces, where
+                          co-located is defined as running on a node whose value
+                          of the label with key topologyKey matches that of
+                          any node on which any of the selected pods is running.
+                          Empty topologyKey is not allowed.
+                        type: string
+                    required:
+                    - topologyKey
+                    type: object
+                  type: array
+              type: object
+            podAntiAffinity:
+              description: Describes pod anti-affinity scheduling rules (e.g.
+                avoid putting this pod in the same node, zone, etc. as some
+                other pod(s)).
+              properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  description: The scheduler will prefer to schedule pods to
+                    nodes that satisfy the anti-affinity expressions specified
+                    by this field, but it may choose a node that violates one
+                    or more of the expressions. The node that is most preferred
+                    is the one with the greatest sum of weights, i.e. for each
+                    node that meets all of the scheduling requirements (resource
+                    request, requiredDuringScheduling anti-affinity expressions,
+                    etc.), compute a sum by iterating through the elements of
+                    this field and adding "weight" to the sum if the node has
+                    pods which matches the corresponding podAffinityTerm; the
+                    node(s) with the highest sum are the most preferred.
+                  items:
+                    description: The weights of all of the matched WeightedPodAffinityTerm
+                      fields are added per-node to find the most preferred node(s)
+                    properties:
+                      podAffinityTerm:
+                        description: Required. A pod affinity term, associated
+                          with the corresponding weight.
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources,
+                              in this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label
+                                  selector requirements. The requirements are
+                                  ANDed.
+                                items:
+                                  description: A label selector requirement
+                                    is a selector that contains values, a key,
+                                    and an operator that relates the key and
+                                    values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that
+                                        the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's
+                                        relationship to a set of values. Valid
+                                        operators are In, NotIn, Exists and
+                                        DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string
+                                        values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
+                                        If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This
+                                        array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value}
+                                  pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions,
+                                  whose key field is "key", the operator is
+                                  "In", and the values array contains only "value".
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          namespaceSelector:
+                            description: A label query over the set of namespaces
+                              that the term applies to. The term is applied
+                              to the union of the namespaces selected by this
+                              field and the ones listed in the namespaces field.
+                              null selector and null or empty namespaces list
+                              means "this pod's namespace". An empty selector
+                              ({}) matches all namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label
+                                  selector requirements. The requirements are
+                                  ANDed.
+                                items:
+                                  description: A label selector requirement
+                                    is a selector that contains values, a key,
+                                    and an operator that relates the key and
+                                    values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that
+                                        the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's
+                                        relationship to a set of values. Valid
+                                        operators are In, NotIn, Exists and
+                                        DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string
+                                        values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
+                                        If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This
+                                        array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value}
+                                  pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions,
+                                  whose key field is "key", the operator is
+                                  "In", and the values array contains only "value".
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          namespaces:
+                            description: namespaces specifies a static list
+                              of namespace names that the term applies to. The
+                              term is applied to the union of the namespaces
+                              listed in this field and the ones selected by
+                              namespaceSelector. null or empty namespaces list
+                              and null namespaceSelector means "this pod's namespace".
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods
+                              matching the labelSelector in the specified namespaces,
+                              where co-located is defined as running on a node
+                              whose value of the label with key topologyKey
+                              matches that of any node on which any of the selected
+                              pods is running. Empty topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      weight:
+                        description: weight associated with matching the corresponding
+                          podAffinityTerm, in the range 1-100.
+                        format: int32
+                        type: integer
+                    required:
+                    - podAffinityTerm
+                    - weight
+                    type: object
+                  type: array
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  description: If the anti-affinity requirements specified by
+                    this field are not met at scheduling time, the pod will
+                    not be scheduled onto the node. If the anti-affinity requirements
+                    specified by this field cease to be met at some point during
+                    pod execution (e.g. due to a pod label update), the system
+                    may or may not try to eventually evict the pod from its
+                    node. When there are multiple elements, the lists of nodes
+                    corresponding to each podAffinityTerm are intersected, i.e.
+                    all terms must be satisfied.
+                  items:
+                    description: Defines a set of pods (namely those matching
+                      the labelSelector relative to the given namespace(s))
+                      that this pod should be co-located (affinity) or not co-located
+                      (anti-affinity) with, where co-located is defined as running
+                      on a node whose value of the label with key <topologyKey>
+                      matches that of any node on which a pod of the set of
+                      pods is running
+                    properties:
+                      labelSelector:
+                        description: A label query over a set of resources,
+                          in this case pods.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label
+                              selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the
+                                    selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string
+                                    values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the
+                                    operator is Exists or DoesNotExist, the
+                                    values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value}
+                              pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In",
+                              and the values array contains only "value". The
+                              requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaceSelector:
+                        description: A label query over the set of namespaces
+                          that the term applies to. The term is applied to the
+                          union of the namespaces selected by this field and
+                          the ones listed in the namespaces field. null selector
+                          and null or empty namespaces list means "this pod's
+                          namespace". An empty selector ({}) matches all namespaces.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label
+                              selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a
+                                selector that contains values, a key, and an
+                                operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the
+                                    selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are
+                                    In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string
+                                    values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the
+                                    operator is Exists or DoesNotExist, the
+                                    values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value}
+                              pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In",
+                              and the values array contains only "value". The
+                              requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: namespaces specifies a static list of namespace
+                          names that the term applies to. The term is applied
+                          to the union of the namespaces listed in this field
+                          and the ones selected by namespaceSelector. null or
+                          empty namespaces list and null namespaceSelector means
+                          "this pod's namespace".
+                        items:
+                          type: string
+                        type: array
+                      topologyKey:
+                        description: This pod should be co-located (affinity)
+                          or not co-located (anti-affinity) with the pods matching
+                          the labelSelector in the specified namespaces, where
+                          co-located is defined as running on a node whose value
+                          of the label with key topologyKey matches that of
+                          any node on which any of the selected pods is running.
+                          Empty topologyKey is not allowed.
+                        type: string
+                    required:
+                    - topologyKey
+                    type: object
+                  type: array
+              type: object
+          type: object
+        tolerations:
+          description: Tolerations allow the scheduler to schedule Package Operator
+            on nodes with matching taints.
+          items:
+            description: The pod this Toleration is attached to tolerates any
+              taint that matches the triple <key,value,effect> using the matching
+              operator <operator>.
+            properties:
+              effect:
+                description: Effect indicates the taint effect to match. Empty
+                  means match all taint effects. When specified, allowed values
+                  are NoSchedule, PreferNoSchedule and NoExecute.
+                type: string
+              key:
+                description: Key is the taint key that the toleration applies
+                  to. Empty means match all taint keys. If the key is empty,
+                  operator must be Exists; this combination means to match all
+                  values and all keys.
+                type: string
+              operator:
+                description: Operator represents a key's relationship to the
+                  value. Valid operators are Exists and Equal. Defaults to Equal.
+                  Exists is equivalent to wildcard for value, so that a pod
+                  can tolerate all taints of a particular category.
+                type: string
+              tolerationSeconds:
+                description: TolerationSeconds represents the period of time
+                  the toleration (which must be of effect NoExecute, otherwise
+                  this field is ignored) tolerates the taint. By default, it
+                  is not set, which means tolerate the taint forever (do not
+                  evict). Zero and negative values will be treated as 0 (evict
+                  immediately) by the system.
+                format: int64
+                type: integer
+              value:
+                description: Value is the taint value the toleration matches
+                  to. If the operator is Exists, the value should be empty,
+                  otherwise just a regular string.
+                type: string
+            type: object
+          type: array
+      type: object


### PR DESCRIPTION
Enable PKO to configure itself to support setting affinity and toleration rules, possible also requests/limits next.
Also setups a local development registry to enable us to "digestify" our image references instead of relying on tags, by using the new `kubectl package update` command.