### PR TITLE
Hotfix, remote-phase-manager wrong RESTMapper

### DIFF
--- a/cmd/remote-phase-manager/main.go
+++ b/cmd/remote-phase-manager/main.go
@@ -156,7 +156,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 	if err != nil {
 		return fmt.Errorf("reading target cluster kubeconfig: %w", err)
 	}
-	targetMapper, err := apiutil.NewDiscoveryRESTMapper(targetCfg)
+	targetMapper, err := apiutil.NewDynamicRESTMapper(targetCfg)
 	if err != nil {
 		return fmt.Errorf("creating target cluster rest mapper: %w", err)
 	}


### PR DESCRIPTION
Wrong RESTMapper is being used by the remote-phase-manager, this causes the remote-phase-manager to be unable to dymically discover new APIs added to the kube-apiserver after the remote-phase-manager has been started.