### PR TITLE
Basic monitoring

### DIFF
--- a/apis/core/v1alpha1/clusterobjectdeployment_types.go
+++ b/apis/core/v1alpha1/clusterobjectdeployment_types.go
@@ -27,6 +27,8 @@ type ClusterObjectDeploymentStatus struct {
 	CollisionCount *int32 `json:"collisionCount,omitempty"`
 	// Computed TemplateHash.
 	TemplateHash string `json:"templateHash,omitempty"`
+	// Deployment revision.
+	Revision int64 `json:"revision,omitempty"`
 }
 
 // ClusterObjectDeployment is the Schema for the ClusterObjectDeployments API

--- a/apis/core/v1alpha1/commonpackage_types.go
+++ b/apis/core/v1alpha1/commonpackage_types.go
@@ -15,6 +15,8 @@ type PackageStatus struct {
 	Phase PackageStatusPhase `json:"phase,omitempty"`
 	// Hash of image + config that was successfully unpacked.
 	UnpackedHash string `json:"unpackedHash,omitempty"`
+	// Package revision as reported by the ObjectDeployment.
+	Revision int64 `json:"revision,omitempty"`
 }
 
 // Package condition types.

--- a/apis/core/v1alpha1/objectdeployment_types.go
+++ b/apis/core/v1alpha1/objectdeployment_types.go
@@ -35,6 +35,8 @@ type ObjectDeploymentStatus struct {
 	CollisionCount *int32 `json:"collisionCount,omitempty"`
 	// Computed TemplateHash.
 	TemplateHash string `json:"templateHash,omitempty"`
+	// Deployment revision.
+	Revision int64 `json:"revision,omitempty"`
 }
 
 // ObjectDeployment Condition Types.

--- a/cmd/package-operator-manager/components/package.go
+++ b/cmd/package-operator-manager/components/package.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"package-operator.run/package-operator/internal/controllers/packages"
+	"package-operator.run/package-operator/internal/metrics"
 	"package-operator.run/package-operator/internal/packages/packageimport"
 )
 
@@ -43,13 +44,14 @@ func prepareRegistryHostOverrides(log logr.Logger, flag string) map[string]strin
 func ProvidePackageController(
 	mgr ctrl.Manager, log logr.Logger,
 	registry *packageimport.Registry,
+	recorder *metrics.Recorder,
 ) PackageController {
 	return PackageController{
 		packages.NewPackageController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("Package"),
 			mgr.GetScheme(),
-			registry,
+			registry, recorder,
 		),
 	}
 }
@@ -57,13 +59,14 @@ func ProvidePackageController(
 func ProvideClusterPackageController(
 	mgr ctrl.Manager, log logr.Logger,
 	registry *packageimport.Registry,
+	recorder *metrics.Recorder,
 ) ClusterPackageController {
 	return ClusterPackageController{
 		packages.NewClusterPackageController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("ClusterPackage"),
 			mgr.GetScheme(),
-			registry,
+			registry, recorder,
 		),
 	}
 }

--- a/config/crds/package-operator.run_clusterobjectdeployments.yaml
+++ b/config/crds/package-operator.run_clusterobjectdeployments.yaml
@@ -444,6 +444,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string

--- a/config/crds/package-operator.run_clusterpackages.yaml
+++ b/config/crds/package-operator.run_clusterpackages.yaml
@@ -133,6 +133,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string

--- a/config/crds/package-operator.run_objectdeployments.yaml
+++ b/config/crds/package-operator.run_objectdeployments.yaml
@@ -441,6 +441,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string

--- a/config/crds/package-operator.run_packages.yaml
+++ b/config/crds/package-operator.run_packages.yaml
@@ -133,6 +133,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string

--- a/config/grafana-dashboard.json
+++ b/config/grafana-dashboard.json
@@ -1,0 +1,1429 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "package_operator_package_created_timestamp_seconds * 1000",
+        "iconColor": "green",
+        "name": "Package Created",
+        "titleFormat": "Created {{pko_namespace}}/{{pko_name}}",
+        "useValueForTime": "on"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 24,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (package_operator_package_availability)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Packages",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (package_operator_package_availability==1)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Available Packages",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(count by(pko_name, pko_namespace) (package_operator_package_availability==0))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unavailable Packages",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (package_operator_object_set_created_timestamp_seconds)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total ObjectSets",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (package_operator_object_set_succeeded_timestamp_seconds)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Succeeded ObjectSets",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (package_operator_object_set_created_timestamp_seconds) - count (package_operator_object_set_succeeded_timestamp_seconds)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Archived ObjectSets",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Unavailable"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Available"
+                },
+                "2": {
+                  "color": "orange",
+                  "index": 2,
+                  "text": "Unknown"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 16,
+        "x": 0,
+        "y": 8
+      },
+      "id": 44,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(pko_name, pko_namespace) (package_operator_package_availability{pko_name=\"package-operator\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 2,
+        "x": 16,
+        "y": 8
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(package_operator_package_revision{pko_name=\"package-operator\",pko_namespace=\"\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Revisions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 2,
+        "x": 18,
+        "y": 8
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "  max by (pko_package_instance, pko_namespace) (package_operator_object_set_succeeded_timestamp_seconds{pko_package_instance=\"package-operator\",pko_namespace=\"\"})\n- on (pko_package_instance, pko_namespace)\n  max by (pko_package_instance, pko_namespace) (package_operator_object_set_created_timestamp_seconds{pko_package_instance=\"package-operator\",pko_namespace=\"\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rollout",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 8
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg (package_operator_package_load_duration_milliseconds)",
+          "legendFormat": "{{pko_namespace}}/{{pko_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Package Load Duration",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "How long in seconds an item stays in workqueue before being requested.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 36,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg by(name) (workqueue_queue_duration_seconds_bucket{service=\"package-operator-metrics\"})",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Queue Duration",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "How long in seconds processing an item from workqueue takes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 37,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by(controller) (controller_runtime_reconcile_time_seconds_bucket{service=\"package-operator-metrics\"})",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Reconcile Duration",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of reconciliation errors per controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 38,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "avg by(controller) (rate(controller_runtime_reconcile_errors_total{service=\"package-operator-metrics\"}[$__rate_interval]))",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Errors",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of reconciliation errors per controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 39,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "avg by(controller) (controller_runtime_active_workers{service=\"package-operator-metrics\"})",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Utilized Workers",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Dynamic Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 20,
+        "x": 0,
+        "y": 23
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg by(pko_gvk) (package_operator_dynamic_cache_objects)",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{pko_gvk}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Cache by GVK",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 23
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "avg(package_operator_dynamic_cache_informers)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Cache Informer Count",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 29
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(package_operator_dynamic_cache_objects)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Objects Cached",
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 41,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed"
+              },
+              "custom": {
+                "fillOpacity": 70,
+                "lineWidth": 0,
+                "spanNulls": true
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Unavailable"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Available"
+                    },
+                    "2": {
+                      "color": "orange",
+                      "index": 2,
+                      "text": "Unknown"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 13,
+            "x": 0,
+            "y": 1
+          },
+          "id": 28,
+          "options": {
+            "alignValue": "center",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "sum by(pko_name, pko_namespace) (package_operator_package_availability{pko_name!=\"package-operator\"})",
+              "legendFormat": "{{pko_namespace}}/{{pko_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Availability",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 4,
+            "x": 13,
+            "y": 1
+          },
+          "id": 43,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "  max by (pko_package_instance, pko_namespace) (package_operator_object_set_succeeded_timestamp_seconds{pko_package_instance!=\"package-operator\"})\n- on (pko_package_instance, pko_namespace)\n  max by (pko_package_instance, pko_namespace) (package_operator_object_set_created_timestamp_seconds{pko_package_instance!=\"package-operator\"})",
+              "legendFormat": "{{pko_namespace}}/{{pko_package_instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Revision Rollout Time",
+          "type": "bargauge"
+        }
+      ],
+      "title": "Packages",
+      "type": "row"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Package Operator",
+  "uid": "BLWcoHf4k",
+  "version": 23,
+  "weekStart": ""
+}

--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -29,6 +29,9 @@ spec:
       containers:
       - args:
         - --enable-leader-election
+        ports:
+        - name: metrics
+          containerPort: 8080
         env:
 {{- if hasKey .config "registryHostOverrides" }}
         - name: PKO_REGISTRY_HOST_OVERRIDES

--- a/config/service-monitor.yaml
+++ b/config/service-monitor.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: package-operator-system
+  labels:
+    package-operator.run/cache: "True"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: package-operator-metrics
+  namespace: package-operator-system
+  labels:
+    app.kubernetes.io/name: package-operator
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: package-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: package-operator
+  namespace: package-operator-system
+  labels:
+    app.kubernetes.io/name: package-operator
+    release: prometheus
+spec:
+  endpoints:
+  - interval: 10s
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: package-operator

--- a/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
@@ -444,6 +444,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string

--- a/config/static-deployment/1-package-operator.run_clusterpackages.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterpackages.yaml
@@ -133,6 +133,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string

--- a/config/static-deployment/1-package-operator.run_objectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_objectdeployments.yaml
@@ -441,6 +441,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string

--- a/config/static-deployment/1-package-operator.run_packages.yaml
+++ b/config/static-deployment/1-package-operator.run_packages.yaml
@@ -133,6 +133,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string

--- a/config/static-deployment/deployment.yaml.tpl
+++ b/config/static-deployment/deployment.yaml.tpl
@@ -30,6 +30,9 @@ spec:
           value: "quay.io/package-operator/package-operator-manager:latest"
         - name: PKO_REMOTE_PHASE_PACKAGE_IMAGE
           value: "quay.io/package-operator/remote-phase-package:latest"
+        ports:
+        - name: metrics
+          containerPort: 8080
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -686,6 +686,7 @@ ClusterObjectDeploymentStatus defines the observed state of a ClusterObjectDeplo
 | `phase` <br><a href="#objectdeploymentphase">ObjectDeploymentPhase</a> | This field is not part of any API contract<br>it will go away as soon as kubectl can print conditions!<br>When evaluating object state in code, use .Conditions instead. |
 | `collisionCount` <br><a href="#int32">int32</a> | Count of hash collisions of the ClusterObjectDeployment. |
 | `templateHash` <br>string | Computed TemplateHash. |
+| `revision` <br>int64 | Deployment revision. |
 
 
 Used in:
@@ -816,6 +817,7 @@ ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
 | `phase` <br><a href="#objectdeploymentphase">ObjectDeploymentPhase</a> | This field is not part of any API contract<br>it will go away as soon as kubectl can print conditions!<br>When evaluating object state in code, use .Conditions instead. |
 | `collisionCount` <br><a href="#int32">int32</a> | Count of hash collisions of the ObjectDeployment. |
 | `templateHash` <br>string | Computed TemplateHash. |
+| `revision` <br>int64 | Deployment revision. |
 
 
 Used in:
@@ -1077,6 +1079,7 @@ PackageStatus defines the observed state of a Package.
 | `conditions` <br>[]metav1.Condition | Conditions is a list of status conditions ths object is in. |
 | `phase` <br><a href="#packagestatusphase">PackageStatusPhase</a> | This field is not part of any API contract<br>it will go away as soon as kubectl can print conditions!<br>When evaluating object state in code, use .Conditions instead. |
 | `unpackedHash` <br>string | Hash of image + config that was successfully unpacked. |
+| `revision` <br>int64 | Package revision as reported by the ObjectDeployment. |
 
 
 Used in:

--- a/install.yaml
+++ b/install.yaml
@@ -448,6 +448,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string
@@ -1616,6 +1620,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string
@@ -2068,6 +2076,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Deployment revision.
+                format: int64
+                type: integer
               templateHash:
                 description: Computed TemplateHash.
                 type: string
@@ -3233,6 +3245,10 @@ spec:
                   away as soon as kubectl can print conditions! When evaluating object
                   state in code, use .Conditions instead.
                 type: string
+              revision:
+                description: Package revision as reported by the ObjectDeployment.
+                format: int64
+                type: integer
               unpackedHash:
                 description: Hash of image + config that was successfully unpacked.
                 type: string
@@ -3373,6 +3389,9 @@ spec:
           value: "quay.io/package-operator/package-operator-manager:latest"
         - name: PKO_REMOTE_PHASE_PACKAGE_IMAGE
           value: "quay.io/package-operator/remote-phase-package:latest"
+        ports:
+        - name: metrics
+          containerPort: 8080
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/adapters/objectdeployment.go
+++ b/internal/adapters/objectdeployment.go
@@ -25,6 +25,8 @@ type ObjectDeploymentAccessor interface {
 	GetStatusTemplateHash() string
 	SetStatusTemplateHash(templateHash string)
 	SetSelector(labels map[string]string)
+	SetStatusRevision(r int64)
+	GetStatusRevision() int64
 }
 
 type ObjectDeploymentFactory func(
@@ -129,6 +131,14 @@ func (a *ObjectDeployment) SetSelector(labels map[string]string) {
 	a.Spec.Template.Metadata.Labels = labels
 }
 
+func (a *ObjectDeployment) SetStatusRevision(r int64) {
+	a.Status.Revision = r
+}
+
+func (a *ObjectDeployment) GetStatusRevision() int64 {
+	return a.Status.Revision
+}
+
 type ClusterObjectDeployment struct {
 	corev1alpha1.ClusterObjectDeployment
 }
@@ -194,6 +204,14 @@ func (a *ClusterObjectDeployment) SetSelector(labels map[string]string) {
 		MatchLabels: labels,
 	}
 	a.Spec.Template.Metadata.Labels = labels
+}
+
+func (a *ClusterObjectDeployment) SetStatusRevision(r int64) {
+	a.Status.Revision = r
+}
+
+func (a *ClusterObjectDeployment) GetStatusRevision() int64 {
+	return a.Status.Revision
 }
 
 func objectDeploymentPhase(conditions []metav1.Condition) corev1alpha1.ObjectDeploymentPhase {

--- a/internal/adapters/package.go
+++ b/internal/adapters/package.go
@@ -21,6 +21,8 @@ type GenericPackageAccessor interface {
 	SetUnpackedHash(hash string)
 	setStatusPhase(phase corev1alpha1.PackageStatusPhase)
 	TemplateContext() manifestsv1alpha1.TemplateContext
+	SetStatusRevision(rev int64)
+	GetStatusRevision() int64
 }
 
 type GenericPackageFactory func(scheme *runtime.Scheme) GenericPackageAccessor
@@ -89,6 +91,14 @@ func (a *GenericPackage) GetUnpackedHash() string {
 	return a.Status.UnpackedHash
 }
 
+func (a *GenericPackage) SetStatusRevision(rev int64) {
+	a.Status.Revision = rev
+}
+
+func (a *GenericPackage) GetStatusRevision() int64 {
+	return a.Status.Revision
+}
+
 func (a *GenericPackage) setStatusPhase(phase corev1alpha1.PackageStatusPhase) {
 	a.Status.Phase = phase
 }
@@ -124,6 +134,14 @@ func (a *GenericClusterPackage) GetImage() string {
 
 func (a *GenericClusterPackage) GetSpecHash() string {
 	return utils.ComputeSHA256Hash(a.Spec, nil)
+}
+
+func (a *GenericClusterPackage) SetStatusRevision(rev int64) {
+	a.Status.Revision = rev
+}
+
+func (a *GenericClusterPackage) GetStatusRevision() int64 {
+	return a.Status.Revision
 }
 
 func (a *GenericClusterPackage) setStatusPhase(phase corev1alpha1.PackageStatusPhase) {

--- a/internal/controllers/objectdeployments/adapters.go
+++ b/internal/controllers/objectdeployments/adapters.go
@@ -20,4 +20,5 @@ type objectDeploymentAccessor interface {
 	GetStatusTemplateHash() string
 	GetGeneration() int64
 	SetStatusTemplateHash(templateHash string)
+	SetStatusRevision(r int64)
 }

--- a/internal/controllers/objectdeployments/mocks_test.go
+++ b/internal/controllers/objectdeployments/mocks_test.go
@@ -102,6 +102,10 @@ type genericObjectDeploymentMock struct {
 	mock.Mock
 }
 
+func (o *genericObjectDeploymentMock) SetStatusRevision(r int64) {
+	o.Called(r)
+}
+
 func (o *genericObjectDeploymentMock) ClientObject() client.Object {
 	args := o.Called()
 	return args.Get(0).(client.Object)

--- a/internal/controllers/objectdeployments/objectset_reconciler.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler.go
@@ -110,9 +110,13 @@ func (o *objectSetReconciler) setObjectDeploymentStatus(ctx context.Context,
 			),
 			conditionFromPreviousObjectSets(objectDeployment.GetGeneration(), prevObjectSets...),
 		)
-
+		if len(prevObjectSets) > 0 {
+			objectDeployment.SetStatusRevision(prevObjectSets[0].GetRevision())
+		}
 		return
 	}
+
+	objectDeployment.SetStatusRevision(currentObjectSet.GetRevision())
 
 	// map conditions
 	// -> copy mapped status conditions

--- a/internal/controllers/objectdeployments/objectset_reconciler_test.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler_test.go
@@ -210,6 +210,7 @@ func makeObjectDeploymentMock(name string, namespace string,
 			"match": "all",
 		},
 	}
+	res.On("SetStatusRevision", mock.Anything).Return()
 	res.On("GetSelector").Return(labelSelector)
 	res.On("GetGeneration").Return(generation)
 	res.On("GetStatusTemplateHash").Return(templateHash)

--- a/internal/controllers/packages/object_deployment_status_reconciler.go
+++ b/internal/controllers/packages/object_deployment_status_reconciler.go
@@ -48,5 +48,7 @@ func (r *objectDeploymentStatusReconciler) Reconcile(ctx context.Context, packag
 		packageObj.ClientObject().GetGeneration(), packageObj.GetConditions(),
 	)
 
+	packageObj.SetStatusRevision(objDep.GetStatusRevision())
+
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/packages/unpack_reconciler_test.go
+++ b/internal/controllers/packages/unpack_reconciler_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnpackReconciler(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd)
+	ur := newUnpackReconciler(ipm, pd, nil)
 
 	const image = "test123:latest"
 
@@ -51,7 +51,7 @@ func TestUnpackReconciler(t *testing.T) {
 func TestUnpackReconciler_noop(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd)
+	ur := newUnpackReconciler(ipm, pd, nil)
 
 	const image = "test123:latest"
 
@@ -74,7 +74,7 @@ var errTest = errors.New("test error")
 func TestUnpackReconciler_pullBackoff(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd)
+	ur := newUnpackReconciler(ipm, pd, nil)
 
 	const image = "test123:latest"
 

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
 	"package-operator.run/package-operator/internal/preflight"
 	"package-operator.run/package-operator/internal/probing"
 )
@@ -434,6 +435,16 @@ func (r *PhaseReconciler) desiredObject(
 		labels = map[string]string{}
 	}
 	labels[DynamicCacheLabel] = "True"
+
+	if ownerLabels := owner.ClientObject().GetLabels(); ownerLabels != nil {
+		if pkgLabel, ok := ownerLabels[manifestsv1alpha1.PackageLabel]; ok {
+			labels[manifestsv1alpha1.PackageLabel] = pkgLabel
+		}
+		if pkgInstanceLabel, ok := ownerLabels[manifestsv1alpha1.PackageInstanceLabel]; ok {
+			labels[manifestsv1alpha1.PackageLabel] = pkgInstanceLabel
+		}
+	}
+
 	desiredObj.SetLabels(labels)
 
 	setObjectRevision(desiredObj, owner.GetRevision())

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -1,28 +1,35 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
 )
 
 // Recorder stores all the metrics related to Addons.
 type Recorder struct {
 	dynamicCacheInformers prometheus.Gauge
 	dynamicCacheObjects   *prometheus.GaugeVec
-	rolloutTime           *prometheus.GaugeVec
-}
 
-type GenericObjectSet interface {
-	ClientObject() client.Object
-	GetConditions() *[]metav1.Condition
+	packageAvailability *prometheus.GaugeVec
+	packageCreated      *prometheus.GaugeVec
+	packageLoadDuration *prometheus.GaugeVec
+	packageRevision     *prometheus.GaugeVec
+
+	objectSetCreated   *prometheus.GaugeVec
+	objectSetSucceeded *prometheus.GaugeVec
 }
 
 func NewRecorder() *Recorder {
+	// DynamicCache
 	dynamicCacheInformers := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "package_operator_dynamic_cache_informers",
@@ -32,39 +39,152 @@ func NewRecorder() *Recorder {
 		prometheus.GaugeOpts{
 			Name: "package_operator_dynamic_cache_objects",
 			Help: "Number of objects for each GVK in the dynamic cache.",
-		}, []string{"gvk"})
-	rolloutTime := prometheus.NewGaugeVec(
+		}, []string{"pko_gvk"})
+
+	// Package
+	packageAvailability := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "package_operator_object_set_rollout_time_seconds",
-			Help: "Time between Object creationTimestamp and the transition to True of the Succeeded condition.",
-		}, []string{"name", "namespace"},
+			Name: "package_operator_package_availability",
+			Help: "Package availability 0=Unavailable,1=Available,2=Unknown.",
+		}, []string{"pko_name", "pko_namespace"},
+	)
+	packageCreated := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "package_operator_package_created_timestamp_seconds",
+			Help: "Package Unix creation timestamp.",
+		}, []string{"pko_name", "pko_namespace"},
+	)
+	packageLoadDuration := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "package_operator_package_load_duration_seconds",
+			Help: "Duration for the last package load operation, including download and parsing.",
+		}, []string{"pko_name", "pko_namespace"},
+	)
+	packageRevision := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "package_operator_package_revision",
+			Help: "Package revision.",
+		}, []string{"pko_name", "pko_namespace"},
+	)
+
+	// Revisions
+	objectSetCreated := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "package_operator_object_set_created_timestamp_seconds",
+			Help: "ObjectSet Unix creation timestamp.",
+		}, []string{"pko_name", "pko_namespace", "pko_package_instance"},
+	)
+	objectSetSucceeded := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "package_operator_object_set_succeeded_timestamp_seconds",
+			Help: "ObjectSet Unix success timestamp.",
+		}, []string{"pko_name", "pko_namespace", "pko_package_instance"},
 	)
 
 	return &Recorder{
 		dynamicCacheInformers: dynamicCacheInformers,
 		dynamicCacheObjects:   dynamicCacheObjects,
-		rolloutTime:           rolloutTime,
+
+		packageAvailability: packageAvailability,
+		packageCreated:      packageCreated,
+		packageLoadDuration: packageLoadDuration,
+		packageRevision:     packageRevision,
+
+		objectSetCreated:   objectSetCreated,
+		objectSetSucceeded: objectSetSucceeded,
 	}
 }
 
 // Register metrics into ctrl registry.
 func (r *Recorder) Register() {
 	ctrlmetrics.Registry.MustRegister(
-		r.dynamicCacheInformers,
-		r.dynamicCacheObjects,
-		r.rolloutTime,
+		r.dynamicCacheInformers, r.dynamicCacheObjects,
+		r.packageAvailability, r.packageCreated, r.packageLoadDuration, r.packageRevision,
+
+		r.objectSetCreated, r.objectSetSucceeded,
 	)
 }
 
-func (r *Recorder) RecordRolloutTime(objectSet GenericObjectSet) {
-	obj := objectSet.ClientObject()
-	start := obj.GetCreationTimestamp()
-	conds := objectSet.GetConditions()
-	for _, cond := range *conds {
-		if cond.Type == corev1alpha1.ObjectSetSucceeded {
-			t := cond.LastTransitionTime.Sub(start.Time).Seconds()
-			r.rolloutTime.WithLabelValues(obj.GetName(), obj.GetNamespace()).Set(t)
+type GenericPackage interface {
+	ClientObject() client.Object
+	GetConditions() *[]metav1.Condition
+	GetStatusRevision() int64
+}
+
+func (r *Recorder) RecordPackageMetrics(pkg GenericPackage) {
+	obj := pkg.ClientObject()
+	if !obj.GetDeletionTimestamp().IsZero() {
+		r.packageAvailability.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+		r.packageCreated.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+		r.packageLoadDuration.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+		r.packageRevision.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+		return
+	}
+
+	// default to unknown
+	healthStatus := 2
+
+	if availableCond := meta.FindStatusCondition(
+		*pkg.GetConditions(), corev1alpha1.PackageAvailable,
+	); availableCond != nil {
+		switch availableCond.Status {
+		case metav1.ConditionFalse:
+			healthStatus = 0
+		case metav1.ConditionTrue:
+			healthStatus = 1
 		}
+	}
+
+	r.packageAvailability.WithLabelValues(
+		obj.GetName(), obj.GetNamespace(),
+	).Set(float64(healthStatus))
+	r.packageCreated.WithLabelValues(
+		obj.GetName(), obj.GetNamespace(),
+	).Set(float64(obj.GetCreationTimestamp().Unix()))
+	r.packageRevision.WithLabelValues(
+		obj.GetName(), obj.GetNamespace(),
+	).Set(float64(pkg.GetStatusRevision()))
+}
+
+func (r *Recorder) RecordPackageLoadMetric(pkg GenericPackage, d time.Duration) {
+	obj := pkg.ClientObject()
+	r.packageLoadDuration.
+		WithLabelValues(obj.GetName(), obj.GetNamespace()).
+		Set(float64(d.Milliseconds()) / 1000)
+}
+
+type GenericObjectSet interface {
+	ClientObject() client.Object
+	GetConditions() *[]metav1.Condition
+}
+
+func (r *Recorder) RecordObjectSetMetrics(objectSet GenericObjectSet) {
+	obj := objectSet.ClientObject()
+
+	// Package instance name -> name of the Package Object.
+	var instance string
+	if l := obj.GetLabels(); l != nil && l[manifestsv1alpha1.PackageInstanceLabel] != "" {
+		instance = l[manifestsv1alpha1.PackageInstanceLabel]
+	}
+
+	if !obj.GetDeletionTimestamp().IsZero() ||
+		meta.IsStatusConditionTrue(*objectSet.GetConditions(), corev1alpha1.ObjectSetArchived) {
+		r.objectSetSucceeded.DeleteLabelValues(obj.GetName(), obj.GetNamespace(), instance)
+	} else {
+		succeededCond := meta.FindStatusCondition(*objectSet.GetConditions(), corev1alpha1.ObjectSetSucceeded)
+		if succeededCond != nil {
+			r.objectSetSucceeded.
+				WithLabelValues(obj.GetName(), obj.GetNamespace(), instance).
+				Set(float64(succeededCond.LastTransitionTime.Unix()))
+		}
+	}
+
+	if !obj.GetDeletionTimestamp().IsZero() {
+		r.objectSetCreated.DeleteLabelValues(obj.GetName(), obj.GetNamespace(), instance)
+	} else {
+		r.objectSetCreated.
+			WithLabelValues(obj.GetName(), obj.GetNamespace(), instance).
+			Set(float64(obj.GetCreationTimestamp().Unix()))
 	}
 }
 


### PR DESCRIPTION
Installs a monitoring stack into the development environment and instruments PKO with new metrics.
A new grafana dashboard is provided at `grafana-dashboard.json`

To reach the in-cluster grafana and prometheus:
```
kubectl port-forward -n monitoring svc/prometheus-grafana 5080:80
kubectl port-forward -n monitoring prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
```