### PR TITLE
Hotfix: wrong obj namespace blocks teardown

### DIFF
--- a/internal/controllers/hostedclusters/hostedcluster_controller.go
+++ b/internal/controllers/hostedclusters/hostedcluster_controller.go
@@ -65,6 +65,11 @@ func (c *HostedClusterController) Reconcile(
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if !hostedCluster.DeletionTimestamp.IsZero() {
+		log.Info("HostedCluster is deleting")
+		return ctrl.Result{}, nil
+	}
+
 	if !meta.IsStatusConditionTrue(hostedCluster.Status.Conditions, v1beta1.HostedClusterAvailable) {
 		log.Info("waiting for HostedCluster to become ready")
 		return ctrl.Result{}, nil


### PR DESCRIPTION
If object specify a namespace that differs from the installation namespace of a ObjectSet, teardown is blocked on failing to set the controller reference.

This commit removes setting the controller reference in the teardown flow and re-runs the preflight checker during teardown to prevent deletion of objects in different namespaces.