### PR TITLE
Use lazy rest mapper

### DIFF
--- a/cmd/package-operator-manager/components/components.go
+++ b/cmd/package-operator-manager/components/components.go
@@ -8,6 +8,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	pkoapis "package-operator.run/apis"
@@ -152,9 +154,9 @@ func ProvideManager(
 		LeaderElectionResourceLock: "leases",
 		LeaderElection:             opts.EnableLeaderElection,
 		LeaderElectionID:           "8a4hp84a6s.package-operator-lock",
-		// MapperProvider: func(c *rest.Config) (meta.RESTMapper, error) {
-		// 	return apiutil.NewDynamicRESTMapper(c)
-		// },
+		MapperProvider: func(c *rest.Config) (meta.RESTMapper, error) {
+			return apiutil.NewDynamicRESTMapper(c, apiutil.WithLazyDiscovery)
+		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				// We create Jobs to unpack package images.

--- a/cmd/remote-phase-manager/main.go
+++ b/cmd/remote-phase-manager/main.go
@@ -157,7 +157,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 	if err != nil {
 		return fmt.Errorf("reading target cluster kubeconfig: %w", err)
 	}
-	targetMapper, err := apiutil.NewDynamicRESTMapper(targetCfg)
+	targetMapper, err := apiutil.NewDynamicRESTMapper(targetCfg, apiutil.WithLazyDiscovery)
 	if err != nil {
 		return fmt.Errorf("creating target cluster rest mapper: %w", err)
 	}


### PR DESCRIPTION
In large clusters with many APIs, PKO startup may take a long time because we are running into client throttling.

Switch to lazy restmapper to delay apidiscovery until required.