### PR TITLE
Wrap preflight violations in SourceError

### DIFF
--- a/internal/controllers/objecttemplate/template_reconciler.go
+++ b/internal/controllers/objecttemplate/template_reconciler.go
@@ -284,7 +284,7 @@ func (r *templateReconciler) templateObject(
 		return err
 	}
 	if len(violations) > 0 {
-		return &preflight.Error{Violations: violations}
+		return &SourceError{Source: object, Err: &preflight.Error{Violations: violations}}
 	}
 
 	if len(objectTemplate.ClientObject().GetNamespace()) > 0 {

--- a/magefile.go
+++ b/magefile.go
@@ -68,7 +68,7 @@ var (
 
 	// packageImages defines what packages in this repository shall be build.
 	// Note that you can't reference the Generate mage target in ExtraDeps
-	// since that would result in a circulat dependency. They must be added via init() for now.
+	// since that would result in a circular dependency. They must be added via init() for now.
 	packageImages = map[string]*PackageImage{
 		pkoPackageName:         {Push: true, SourcePath: filepath.Join("config", "packages", "package-operator")},
 		remotePhasePackageName: {Push: true, SourcePath: filepath.Join("config", "packages", "remote-phase")},


### PR DESCRIPTION
Rendered object preflight errors weren't being shown in the conditions because they weren't wrapped in a SourceError