### PR TITLE
Fix fatal object creation error blocks new rollout

### DIFF
--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -120,6 +120,7 @@ func newGenericObjectSetController(
 			ownerhandling.NewNative(scheme),
 			preflight.List{
 				preflight.NewAPIExistence(restMapper),
+				preflight.NewEmptyNamespaceNoDefault(restMapper),
 				preflight.NewNamespaceEscalation(restMapper),
 			},
 		),
@@ -213,6 +214,9 @@ func (c *GenericObjectSetController) Reconcile(
 
 	for _, r := range c.reconciler {
 		res, err = r.Reconcile(ctx, objectSet)
+		if _, preflightFail := err.(*preflight.Error); preflightFail {
+			err = nil
+		}
 		if err != nil || !res.IsZero() {
 			break
 		}


### PR DESCRIPTION
Fix for fatal object creation error due to missing namespace which blocks roll outs of new revision. 

The fix involved adding the namespace preflight check and adding the failure message to the status of the objectset. 
Then the  objectset_controller doesn't treat preflight check failiures as errors, allowing the reconcile to continue to update the revision number and the status of the objectset api.