### PR TITLE
[MTSRE-1142] fix: apply backoff when external objects not found

### DIFF
--- a/internal/controllers/config.go
+++ b/internal/controllers/config.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+const (
+	DefaultInitialBackoff = 10 * time.Second
+	DefaultMaxBackoff     = 300 * time.Second
+)
+
+type BackoffConfig struct {
+	InitialBackoff *time.Duration
+	MaxBackoff     *time.Duration
+}
+
+func (c *BackoffConfig) Option(opts ...BackoffOption) {
+	for _, opt := range opts {
+		opt.ConfigureBackoff(c)
+	}
+}
+
+type BackoffOption interface {
+	ConfigureBackoff(*BackoffConfig)
+}
+
+func (c *BackoffConfig) Default() {
+	var (
+		initialBackoff = DefaultInitialBackoff
+		maxBackoff     = DefaultMaxBackoff
+	)
+
+	if c.InitialBackoff == nil {
+		c.InitialBackoff = &initialBackoff
+	}
+	if c.MaxBackoff == nil {
+		c.MaxBackoff = &maxBackoff
+	}
+}
+
+func (c *BackoffConfig) GetBackoff() *flowcontrol.Backoff {
+	return flowcontrol.NewBackOff(*c.InitialBackoff, *c.MaxBackoff)
+}

--- a/internal/controllers/errors.go
+++ b/internal/controllers/errors.go
@@ -1,0 +1,56 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsExternalResourceNotFound(err error) bool {
+	var ctrlErr ControllerError
+
+	return errors.As(err, &ctrlErr) && ctrlErr.CausedBy(ErrorReasonExternalResourceNotFound)
+}
+
+type ControllerError interface {
+	CausedBy(reason ErrorReason) bool
+}
+
+type ErrorReason string
+
+func (r ErrorReason) String() string {
+	return string(r)
+}
+
+const (
+	ErrorReasonExternalResourceNotFound ErrorReason = "external resource not found"
+)
+
+func NewExternalResourceNotFoundError(rsrc client.Object) *PhaseReconcilerError {
+	return &PhaseReconcilerError{
+		rsrc:   rsrc,
+		reason: ErrorReasonExternalResourceNotFound,
+	}
+}
+
+type PhaseReconcilerError struct {
+	rsrc   client.Object
+	reason ErrorReason
+}
+
+func (e *PhaseReconcilerError) Error() string {
+	var (
+		gvk       = e.rsrc.GetObjectKind().GroupVersionKind()
+		name      = e.rsrc.GetName()
+		namespace = e.rsrc.GetNamespace()
+	)
+
+	return fmt.Sprintf(
+		"%s/%s %s/%s: %s", gvk.Group, gvk.Kind, namespace, name, e.reason,
+	)
+}
+
+func (e *PhaseReconcilerError) CausedBy(reason ErrorReason) bool {
+	return e.reason == reason
+}

--- a/internal/controllers/errors_test.go
+++ b/internal/controllers/errors_test.go
@@ -1,0 +1,51 @@
+package controllers
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExternalResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		Error     error
+		Assertion assert.BoolAssertionFunc
+	}{
+		"nil": {
+			Error:     nil,
+			Assertion: assert.False,
+		},
+		"external resource not found error": {
+			Error:     NewExternalResourceNotFoundError(nil),
+			Assertion: assert.True,
+		},
+		"wrapped external resource not found error": {
+			Error:     fmt.Errorf("%w", NewExternalResourceNotFoundError(nil)),
+			Assertion: assert.True,
+		},
+		"io error": {
+			Error:     io.EOF,
+			Assertion: assert.False,
+		},
+	} {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.Assertion(t, IsExternalResourceNotFound(tc.Error))
+		})
+	}
+}
+
+func TestPhaseReconcilerErrorInterfaces(t *testing.T) {
+	t.Parallel()
+
+	require.Implements(t, new(error), new(PhaseReconcilerError))
+	require.Implements(t, new(ControllerError), new(PhaseReconcilerError))
+}

--- a/internal/controllers/options.go
+++ b/internal/controllers/options.go
@@ -1,0 +1,21 @@
+package controllers
+
+import (
+	"time"
+)
+
+type WithInitialBackoff time.Duration
+
+func (w WithInitialBackoff) ConfigureBackoff(c *BackoffConfig) {
+	val := time.Duration(w)
+
+	c.InitialBackoff = &val
+}
+
+type WithMaxBackoff time.Duration
+
+func (w WithMaxBackoff) ConfigureBackoff(c *BackoffConfig) {
+	val := time.Duration(w)
+
+	c.MaxBackoff = &val
+}

--- a/internal/controllers/packages/unpack_reconciler_test.go
+++ b/internal/controllers/packages/unpack_reconciler_test.go
@@ -12,6 +12,7 @@ import (
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/package-operator/internal/adapters"
+	"package-operator.run/package-operator/internal/controllers"
 	"package-operator.run/package-operator/internal/packages/packagecontent"
 )
 
@@ -94,7 +95,7 @@ func TestUnpackReconciler_pullBackoff(t *testing.T) {
 	ctx := context.Background()
 	res, err := ur.Reconcile(ctx, pkg)
 	require.NoError(t, err)
-	assert.Equal(t, pullBackOffPeriod, res.RequeueAfter)
+	assert.Equal(t, controllers.DefaultInitialBackoff, res.RequeueAfter)
 
 	assert.True(t,
 		meta.IsStatusConditionFalse(*pkg.GetConditions(),

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -222,7 +222,9 @@ func (r *PhaseReconciler) observeExternalObject(
 	)
 
 	if err := r.dynamicCache.Get(ctx, key, observed); errors.IsNotFound(err) {
-		if err := r.uncachedClient.Get(ctx, key, obj); err != nil {
+		if err := r.uncachedClient.Get(ctx, key, obj); errors.IsNotFound(err) {
+			return nil, NewExternalResourceNotFoundError(obj)
+		} else if err != nil {
 			return nil, fmt.Errorf("retrieving external object: %w", err)
 		}
 


### PR DESCRIPTION
### Summary

Applies backoff when external objects are not found for a given phase reconciliation loop.
This is needed to prevent "hot" loops from occurring due to external issues.