### PR TITLE
Add base64 decoded stringData to secret

### DIFF
--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -528,3 +528,25 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 		})
 	}
 }
+
+func Test_secretInjectStringData(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"data": map[string]interface{}{
+				"test": "YWJjZGVm",
+			},
+		},
+	}
+	obj.SetGroupVersionKind(secretGK.WithVersion("v1"))
+
+	err := secretInjectStringData(obj)
+	require.NoError(t, err)
+
+	stringData, ok, err := unstructured.NestedStringMap(
+		obj.Object, "stringData")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, map[string]string{
+		"test": "abcdef",
+	}, stringData)
+}


### PR DESCRIPTION
Injects a new top-level key `stringData` into v1/Secrets used as source in the `ObjectTemplate` API.
This key contains all keys under `.data` but base64 decoded.