### PR TITLE
DryRun preflight check mutates object

### DIFF
--- a/internal/preflight/dryrun.go
+++ b/internal/preflight/dryrun.go
@@ -22,7 +22,7 @@ func (p *CreationDryRun) Check(
 ) (violations []Violation, err error) {
 	defer addPositionToViolations(ctx, obj, &violations)
 
-	drerr := p.client.Create(ctx, obj, client.DryRunAll)
+	drerr := p.client.Create(ctx, obj.DeepCopyObject().(client.Object), client.DryRunAll)
 	if errors.IsAlreadyExists(drerr) {
 		return
 	}


### PR DESCRIPTION
Performing a dry-run on an object may mutate the object using webhooks or API-internal defaulting. Trying to create this object afterwards may not succeed.