### PR TITLE
Fix hidden files imported from image

### DIFF
--- a/internal/packages/packageimport/fs.go
+++ b/internal/packages/packageimport/fs.go
@@ -56,4 +56,10 @@ func Folder(ctx context.Context, path string) (packagecontent.Files, error) {
 	return FS(ctx, os.DirFS(path))
 }
 
-func isFileToBeExcluded(entry fs.DirEntry) bool { return strings.HasPrefix(entry.Name(), ".") }
+func isFileToBeExcluded(entry fs.DirEntry) bool {
+	return isFilenameToBeExcluded(entry.Name())
+}
+
+func isFilenameToBeExcluded(fileName string) bool {
+	return strings.HasPrefix(fileName, ".")
+}

--- a/internal/packages/packageimport/image.go
+++ b/internal/packages/packageimport/image.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -16,9 +18,11 @@ import (
 	"package-operator.run/package-operator/internal/packages/packagecontent"
 )
 
-func Image(_ context.Context, image v1.Image) (m packagecontent.Files, err error) {
+func Image(ctx context.Context, image v1.Image) (m packagecontent.Files, err error) {
 	files := packagecontent.Files{}
 	reader := mutate.Extract(image)
+	verboseLog := logr.FromContextOrDiscard(ctx).V(1)
+
 	defer func() {
 		if cErr := reader.Close(); err == nil && cErr != nil {
 			err = cErr
@@ -36,6 +40,11 @@ func Image(_ context.Context, image v1.Image) (m packagecontent.Files, err error
 		path, err := filepath.Rel(packages.ImageFilePrefixPath, tarPath)
 		if err != nil {
 			return nil, fmt.Errorf("package image contains files not under the dir %s: %w", packages.ImageFilePrefixPath, err)
+		}
+
+		if isFilePathToBeExcluded(path) {
+			verboseLog.Info("skipping file in source", "path", path)
+			continue
 		}
 
 		data, err := io.ReadAll(tarReader)
@@ -56,4 +65,14 @@ func PulledImage(ctx context.Context, ref string) (packagecontent.Files, error) 
 	}
 
 	return Image(ctx, img)
+}
+
+func isFilePathToBeExcluded(path string) bool {
+	for _, pathSegment := range strings.Split(
+		path, string(filepath.Separator)) {
+		if isFilenameToBeExcluded(pathSegment) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Summary
Package operator is ignoring hidden "dot" files when loading and building package images.
So when consuming a PKO-CLI-build package image, all dot files will be already stripped.

But when importing a package image that has been build with docker/podman and still contains dot-files, we are loading them into the ObjectDeployment.

This commit strips all dot files/paths when importing image contents.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
