### PR TITLE
Fix CLI validation not using default validators

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -89,6 +89,7 @@ func (v *Validate) ValidatePackage(ctx context.Context, opts ...ValidatePackageO
 		}
 	}
 
+	extraOpts = append(extraOpts, packageloader.WithDefaults)
 	if _, err := packageloader.New(v.scheme, extraOpts...).FromFiles(ctx, filemap); err != nil {
 		return fmt.Errorf("loading package from files: %w", err)
 	}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Default validators are not executed when the CLI validation command is run.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
