### PR TITLE
Hotfix 2nd kubectl-package update empties lockfile

### DIFF
--- a/cmd/kubectl-package/updatecmd/update.go
+++ b/cmd/kubectl-package/updatecmd/update.go
@@ -14,7 +14,9 @@ import (
 )
 
 type Updater interface {
-	GenerateLockData(ctx context.Context, srcPath string, opts ...internalcmd.GenerateLockDataOption) ([]byte, error)
+	GenerateLockData(ctx context.Context, srcPath string, opts ...internalcmd.GenerateLockDataOption) (
+		data []byte, unchanged bool, err error,
+	)
 }
 
 func NewCmd(updater Updater) *cobra.Command {
@@ -42,9 +44,14 @@ func NewCmd(updater Updater) *cobra.Command {
 
 		srcPath := args[0]
 
-		data, err := updater.GenerateLockData(cmd.Context(), srcPath, internalcmd.WithInsecure(opts.Insecure))
+		data, unchanged, err := updater.GenerateLockData(
+			cmd.Context(), srcPath, internalcmd.WithInsecure(opts.Insecure))
 		if err != nil {
 			return err
+		}
+		if unchanged {
+			// Nothing to do.
+			return nil
 		}
 
 		lockFilePath := filepath.Join(srcPath, packages.PackageManifestLockFile)

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -129,10 +129,15 @@ func TestUpdate(t *testing.T) {
 				WithDigestResolver{Resolver: mResolver},
 			)
 
-			data, err := update.GenerateLockData(context.Background(), "src")
+			data, unchanged, err := update.GenerateLockData(context.Background(), "src")
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.Expected, string(data))
+			if len(tc.Expected) == 0 {
+				assert.True(t, unchanged)
+			} else {
+				assert.False(t, unchanged)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Summary
Running kubectl-package update on an empty lockfile will clear the content of the lockfile making package validation for subsequent calls fail.

### Change Type
 Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
