### PR TITLE
Prepares PKO for rollback CLI commands

### DIFF
--- a/apis/manifests/v1alpha1/packagemanifest_types.go
+++ b/apis/manifests/v1alpha1/packagemanifest_types.go
@@ -23,6 +23,10 @@ const (
 const (
 	// PackageLabel contains the name of the Package from the PackageManifest.
 	PackageLabel = "package-operator.run/package"
+	// PackageSourceImageAnnotation references the package container image originating this object.
+	PackageSourceImageAnnotation = "package-operator.run/package-source-image"
+	// PackageConfigAnnotation contains the configuration for this object.
+	PackageConfigAnnotation = "package-operator.run/package-config"
 	// PackageInstanceLabel contains the name of the Package instance.
 	PackageInstanceLabel = "package-operator.run/instance"
 )

--- a/internal/controllers/controllers.go
+++ b/internal/controllers/controllers.go
@@ -23,6 +23,8 @@ const (
 	DynamicCacheLabel = "package-operator.run/cache"
 	// Common finalizer to free allocated caches when objects are deleted.
 	CachedFinalizer = "package-operator.run/cached"
+	// Records cause of change for history keeping.
+	ChangeCauseAnnotation = "kubernetes.io/change-cause"
 	// Causes PKO to skip ownership checks, used during self-bootstrap.
 	ForceAdoptionEnvironmentVariable = "PKO_FORCE_ADOPTION"
 )

--- a/internal/controllers/objectdeployments/new_revision_reconciler.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler.go
@@ -99,10 +99,16 @@ func (r *newRevisionReconciler) newObjectSetFromDeployment(
 	)
 	newObjectSet.SetPreviousRevisions(prevObjectSets)
 
+	if newObjectSetClientObj.GetLabels() == nil {
+		newObjectSetClientObj.SetLabels(map[string]string{})
+	}
+	newObjectSetClientObj.GetLabels()[ObjectSetObjectDeploymentLabel] = objectDeployment.ClientObject().GetName()
+
 	if newObjectSetClientObj.GetAnnotations() == nil {
 		newObjectSetClientObj.SetAnnotations(map[string]string{})
 	}
 	newObjectSetClientObj.GetAnnotations()[ObjectSetHashAnnotation] = objectDeployment.GetStatusTemplateHash()
+
 	if err := controllerutil.SetControllerReference(
 		deploymentClientObj, newObjectSetClientObj, r.scheme); err != nil {
 		return nil, err

--- a/internal/controllers/objectdeployments/objectdeployment_controller.go
+++ b/internal/controllers/objectdeployments/objectdeployment_controller.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	ObjectSetHashAnnotation = "package-operator.run/hash"
+	// Used to filter ObjectSets by their owning ObjectDeployment.
+	ObjectSetObjectDeploymentLabel = "package-operator.run/object-deployment"
 )
 
 type reconciler interface {


### PR DESCRIPTION
### Summary
- Add a object-deployment label to ObjectSets to query deployment childs
- Add change cause annotation taken from kube Deployments
- Add source-image and config annotations to ObjectDeployments and ObjectSets to refer back to the originating Package

### Change Type
New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
