### PR TITLE
fix: kubectl package update prints message when no update is needed

### DIFF
--- a/integration/kubectl-package/fixtures_test.go
+++ b/integration/kubectl-package/fixtures_test.go
@@ -1,7 +1,16 @@
 package kubectlpackage
 
 import (
+	"os"
 	"path/filepath"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+
+	. "github.com/onsi/gomega"
 )
 
 func sourcePathFixture(name string) string {
@@ -20,4 +29,96 @@ func sourcePathFixture(name string) string {
 		"invalid_missing_phase_annotation": filepath.Join(invalidPackages, "missing_phase_annotation"),
 		"invalid_missing_resource_gvk":     filepath.Join(invalidPackages, "missing_resource_gvk"),
 	}[name]
+}
+
+func generatePackage(dir string, opts ...generatePackageOption) {
+	var cfg generatePackageConfig
+
+	cfg.Option(opts...)
+
+	ExpectWithOffset(1, os.MkdirAll(dir, 0o755)).To(Succeed())
+
+	man := manv1alpha1.PackageManifest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "manifests.package-operator.run/v1alpha1",
+			Kind:       "PackageManifest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-package",
+		},
+		Spec: manv1alpha1.PackageManifestSpec{
+			Phases: []manv1alpha1.PackageManifestPhase{
+				{
+					Name: "test",
+				},
+			},
+			Scopes: []manv1alpha1.PackageManifestScope{
+				manv1alpha1.PackageManifestScopeCluster,
+			},
+			AvailabilityProbes: []corev1alpha1.ObjectSetProbe{
+				{
+					Probes: []corev1alpha1.Probe{
+						{
+							Condition: &corev1alpha1.ProbeConditionSpec{
+								Type:   "Available",
+								Status: "True",
+							},
+							FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+								FieldA: ".status.updatedReplicas",
+								FieldB: ".status.repicas",
+							},
+						},
+					},
+					Selector: corev1alpha1.ProbeSelector{
+						Kind: &corev1alpha1.PackageProbeKindSpec{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+					},
+				},
+			},
+			Images: cfg.Images,
+		},
+	}
+
+	manData, err := yaml.Marshal(man)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	ExpectWithOffset(1, os.WriteFile(filepath.Join(dir, "manifest.yaml"), manData, 0o644)).To(Succeed())
+
+	if cfg.LockData != nil {
+		lockData, err := yaml.Marshal(cfg.LockData)
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		ExpectWithOffset(1, os.WriteFile(filepath.Join(dir, "manifest.lock.yaml"), lockData, 0o644)).To(Succeed())
+	}
+}
+
+type generatePackageConfig struct {
+	Images   []manv1alpha1.PackageManifestImage
+	LockData *manv1alpha1.PackageManifestLock
+}
+
+func (c *generatePackageConfig) Option(opts ...generatePackageOption) {
+	for _, opt := range opts {
+		opt.ConfigureGeneratePackage(c)
+	}
+}
+
+type generatePackageOption interface {
+	ConfigureGeneratePackage(*generatePackageConfig)
+}
+
+type withImages []manv1alpha1.PackageManifestImage
+
+func (w withImages) ConfigureGeneratePackage(c *generatePackageConfig) {
+	c.Images = append(c.Images, w...)
+}
+
+type withLockData struct {
+	LockData *manv1alpha1.PackageManifestLock
+}
+
+func (w withLockData) ConfigureGeneratePackage(c *generatePackageConfig) {
+	c.LockData = w.LockData
 }

--- a/integration/kubectl-package/helpers_test.go
+++ b/integration/kubectl-package/helpers_test.go
@@ -50,7 +50,10 @@ func testSubCommand(subcommand string) func(tc subCommandTestCase) {
 	}
 }
 
-const registryPlaceholder = "TEST_REGISTRY"
+const (
+	registryPlaceholder = "TEST_REGISTRY"
+	TempDirPlaceholder  = "TEMP_DIR"
+)
 
 func substitutePlaceholders(args ...string) []string {
 	res := make([]string, 0, len(args))
@@ -60,6 +63,10 @@ func substitutePlaceholders(args ...string) []string {
 			sfx := strings.TrimPrefix(arg, registryPlaceholder)
 
 			arg = _registryDomain + sfx
+		} else if strings.HasPrefix(arg, TempDirPlaceholder) {
+			sfx := strings.TrimPrefix(arg, TempDirPlaceholder)
+
+			arg = _tempDir + sfx
 		}
 
 		res = append(res, arg)

--- a/integration/kubectl-package/update_test.go
+++ b/integration/kubectl-package/update_test.go
@@ -3,6 +3,8 @@
 package kubectlpackage
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
@@ -19,10 +21,37 @@ var _ = DescribeTable("update subcommand",
 			ExpectedExitCode: 1,
 		},
 	),
-	// TODO: Add test registry
-	// When given a valid source path which requires update, but cannot be written to should fail
-	// TODO: Add test registry
-	// When given a valid source path and lock file with unresolvable lock images should fail
-	// TODO: Add test registry
-	// When given a valid source path and no updates to lock file are required should succeed with no action
+	Entry("given a valid package",
+		subCommandTestCase{
+			Args: []string{
+				"--insecure",
+				filepath.Join(TempDirPlaceholder, "valid_package"),
+			},
+			ExpectedExitCode: 0,
+		},
+	),
+	Entry("given a valid package with a valid lock file",
+		subCommandTestCase{
+			Args: []string{
+				"--insecure",
+				filepath.Join(TempDirPlaceholder, "valid_package_valid_lockfile"),
+			},
+			ExpectedExitCode: 0,
+			ExpectedOutput: []string{
+				"Package is already up-to-date",
+			},
+		},
+	),
+	Entry("given a valid package with lock file containing unresolvable images",
+		subCommandTestCase{
+			Args: []string{
+				"--insecure",
+				filepath.Join(TempDirPlaceholder, "valid_package_invalid_lockfile_unresolvable_images"),
+			},
+			ExpectedExitCode: 1,
+			ExpectedErrorOutput: []string{
+				"resolving image digest",
+			},
+		},
+	),
 )


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Adds clarity to `kubectl package update` when no changes are required.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
