### PR TITLE
Remove package-operator package namespace override.

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1371,11 +1371,6 @@ func (Generate) PackageOperatorPackage() error {
 		return err
 	}
 
-	packageNamespaceOverride := os.Getenv("PKO_PACKAGE_NAMESPACE_OVERRIDE")
-	if len(packageNamespaceOverride) > 0 {
-		logger.Info("replacing default package-operator-system namespace", "new ns", packageNamespaceOverride)
-		manifestYaml = bytes.ReplaceAll(manifestYaml, []byte("package-operator-system"), []byte(packageNamespaceOverride))
-	}
 	if err := os.WriteFile(manifestFile, manifestYaml, os.ModePerm); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary
Remove namespace override in magefile.go

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
