### PR TITLE
[AUTH-388] config/packages/p/namespace.yaml: set pod security admission labels

### DIFF
--- a/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/package-operator.Namespace.yaml
+++ b/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/package-operator.Namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   annotations:
     package-operator.run/phase: namespace
   name: package-operator-system
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/packages/package-operator/.test-fixtures/no-config/package-operator.Namespace.yaml
+++ b/config/packages/package-operator/.test-fixtures/no-config/package-operator.Namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   annotations:
     package-operator.run/phase: namespace
   name: package-operator-system
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/packages/package-operator/.test-fixtures/openshift-with-proxy/package-operator.Namespace.yaml
+++ b/config/packages/package-operator/.test-fixtures/openshift-with-proxy/package-operator.Namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   annotations:
     package-operator.run/phase: namespace
   name: package-operator-system
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/packages/package-operator/package-operator.Namespace.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator.Namespace.yaml.gotmpl
@@ -4,3 +4,7 @@ metadata:
   annotations:
     package-operator.run/phase: namespace
   name: {{ .config.namespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
