### PR TITLE
[MTSRE-1300] Fix data race when Packages are loaded in parallel

### DIFF
--- a/internal/packages/packagecontent/content.go
+++ b/internal/packages/packagecontent/content.go
@@ -17,3 +17,14 @@ type (
 		Objects             map[string][]unstructured.Unstructured
 	}
 )
+
+// Returns a deep copy of the files map.
+func (f Files) DeepCopy() Files {
+	newF := Files{}
+	for k, v := range f {
+		newV := make([]byte, len(v))
+		copy(newV, v)
+		newF[k] = newV
+	}
+	return newF
+}

--- a/internal/packages/packagecontent/content_test.go
+++ b/internal/packages/packagecontent/content_test.go
@@ -1,0 +1,18 @@
+package packagecontent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFiles_DeepCopy(t *testing.T) {
+	f := Files{
+		"test": []byte("xxx"),
+	}
+
+	newF := f.DeepCopy()
+	assert.NotSame(t, f, newF)                 // new map
+	assert.NotSame(t, f["test"], newF["test"]) // new slice
+	assert.Equal(t, f, newF)                   // equal content
+}

--- a/internal/packages/packageimport/registry.go
+++ b/internal/packages/packageimport/registry.go
@@ -91,7 +91,11 @@ func (r *Registry) handleResponse(image string, res response) {
 	defer r.inFlightLock.Unlock()
 
 	for _, recv := range r.inFlight[image] {
-		recv <- res
+		recv <- response{
+			// DeepCopy to ensure clients can work concurrently on the returned files map.
+			Files: res.Files.DeepCopy(),
+			Err:   res.Err,
+		}
 	}
 
 	delete(r.inFlight, image)


### PR DESCRIPTION
### Summary
Loading the same package image for multiple packages in parallel is de-duplicated, but the resulting data structure is afterwards manipulated by multiple go routines in parallel.

This fix is always returning a DeepCopy of the File map to prevent this data race.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
