### PR TITLE
Object patch/adoption support via collision protection setting

### DIFF
--- a/apis/core/v1alpha1/commonobjectset_types.go
+++ b/apis/core/v1alpha1/commonobjectset_types.go
@@ -64,6 +64,9 @@ type ObjectSetObject struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +example={apiVersion: apps/v1, kind: Deployment, metadata: {name: example-deployment}}
 	Object unstructured.Unstructured `json:"object"`
+	// Collision protection prevents Package Operator from working on objects already under management by a different operator.
+	// +kubebuilder:default=Prevent
+	CollisionProtection CollisionProtection `json:"collisionProtection,omitempty"`
 	// Maps conditions from this object into the Package Operator APIs.
 	ConditionMappings []ConditionMapping `json:"conditionMappings,omitempty"`
 }
@@ -73,6 +76,18 @@ func (o ObjectSetObject) String() string {
 
 	return fmt.Sprintf("object %s/%s kind:%s", obj.GetNamespace(), obj.GetName(), obj.GetKind())
 }
+
+type CollisionProtection string
+
+const (
+	// Prevent owner collisions entirely by only allowing Package Operator to work with objects itself has created.
+	CollisionProtectionPrevent CollisionProtection = "Prevent"
+	// Allow Package Operator to patch and override objects already present if they are not owned by another controller.
+	CollisionProtectionIfNoController CollisionProtection = "IfNoController"
+	// Allow Package Operator to patch and override objects already present and owned by other controllers.
+	// Be careful! This setting may cause multiple controllers to fight over a resource, causing load on the API server and etcd.
+	CollisionProtectionNone CollisionProtection = "None"
+)
 
 // ObjectSet Condition Types.
 const (

--- a/apis/manifests/v1alpha1/packagemanifest_types.go
+++ b/apis/manifests/v1alpha1/packagemanifest_types.go
@@ -18,6 +18,8 @@ const (
 	// that the referenced object should only be observed during a phase
 	// rather than reconciled.
 	PackageExternalObjectAnnotation = "package-operator.run/external"
+	// Collision protection prevents Package Operator from working on objects already under management by a different operator.
+	PackageCollisionProtectionAnnotation = "package-operator.run/collision-protection"
 )
 
 const (

--- a/config/crds/package-operator.run_clusterobjectdeployments.yaml
+++ b/config/crds/package-operator.run_clusterobjectdeployments.yaml
@@ -269,6 +269,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -305,6 +311,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.

--- a/config/crds/package-operator.run_clusterobjectsetphases.yaml
+++ b/config/crds/package-operator.run_clusterobjectsetphases.yaml
@@ -164,6 +164,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -195,6 +201,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -194,6 +194,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -229,6 +235,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.

--- a/config/crds/package-operator.run_clusterobjectslices.yaml
+++ b/config/crds/package-operator.run_clusterobjectslices.yaml
@@ -42,6 +42,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.

--- a/config/crds/package-operator.run_objectdeployments.yaml
+++ b/config/crds/package-operator.run_objectdeployments.yaml
@@ -267,6 +267,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -303,6 +309,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.

--- a/config/crds/package-operator.run_objectsetphases.yaml
+++ b/config/crds/package-operator.run_objectsetphases.yaml
@@ -162,6 +162,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -193,6 +199,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -193,6 +193,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -228,6 +234,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.

--- a/config/crds/package-operator.run_objectslices.yaml
+++ b/config/crds/package-operator.run_objectslices.yaml
@@ -42,6 +42,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.

--- a/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
@@ -269,6 +269,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -305,6 +311,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.

--- a/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
@@ -164,6 +164,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -195,6 +201,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -194,6 +194,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -229,6 +235,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.

--- a/config/static-deployment/1-package-operator.run_clusterobjectslices.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectslices.yaml
@@ -42,6 +42,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.

--- a/config/static-deployment/1-package-operator.run_objectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_objectdeployments.yaml
@@ -267,6 +267,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -303,6 +309,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.

--- a/config/static-deployment/1-package-operator.run_objectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsetphases.yaml
@@ -162,6 +162,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -193,6 +199,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -193,6 +193,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -228,6 +234,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.

--- a/config/static-deployment/1-package-operator.run_objectslices.yaml
+++ b/config/static-deployment/1-package-operator.run_objectslices.yaml
@@ -42,6 +42,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,7 +53,8 @@ spec:
       phases:
       - class: ipsum
         externalObjects:
-        - conditionMappings:
+        - collisionProtection: Prevent
+          conditionMappings:
           - destinationType: consetetur
             sourceType: amet
           object:
@@ -63,7 +64,8 @@ spec:
               name: example-deployment
         name: lorem
         objects:
-        - conditionMappings:
+        - collisionProtection: Prevent
+          conditionMappings:
           - destinationType: sit
             sourceType: dolor
           object:
@@ -126,7 +128,8 @@ spec:
   phases:
   - class: sed
     externalObjects:
-    - conditionMappings:
+    - collisionProtection: Prevent
+      conditionMappings:
       - destinationType: tempor
         sourceType: eirmod
       object:
@@ -136,7 +139,8 @@ spec:
           name: example-deployment
     name: elitr
     objects:
-    - conditionMappings:
+    - collisionProtection: Prevent
+      conditionMappings:
       - destinationType: nonumy
         sourceType: diam
       object:
@@ -192,7 +196,8 @@ spec:
         matchLabels:
           app.kubernetes.io/name: example-operator
   externalObjects:
-  - conditionMappings:
+  - collisionProtection: Prevent
+    conditionMappings:
     - destinationType: amet
       sourceType: sit
     object:
@@ -201,7 +206,8 @@ spec:
       metadata:
         name: example-deployment
   objects:
-  - conditionMappings:
+  - collisionProtection: Prevent
+    conditionMappings:
     - destinationType: dolor
       sourceType: ipsum
     object:
@@ -248,7 +254,8 @@ kind: ClusterObjectSlice
 metadata:
   name: example
 objects:
-- conditionMappings:
+- collisionProtection: Prevent
+  conditionMappings:
   - destinationType: nonumy
     sourceType: diam
   object:
@@ -371,7 +378,8 @@ spec:
       phases:
       - class: elitr
         externalObjects:
-        - conditionMappings:
+        - collisionProtection: Prevent
+          conditionMappings:
           - destinationType: eirmod
             sourceType: nonumy
           object:
@@ -381,7 +389,8 @@ spec:
               name: example-deployment
         name: sadipscing
         objects:
-        - conditionMappings:
+        - collisionProtection: Prevent
+          conditionMappings:
           - destinationType: diam
             sourceType: sed
           object:
@@ -445,7 +454,8 @@ spec:
   phases:
   - class: ipsum
     externalObjects:
-    - conditionMappings:
+    - collisionProtection: Prevent
+      conditionMappings:
       - destinationType: consetetur
         sourceType: amet
       object:
@@ -455,7 +465,8 @@ spec:
           name: example-deployment
     name: lorem
     objects:
-    - conditionMappings:
+    - collisionProtection: Prevent
+      conditionMappings:
       - destinationType: sit
         sourceType: dolor
       object:
@@ -512,7 +523,8 @@ spec:
         matchLabels:
           app.kubernetes.io/name: example-operator
   externalObjects:
-  - conditionMappings:
+  - collisionProtection: Prevent
+    conditionMappings:
     - destinationType: nonumy
       sourceType: diam
     object:
@@ -521,7 +533,8 @@ spec:
       metadata:
         name: example-deployment
   objects:
-  - conditionMappings:
+  - collisionProtection: Prevent
+    conditionMappings:
     - destinationType: sed
       sourceType: elitr
     object:
@@ -569,7 +582,8 @@ metadata:
   name: example
   namespace: default
 objects:
-- conditionMappings:
+- collisionProtection: Prevent
+  conditionMappings:
   - destinationType: sit
     sourceType: dolor
   object:
@@ -831,6 +845,7 @@ An object that is part of the phase of an ObjectSet.
 | Field | Description |
 | ----- | ----------- |
 | `object` <b>required</b><br>unstructured.Unstructured |  |
+| `collisionProtection` <br><a href="#collisionprotection">CollisionProtection</a> | Collision protection prevents Package Operator from working on objects already under management by a different operator. |
 | `conditionMappings` <br><a href="#conditionmapping">[]ConditionMapping</a> | Maps conditions from this object into the Package Operator APIs. |
 
 

--- a/install.yaml
+++ b/install.yaml
@@ -273,6 +273,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -309,6 +315,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -626,6 +638,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -657,6 +675,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -1009,6 +1033,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -1044,6 +1074,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -1278,6 +1314,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.
@@ -1896,6 +1937,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -1932,6 +1979,12 @@ spec:
                                 description: An object that is part of the phase of
                                   an ObjectSet.
                                 properties:
+                                  collisionProtection:
+                                    default: Prevent
+                                    description: Collision protection prevents Package
+                                      Operator from working on objects already under
+                                      management by a different operator.
+                                    type: string
                                   conditionMappings:
                                     description: Maps conditions from this object
                                       into the Package Operator APIs.
@@ -2246,6 +2299,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -2277,6 +2336,12 @@ spec:
                 items:
                   description: An object that is part of the phase of an ObjectSet.
                   properties:
+                    collisionProtection:
+                      default: Prevent
+                      description: Collision protection prevents Package Operator
+                        from working on objects already under management by a different
+                        operator.
+                      type: string
                     conditionMappings:
                       description: Maps conditions from this object into the Package
                         Operator APIs.
@@ -2627,6 +2692,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -2662,6 +2733,12 @@ spec:
                       items:
                         description: An object that is part of the phase of an ObjectSet.
                         properties:
+                          collisionProtection:
+                            default: Prevent
+                            description: Collision protection prevents Package Operator
+                              from working on objects already under management by
+                              a different operator.
+                            type: string
                           conditionMappings:
                             description: Maps conditions from this object into the
                               Package Operator APIs.
@@ -2896,6 +2973,11 @@ spec:
             items:
               description: An object that is part of the phase of an ObjectSet.
               properties:
+                collisionProtection:
+                  default: Prevent
+                  description: Collision protection prevents Package Operator from
+                    working on objects already under management by a different operator.
+                  type: string
                 conditionMappings:
                   description: Maps conditions from this object into the Package Operator
                     APIs.

--- a/integration/package-operator/objectdeployment_test.go
+++ b/integration/package-operator/objectdeployment_test.go
@@ -104,7 +104,7 @@ func TestObjectDeployment_availability_and_hash_collision(t *testing.T) {
 	// Pre-Creating a ObjectSet that should conflict with Generation 2.
 	existingConflictObjectSet := &corev1alpha1.ObjectSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-objectdeployment-6c95888dd8",
+			Name:      "test-objectdeployment-995cbf7d6",
 			Namespace: "default",
 		},
 		Spec: corev1alpha1.ObjectSetSpec{

--- a/internal/controllers/mocks_test.go
+++ b/internal/controllers/mocks_test.go
@@ -71,8 +71,9 @@ type adoptionCheckerMock struct {
 
 func (m *adoptionCheckerMock) Check(
 	ctx context.Context, owner PhaseObjectOwner, obj client.Object, previous []PreviousObjectSet,
+	collisionProtection corev1alpha1.CollisionProtection,
 ) (needsAdoption bool, err error) {
-	args := m.Called(ctx, owner, obj, previous)
+	args := m.Called(ctx, owner, obj, previous, collisionProtection)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -38,6 +38,7 @@ type ownerStrategy interface {
 	ReleaseController(obj metav1.Object)
 	RemoveOwner(owner, obj metav1.Object)
 	SetControllerReference(owner, obj metav1.Object) error
+	HasController(obj metav1.Object) bool
 	OwnerPatch(owner metav1.Object) ([]byte, error)
 	EnqueueRequestForOwner(
 		ownerType client.Object, isController bool,

--- a/internal/ownerhandling/annotation.go
+++ b/internal/ownerhandling/annotation.go
@@ -35,6 +35,20 @@ func NewAnnotation(scheme *runtime.Scheme) *OwnerStrategyAnnotation {
 	}
 }
 
+func (s *OwnerStrategyAnnotation) HasController(obj metav1.Object) bool {
+	for _, ref := range s.getOwnerReferences(obj) {
+		if ref.isController() {
+			return true
+		}
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *OwnerStrategyAnnotation) OwnerPatch(owner metav1.Object) ([]byte, error) {
 	annotations := owner.GetAnnotations()
 	if annotations == nil {

--- a/internal/ownerhandling/common.go
+++ b/internal/ownerhandling/common.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ownerStrategy interface {
+	HasController(obj metav1.Object) bool
 	IsOwner(owner, obj metav1.Object) bool
 	IsController(owner, obj metav1.Object) bool
 	ReleaseController(obj metav1.Object)

--- a/internal/ownerhandling/native.go
+++ b/internal/ownerhandling/native.go
@@ -26,6 +26,15 @@ func NewNative(scheme *runtime.Scheme) *OwnerStrategyNative {
 	}
 }
 
+func (s *OwnerStrategyNative) HasController(obj metav1.Object) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *OwnerStrategyNative) OwnerPatch(owner metav1.Object) ([]byte, error) {
 	patchMetadata := map[string]interface{}{
 		"metadata": map[string]interface{}{

--- a/internal/packages/packagecontent/totemplate.go
+++ b/internal/packages/packagecontent/totemplate.go
@@ -49,10 +49,12 @@ func (c phaseCollector) AddObjects(objs ...unstructured.Unstructured) {
 	for i, object := range objs {
 		annotations := object.GetAnnotations()
 		phaseAnnotation := annotations[manifestsv1alpha1.PackagePhaseAnnotation]
+		collisionProtectionAnnotation := annotations[manifestsv1alpha1.PackageCollisionProtectionAnnotation]
 		isExternalObject := annotations[manifestsv1alpha1.PackageExternalObjectAnnotation] == "True"
 		delete(annotations, manifestsv1alpha1.PackagePhaseAnnotation)
 		delete(annotations, manifestsv1alpha1.PackageConditionMapAnnotation)
 		delete(annotations, manifestsv1alpha1.PackageExternalObjectAnnotation)
+		delete(annotations, manifestsv1alpha1.PackageCollisionProtectionAnnotation)
 		if len(annotations) == 0 {
 			// This is important!
 			// When submitted to the API server empty maps will be dropped.
@@ -70,8 +72,9 @@ func (c phaseCollector) AddObjects(objs ...unstructured.Unstructured) {
 		object.SetAnnotations(annotations)
 
 		objSetObj := corev1alpha1.ObjectSetObject{
-			Object:            object,
-			ConditionMappings: conditionMapping,
+			Object:              object,
+			ConditionMappings:   conditionMapping,
+			CollisionProtection: corev1alpha1.CollisionProtection(collisionProtectionAnnotation),
 		}
 
 		if isExternalObject {

--- a/internal/packages/packagedeploy/deployment_reconciler_test.go
+++ b/internal/packages/packagedeploy/deployment_reconciler_test.go
@@ -135,7 +135,7 @@ func Test_DeploymentReconciler_Reconcile(t *testing.T) {
 	assert.Equal(t, []corev1alpha1.ObjectSetTemplatePhase{
 		{
 			Name:   "test",
-			Slices: []string{"test-depl-85dfb9bbb4"},
+			Slices: []string{"test-depl-95565fb5c"},
 		},
 	}, updatedDeployment.Spec.Template.Spec.Phases)
 }

--- a/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
+++ b/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
@@ -16,6 +16,11 @@ func (m *OwnerStrategyMock) OwnerPatch(obj metav1.Object) ([]byte, error) {
 	return args.Get(0).([]byte), args.Error(1)
 }
 
+func (m *OwnerStrategyMock) HasController(obj metav1.Object) bool {
+	args := m.Called(obj)
+	return args.Bool(0)
+}
+
 func (m *OwnerStrategyMock) IsController(owner, obj metav1.Object) bool {
 	args := m.Called(owner, obj)
 	return args.Bool(0)


### PR DESCRIPTION
### Summary
Allows users to specify the collision protection strategy that an object should adhere to.
Setting collision protection for an object to `IfNoController` or `None` allows PKO to adopt objects already present on a cluster.

When opting out of strict collision protection, the user has to make sure multiple controllers are not starting to fight over a resource.

### Change Type
New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
