### PR TITLE
[MTSRE-1277] Fix garbage collection of archived revisions

### DIFF
--- a/internal/controllers/objectdeployments/archive_reconciler.go
+++ b/internal/controllers/objectdeployments/archive_reconciler.go
@@ -225,9 +225,13 @@ func (a *archiveReconciler) garbageCollectRevisions(ctx context.Context, previou
 	if deploymentRevisionLimit != nil {
 		revisionLimit = *deploymentRevisionLimit
 	}
-	numToDelete := len(previousObjectSets) - (int(revisionLimit))
-	for numToDelete > 0 {
-		if err := a.client.Delete(ctx, previousObjectSets[0].ClientObject()); err != nil {
+	numToDelete := len(previousObjectSets) - int(revisionLimit)
+	for _, previousObjectSet := range previousObjectSets {
+		if numToDelete <= 0 {
+			break
+		}
+
+		if err := a.client.Delete(ctx, previousObjectSet.ClientObject()); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete objectset: %w", err)
 		}
 		numToDelete--

--- a/internal/controllers/objectdeployments/archive_reconciler.go
+++ b/internal/controllers/objectdeployments/archive_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Currently archived `objectsets` are not being garbage collected according to the `revisionHistoryLimit`. This PR fix this bug so when new revisions are created archived ones are deleted accordingly. `objectsets` are also configured to only store the same number of `previousRevisions` to avoid 'not found' errors when looking up previous revisoins which have been garbage collected. 

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
 Bug Fix 
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
