### PR TITLE
EXPERIMENTAL: Add support for OLMv0 bundle images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/api v0.0.0-20211122204231-b094ceff1955
+	github.com/operator-framework/api v0.17.6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1
 	github.com/pterm/pterm v0.12.62

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/openshift/addon-operator/apis v0.0.0-20220111092509-93ca25c9359f h1:w
 github.com/openshift/api v0.0.0-20211122204231-b094ceff1955 h1:ae+zsMFNxSIIDaRwrl0RvGaHt7kvtotEkhw8M1R7q44=
 github.com/openshift/api v0.0.0-20211122204231-b094ceff1955/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/operator-framework/api v0.17.6 h1:E6+vlvYUKafvoXYtCuHlDZrXX4vl8AT+r93OxNlzjpU=
+github.com/operator-framework/api v0.17.6/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/packages/packagecontent/content.go
+++ b/internal/packages/packagecontent/content.go
@@ -1,6 +1,9 @@
 package packagecontent
 
 import (
+	"io/fs"
+	"testing/fstest"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
@@ -27,4 +30,14 @@ func (f Files) DeepCopy() Files {
 		newF[k] = newV
 	}
 	return newF
+}
+
+func (f Files) ToFS() fs.FS {
+	fsMap := fstest.MapFS{}
+	for k, v := range f {
+		fsMap[k] = &fstest.MapFile{
+			Data: v,
+		}
+	}
+	return fsMap
 }

--- a/internal/packages/packagecontent/topackage.go
+++ b/internal/packages/packagecontent/topackage.go
@@ -52,25 +52,10 @@ func PackageFromFiles(ctx context.Context, scheme *runtime.Scheme, files Files) 
 			continue
 		}
 
-		// Trim empty starting and ending objects
-		objects := []unstructured.Unstructured{}
-
 		// Split for every included yaml document.
-		for i, yamlDocument := range bytes.Split(bytes.Trim(content, "---\n"), []byte("---\n")) {
-			obj := unstructured.Unstructured{}
-			if err = yaml.Unmarshal(yamlDocument, &obj); err != nil {
-				err = packages.NewInvalidError(packages.Violation{
-					Reason:   packages.ViolationReasonInvalidYAML,
-					Details:  err.Error(),
-					Location: &packages.ViolationLocation{Path: path, DocumentIndex: pointer.Int(i)},
-				})
-
-				return
-			}
-
-			if len(obj.Object) != 0 {
-				objects = append(objects, obj)
-			}
+		objects, err := UnstructuredObjectsFromBytes(path, content)
+		if err != nil {
+			return nil, err
 		}
 		if len(objects) != 0 {
 			pkg.Objects[path] = objects
@@ -88,4 +73,23 @@ func PackageFromFiles(ctx context.Context, scheme *runtime.Scheme, files Files) 
 	}
 
 	return
+}
+
+func UnstructuredObjectsFromBytes(path string, content []byte) (objects []unstructured.Unstructured, err error) {
+	// Split for every included yaml document.
+	for i, yamlDocument := range bytes.Split(bytes.Trim(content, "---\n"), []byte("---\n")) {
+		obj := unstructured.Unstructured{}
+		if err := yaml.Unmarshal(yamlDocument, &obj); err != nil {
+			return nil, packages.NewInvalidError(packages.Violation{
+				Reason:   packages.ViolationReasonInvalidYAML,
+				Details:  err.Error(),
+				Location: &packages.ViolationLocation{Path: path, DocumentIndex: pointer.Int(i)},
+			})
+		}
+
+		if len(obj.Object) != 0 {
+			objects = append(objects, obj)
+		}
+	}
+	return objects, nil
 }

--- a/internal/packages/packageimport/image.go
+++ b/internal/packages/packageimport/image.go
@@ -37,6 +37,19 @@ func Image(ctx context.Context, image v1.Image) (m packagecontent.Files, err err
 		}
 
 		tarPath := hdr.Name
+
+		// Keep OLMv0 bundle files
+		if strings.HasPrefix(tarPath, "manifests/") ||
+			strings.HasPrefix(tarPath, "metadata/") {
+			data, err := io.ReadAll(tarReader)
+			if err != nil {
+				return nil, fmt.Errorf("read file header from layer: %w", err)
+			}
+
+			files[tarPath] = data
+			continue
+		}
+
 		path, err := filepath.Rel(packages.ImageFilePrefixPath, tarPath)
 		if err != nil {
 			return nil, fmt.Errorf("package image contains files not under the dir %s: %w", packages.ImageFilePrefixPath, err)

--- a/internal/packages/packageloader/loader.go
+++ b/internal/packages/packageloader/loader.go
@@ -80,6 +80,10 @@ func (l Loader) FromFiles(ctx context.Context, files packagecontent.Files, opts 
 		}
 	}
 
+	if IsOLMBundle(ctx, files) {
+		return OLMBundleToPackageContent(ctx, files)
+	}
+
 	for _, t := range l.filesTransformers {
 		if err := t.TransformPackageFiles(ctx, files); err != nil {
 			return nil, fmt.Errorf("transform files: %w", err)

--- a/internal/packages/packageloader/olm.go
+++ b/internal/packages/packageloader/olm.go
@@ -1,0 +1,149 @@
+package packageloader
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+	"package-operator.run/package-operator/internal/packages"
+	"package-operator.run/package-operator/internal/packages/packagecontent"
+	"package-operator.run/package-operator/internal/rukpak/convert"
+)
+
+const (
+	olmManifestFolder = "manifests"
+	olmMetadataFolder = "metadata"
+)
+
+func IsOLMBundle(_ context.Context, files packagecontent.Files) bool {
+	var (
+		packageManifestFound bool
+		manifestsFolderFound bool
+		metadataFolderFound  bool
+	)
+	for fpath := range files {
+		if packages.IsManifestFile(fpath) {
+			packageManifestFound = true
+		}
+		if strings.HasPrefix(fpath, olmManifestFolder+"/") {
+			manifestsFolderFound = true
+		}
+		if strings.HasPrefix(fpath, olmMetadataFolder+"/") {
+			metadataFolderFound = true
+		}
+	}
+	return !packageManifestFound && manifestsFolderFound && metadataFolderFound
+}
+
+func OLMBundleToPackageContent(ctx context.Context, files packagecontent.Files) (*packagecontent.Package, error) {
+	// 1. Do OLM internal conversion
+	plainFS, err := convert.RegistryV1ToPlain(files.ToFS())
+	if err != nil {
+		return nil, fmt.Errorf("converting OLM bundle: %w", err)
+	}
+
+	const convertedManifestFile = "manifests/manifest.yaml"
+	bundleManifests, err := fs.ReadFile(plainFS, convertedManifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading converted manifests: %w", err)
+	}
+
+	objects, err := packagecontent.UnstructuredObjectsFromBytes(convertedManifestFile, bundleManifests)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range objects {
+		obj := &objects[i]
+		switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
+		case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"},
+			schema.GroupKind{Group: "", Kind: "Namespace"}:
+			setAnnotation(obj, manifestsv1alpha1.PackagePhaseAnnotation, "crds-namespace")
+		case schema.GroupKind{Group: "", Kind: "ServiceAccount"},
+			schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
+			schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"},
+			schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "Role"},
+			schema.GroupKind{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"}:
+			setAnnotation(obj, manifestsv1alpha1.PackagePhaseAnnotation, "rbac")
+		default:
+			setAnnotation(obj, manifestsv1alpha1.PackagePhaseAnnotation, "deploy")
+		}
+	}
+
+	pkg := &packagecontent.Package{
+		PackageManifest: &manifestsv1alpha1.PackageManifest{
+			Spec: manifestsv1alpha1.PackageManifestSpec{
+				Scopes: []manifestsv1alpha1.PackageManifestScope{
+					manifestsv1alpha1.PackageManifestScopeCluster,
+				},
+				Phases: []manifestsv1alpha1.PackageManifestPhase{
+					{Name: "crds-namespace"},
+					{Name: "rbac"},
+					{Name: "deploy"},
+				},
+				AvailabilityProbes: []corev1alpha1.ObjectSetProbe{
+					{
+						Selector: corev1alpha1.ProbeSelector{
+							Kind: &corev1alpha1.PackageProbeKindSpec{
+								Group: "apps",
+								Kind:  "Deployment",
+							},
+						},
+						Probes: []corev1alpha1.Probe{
+							{
+								Condition: &corev1alpha1.ProbeConditionSpec{
+									Type:   "Available",
+									Status: "True",
+								},
+							},
+							{
+								FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+									FieldA: ".status.updatedReplicas",
+									FieldB: ".status.replicas",
+								},
+							},
+						},
+					},
+					{
+						Selector: corev1alpha1.ProbeSelector{
+							Kind: &corev1alpha1.PackageProbeKindSpec{
+								Group: "apiextensions.k8s.io",
+								Kind:  "CustomResourceDefinition",
+							},
+						},
+						Probes: []corev1alpha1.Probe{
+							{
+								Condition: &corev1alpha1.ProbeConditionSpec{
+									Type:   "Established",
+									Status: "True",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Objects: map[string][]unstructured.Unstructured{
+			convertedManifestFile: objects,
+		},
+	}
+
+	// manifests/manifest.yaml
+
+	return pkg, nil
+}
+
+func setAnnotation(obj *unstructured.Unstructured, key, value string) {
+	a := obj.GetAnnotations()
+	if a == nil {
+		a = map[string]string{}
+	}
+	a[key] = value
+	obj.SetAnnotations(a)
+}

--- a/internal/packages/packageloader/olm_test.go
+++ b/internal/packages/packageloader/olm_test.go
@@ -1,0 +1,32 @@
+package packageloader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"package-operator.run/package-operator/internal/packages/packagecontent"
+)
+
+func TestIsOLMBundle(t *testing.T) {
+	files := packagecontent.Files{
+		"manifests/xxx": nil,
+		"metadata/xxx":  nil,
+	}
+	ctx := context.Background()
+	isOLM := IsOLMBundle(ctx, files)
+
+	assert.True(t, isOLM)
+}
+
+func TestIsOLMBundleNegative(t *testing.T) {
+	files := packagecontent.Files{
+		"manifests/xxx": nil,
+		"metadata/xxx":  nil,
+		"manifest.yaml": nil,
+	}
+	ctx := context.Background()
+	isOLM := IsOLMBundle(ctx, files)
+
+	assert.False(t, isOLM)
+}

--- a/internal/rukpak/convert/registryv1.go
+++ b/internal/rukpak/convert/registryv1.go
@@ -1,0 +1,440 @@
+package convert
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing/fstest"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apimachyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	registry "package-operator.run/package-operator/internal/rukpak/operator-registry"
+	"package-operator.run/package-operator/internal/rukpak/util"
+)
+
+type RegistryV1 struct {
+	PackageName string
+	CSV         v1alpha1.ClusterServiceVersion
+	CRDs        []apiextensionsv1.CustomResourceDefinition
+	Others      []unstructured.Unstructured
+}
+
+type Plain struct {
+	Objects []client.Object
+}
+
+func RegistryV1ToPlain(rv1 fs.FS) (fs.FS, error) {
+	reg := RegistryV1{}
+	fileData, err := fs.ReadFile(rv1, filepath.Join("metadata", "annotations.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	annotationsFile := registry.AnnotationsFile{}
+	if err := yaml.Unmarshal(fileData, &annotationsFile); err != nil {
+		return nil, err
+	}
+	reg.PackageName = annotationsFile.Annotations.PackageName
+
+	var objects []*unstructured.Unstructured
+	const manifestsDir = "manifests"
+
+	entries, err := fs.ReadDir(rv1, manifestsDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			return nil, fmt.Errorf("subdirectories are not allowed within the %q directory of the bundle image filesystem: found %q", manifestsDir, filepath.Join(manifestsDir, e.Name()))
+		}
+		fileData, err := fs.ReadFile(rv1, filepath.Join(manifestsDir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		dec := apimachyaml.NewYAMLOrJSONDecoder(bytes.NewReader(fileData), 1024)
+		for {
+			obj := unstructured.Unstructured{}
+			err := dec.Decode(&obj)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("read %q: %v", e.Name(), err)
+			}
+			objects = append(objects, &obj)
+		}
+	}
+
+	for _, obj := range objects {
+		obj := obj
+		switch obj.GetObjectKind().GroupVersionKind().Kind {
+		case "ClusterServiceVersion":
+			csv := v1alpha1.ClusterServiceVersion{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &csv); err != nil {
+				return nil, err
+			}
+			reg.CSV = csv
+		case "CustomResourceDefinition":
+			crd := apiextensionsv1.CustomResourceDefinition{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &crd); err != nil {
+				return nil, err
+			}
+			reg.CRDs = append(reg.CRDs, crd)
+		default:
+			reg.Others = append(reg.Others, *obj)
+		}
+	}
+
+	plain, err := Simple(reg)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest bytes.Buffer
+	for _, obj := range plain.Objects {
+		yamlData, err := yaml.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := fmt.Fprintf(&manifest, "---\n%s\n", string(yamlData)); err != nil {
+			return nil, err
+		}
+	}
+
+	now := time.Now()
+	plainFS := fstest.MapFS{
+		".": &fstest.MapFile{
+			Data:    nil,
+			Mode:    fs.ModeDir | 0o755,
+			ModTime: now,
+		},
+		"manifests": &fstest.MapFile{
+			Data:    nil,
+			Mode:    fs.ModeDir | 0o755,
+			ModTime: now,
+		},
+		"manifests/manifest.yaml": &fstest.MapFile{
+			Data:    manifest.Bytes(),
+			Mode:    0o644,
+			ModTime: now,
+		},
+	}
+
+	return plainFS, nil
+}
+
+func validateTargetNamespaces(supportedInstallModes sets.Set[string], installNamespace string, targetNamespaces []string) error {
+	set := sets.New[string](targetNamespaces...)
+	switch set.Len() {
+	case 0:
+		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
+			return nil
+		}
+	case 1:
+		if set.Has("") && supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
+			return nil
+		}
+		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeSingleNamespace)) {
+			return nil
+		}
+		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeOwnNamespace)) && targetNamespaces[0] == installNamespace {
+			return nil
+		}
+	default:
+		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeMultiNamespace)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("supported install modes %v do not support target namespaces %v", sets.List[string](supportedInstallModes), targetNamespaces)
+}
+
+func Simple(in RegistryV1) (*Plain, error) {
+	return Convert(in, "", nil)
+}
+
+func saNameOrDefault(saName string) string {
+	if saName == "" {
+		return "default"
+	}
+	return saName
+}
+
+func Convert(in RegistryV1, installNamespace string, targetNamespaces []string) (*Plain, error) {
+	if installNamespace == "" {
+		installNamespace = in.CSV.Annotations["operatorframework.io/suggested-namespace"]
+	}
+	if installNamespace == "" {
+		installNamespace = fmt.Sprintf("%s-system", in.PackageName)
+	}
+	supportedInstallModes := sets.New[string]()
+	for _, im := range in.CSV.Spec.InstallModes {
+		if im.Supported {
+			supportedInstallModes.Insert(string(im.Type))
+		}
+	}
+	if !supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
+		return nil, fmt.Errorf("AllNamespace install mode must be enabled")
+	}
+	if targetNamespaces == nil {
+		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
+			targetNamespaces = []string{""}
+		} else if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeOwnNamespace)) {
+			targetNamespaces = []string{installNamespace}
+		}
+	}
+
+	if err := validateTargetNamespaces(supportedInstallModes, installNamespace, targetNamespaces); err != nil {
+		return nil, err
+	}
+
+	if len(in.CSV.Spec.APIServiceDefinitions.Owned) > 0 {
+		return nil, fmt.Errorf("apiServiceDefintions are not supported")
+	}
+
+	// if len(in.CSV.Spec.WebhookDefinitions) > 0 {
+	// 	return nil, fmt.Errorf("webhookDefinitions are not supported")
+	// }
+
+	deployments := []appsv1.Deployment{}
+	serviceAccounts := map[string]corev1.ServiceAccount{}
+	for _, depSpec := range in.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		annotations := util.MergeMaps(in.CSV.Annotations, depSpec.Spec.Template.Annotations)
+		annotations["olm.targetNamespaces"] = strings.Join(targetNamespaces, ",")
+		deployments = append(deployments, appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+			},
+
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   installNamespace,
+				Name:        depSpec.Name,
+				Labels:      depSpec.Label,
+				Annotations: annotations,
+			},
+			Spec: depSpec.Spec,
+		})
+		saName := saNameOrDefault(depSpec.Spec.Template.Spec.ServiceAccountName)
+		serviceAccounts[saName] = newServiceAccount(installNamespace, saName)
+	}
+
+	// NOTES:
+	//   1. There's an extra Role for OperatorConditions: get/update/patch; resourceName=csv.name
+	//        - This is managed by the OperatorConditions controller here: https://github.com/operator-framework/operator-lifecycle-manager/blob/9ced412f3e263b8827680dc0ad3477327cd9a508/pkg/controller/operators/operatorcondition_controller.go#L106-L109
+	//   2. There's an extra RoleBinding for the above mentioned role.
+	//        - Every SA mentioned in the OperatorCondition.spec.serviceAccounts is a subject for this role binding: https://github.com/operator-framework/operator-lifecycle-manager/blob/9ced412f3e263b8827680dc0ad3477327cd9a508/pkg/controller/operators/operatorcondition_controller.go#L171-L177
+	//   3. strategySpec.permissions are _also_ given a clusterrole/clusterrole binding.
+	//  		- (for AllNamespaces mode only?)
+	//			- (where does the extra namespaces get/list/watch rule come from?)
+
+	roles := []rbacv1.Role{}
+	roleBindings := []rbacv1.RoleBinding{}
+	clusterRoles := []rbacv1.ClusterRole{}
+	clusterRoleBindings := []rbacv1.ClusterRoleBinding{}
+
+	permissions := in.CSV.Spec.InstallStrategy.StrategySpec.Permissions
+	clusterPermissions := in.CSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions
+	allPermissions := append(permissions, clusterPermissions...)
+
+	// Create all the service accounts
+	for _, permission := range allPermissions {
+		saName := saNameOrDefault(permission.ServiceAccountName)
+		if _, ok := serviceAccounts[saName]; !ok {
+			serviceAccounts[saName] = newServiceAccount(installNamespace, saName)
+		}
+	}
+
+	// If we're in AllNamespaces mode, promote the permissions to clusterPermissions
+	if len(targetNamespaces) == 1 && targetNamespaces[0] == "" {
+		for _, p := range permissions {
+			p.Rules = append(p.Rules, rbacv1.PolicyRule{
+				Verbs:     []string{"get", "list", "watch"},
+				APIGroups: []string{corev1.GroupName},
+				Resources: []string{"namespaces"},
+			})
+		}
+		clusterPermissions = append(clusterPermissions, permissions...)
+		permissions = nil
+	}
+
+	for _, permission := range permissions {
+		saName := saNameOrDefault(permission.ServiceAccountName)
+		name := generateName(fmt.Sprintf("%s-%s", in.CSV.Name, saName), []interface{}{in.CSV.Name, permission})
+		roles = append(roles, newRole(installNamespace, name, permission.Rules))
+		roleBindings = append(roleBindings, newRoleBinding(installNamespace, name, name, installNamespace, saName))
+	}
+	for _, permission := range clusterPermissions {
+		saName := saNameOrDefault(permission.ServiceAccountName)
+		name := generateName(fmt.Sprintf("%s-%s", in.CSV.Name, saName), []interface{}{in.CSV.GetName(), permission})
+		clusterRoles = append(clusterRoles, newClusterRole(name, permission.Rules))
+		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(name, name, installNamespace, saName))
+	}
+
+	ns := &corev1.Namespace{
+		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: installNamespace},
+	}
+	objs := []client.Object{ns}
+	for _, obj := range serviceAccounts {
+		obj := obj
+		if obj.GetName() != "default" {
+			objs = append(objs, &obj)
+		}
+	}
+	for _, obj := range roles {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	for _, obj := range roleBindings {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	for _, obj := range clusterRoles {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	for _, obj := range clusterRoleBindings {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	for _, obj := range in.CRDs {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	for _, obj := range in.Others {
+		obj := obj
+		// Default the namespace of other bundled objects to the installNamespace, like in OLMv0.
+		obj.SetNamespace(installNamespace)
+		objs = append(objs, &obj)
+	}
+	for _, obj := range deployments {
+		obj := obj
+		objs = append(objs, &obj)
+	}
+	return &Plain{Objects: objs}, nil
+}
+
+const maxNameLength = 63
+
+func generateName(base string, o interface{}) string {
+	hasher := fnv.New32a()
+
+	util.DeepHashObject(hasher, o)
+	hashStr := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+	if len(base)+len(hashStr) > maxNameLength {
+		base = base[:maxNameLength-len(hashStr)-1]
+	}
+
+	return fmt.Sprintf("%s-%s", base, hashStr)
+}
+
+func newServiceAccount(namespace, name string) corev1.ServiceAccount {
+	return corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func newRole(namespace, name string, rules []rbacv1.PolicyRule) rbacv1.Role {
+	return rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Role",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Rules: rules,
+	}
+}
+
+func newClusterRole(name string, rules []rbacv1.PolicyRule) rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: rules,
+	}
+}
+
+func newRoleBinding(namespace, name, roleName, saNamespace string, saNames ...string) rbacv1.RoleBinding {
+	subjects := make([]rbacv1.Subject, 0, len(saNames))
+	for _, saName := range saNames {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Namespace: saNamespace,
+			Name:      saName,
+		})
+	}
+	return rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}
+}
+
+func newClusterRoleBinding(name, roleName, saNamespace string, saNames ...string) rbacv1.ClusterRoleBinding {
+	subjects := make([]rbacv1.Subject, 0, len(saNames))
+	for _, saName := range saNames {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Namespace: saNamespace,
+			Name:      saName,
+		})
+	}
+	return rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+	}
+}

--- a/internal/rukpak/operator-registry/registry.go
+++ b/internal/rukpak/operator-registry/registry.go
@@ -1,0 +1,23 @@
+// Package registry contains the manually vendored type definitions from
+// the operator-framework/operator-registry repository.
+package registry
+
+// AnnotationsFile holds annotation information about a bundle.
+type AnnotationsFile struct {
+	// annotations is a list of annotations for a given bundle
+	Annotations Annotations `json:"annotations" yaml:"annotations"`
+}
+
+// Annotations is a list of annotations for a given bundle.
+type Annotations struct {
+	// PackageName is the name of the overall package, ala `etcd`.
+	PackageName string `json:"operators.operatorframework.io.bundle.package.v1" yaml:"operators.operatorframework.io.bundle.package.v1"`
+
+	// Channels are a comma separated list of the declared channels for the bundle, ala `stable` or `alpha`.
+	Channels string `json:"operators.operatorframework.io.bundle.channels.v1" yaml:"operators.operatorframework.io.bundle.channels.v1"`
+
+	// DefaultChannelName is, if specified, the name of the default channel for the package. The
+	// default channel will be installed if no other channel is explicitly given. If the package
+	// has a single channel, then that channel is implicitly the default.
+	DefaultChannelName string `json:"operators.operatorframework.io.bundle.channel.default.v1" yaml:"operators.operatorframework.io.bundle.channel.default.v1"`
+}

--- a/internal/rukpak/util/hash.go
+++ b/internal/rukpak/util/hash.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+// From https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/lib/kubernetes/pkg/util/hash/hash.go
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}
+
+func MergeMaps(maps ...map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}


### PR DESCRIPTION
### Summary
Adds native support for OLMv0 bundle images via the `ClusterPackage` API by utilizing the rukpak/OLMv1 manifest converter.

OLMv0 Bundle images can be installed just by referencing them in the `ClusterPackage` instead of a PKO package image:
```
apiVersion: package-operator.run/v1alpha1
kind: ClusterPackage
metadata:
  name: cert-manager
spec:
  image: quay.io/operatorhubio/cert-manager:v1.12.2
```

Known limitations:
- webhooks are not supported by the rukpak converter and are silently dropped in PKO
- more probes need to be defined
- automatic object assignment to PKO phases needs work

### Change Type
New Feature

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
