### PR TITLE
[MTSRE-1391] Allow force re-deployment of all packages

### DIFF
--- a/cmd/package-operator-manager/components/options_test.go
+++ b/cmd/package-operator-manager/components/options_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestProvideOptions(t *testing.T) {
-	opts := ProvideOptions()
+	opts, err := ProvideOptions()
+
+	assert.Nil(t, err)
 	assert.Equal(t, Options{
 		MetricsAddr: ":8080",
 		ProbeAddr:   ":8081",

--- a/cmd/package-operator-manager/components/package.go
+++ b/cmd/package-operator-manager/components/package.go
@@ -49,13 +49,14 @@ func ProvidePackageController(
 	mgr ctrl.Manager, log logr.Logger,
 	registry *packageimport.Registry,
 	recorder *metrics.Recorder,
+	opts Options,
 ) PackageController {
 	return PackageController{
 		packages.NewPackageController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("Package"),
 			mgr.GetScheme(),
-			registry, recorder,
+			registry, recorder, opts.PackageHashModifier,
 		),
 	}
 }
@@ -64,13 +65,14 @@ func ProvideClusterPackageController(
 	mgr ctrl.Manager, log logr.Logger,
 	registry *packageimport.Registry,
 	recorder *metrics.Recorder,
+	opts Options,
 ) ClusterPackageController {
 	return ClusterPackageController{
 		packages.NewClusterPackageController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("ClusterPackage"),
 			mgr.GetScheme(),
-			registry, recorder,
+			registry, recorder, opts.PackageHashModifier,
 		),
 	}
 }

--- a/config/packages/package-operator/manifest.yaml.tpl
+++ b/config/packages/package-operator/manifest.yaml.tpl
@@ -27,6 +27,12 @@ spec:
   config:
     openAPIV3Schema:
       properties:
+        packageHashModifier:
+          description: A value that is used when creating the package hash. 
+            This parameter can be used to force the redeployment of all packages by 
+            modifying their calculated hash value.
+          type: integer
+          format: int32
         registryHostOverrides:
           type: string
         namespace:

--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -37,6 +37,10 @@ spec:
         - name: PKO_REGISTRY_HOST_OVERRIDES
           value: {{ .config.registryHostOverrides }}
 {{- end}}
+{{- if hasKey .config "packageHashModifier" }}
+        - name: PKO_PACKAGE_HASH_MODIFIER
+          value: {{ .config.packageHashModifier | quote }}
+{{- end}}
         - name: PKO_NAMESPACE
           valueFrom:
             fieldRef:

--- a/internal/adapters/package.go
+++ b/internal/adapters/package.go
@@ -16,7 +16,7 @@ type GenericPackageAccessor interface {
 	UpdatePhase()
 	GetConditions() *[]metav1.Condition
 	GetImage() string
-	GetSpecHash() string
+	GetSpecHash(packageHashModifier *int32) string
 	GetUnpackedHash() string
 	SetUnpackedHash(hash string)
 	setStatusPhase(phase corev1alpha1.PackageStatusPhase)
@@ -79,8 +79,8 @@ func (a *GenericPackage) GetImage() string {
 	return a.Spec.Image
 }
 
-func (a *GenericPackage) GetSpecHash() string {
-	return utils.ComputeSHA256Hash(a.Spec, nil)
+func (a *GenericPackage) GetSpecHash(packageHashModifier *int32) string {
+	return utils.ComputeSHA256Hash(a.Spec, packageHashModifier)
 }
 
 func (a *GenericPackage) SetUnpackedHash(hash string) {
@@ -132,8 +132,8 @@ func (a *GenericClusterPackage) GetImage() string {
 	return a.Spec.Image
 }
 
-func (a *GenericClusterPackage) GetSpecHash() string {
-	return utils.ComputeSHA256Hash(a.Spec, nil)
+func (a *GenericClusterPackage) GetSpecHash(packageHashModifier *int32) string {
+	return utils.ComputeSHA256Hash(a.Spec, packageHashModifier)
 }
 
 func (a *GenericClusterPackage) SetStatusRevision(rev int64) {

--- a/internal/controllers/packages/package_controller.go
+++ b/internal/controllers/packages/package_controller.go
@@ -50,11 +50,12 @@ func NewPackageController(
 	scheme *runtime.Scheme,
 	imagePuller imagePuller,
 	metricsRecorder metricsRecorder,
+	packageHashModifier *int32,
 ) *GenericPackageController {
 	return newGenericPackageController(
 		adapters.NewGenericPackage, adapters.NewObjectDeployment,
 		c, log, scheme, imagePuller, packagedeploy.NewPackageDeployer(c, scheme),
-		metricsRecorder,
+		metricsRecorder, packageHashModifier,
 	)
 }
 
@@ -63,11 +64,12 @@ func NewClusterPackageController(
 	scheme *runtime.Scheme,
 	imagePuller imagePuller,
 	metricsRecorder metricsRecorder,
+	packageHashModifier *int32,
 ) *GenericPackageController {
 	return newGenericPackageController(
 		adapters.NewGenericClusterPackage, adapters.NewClusterObjectDeployment,
 		c, log, scheme, imagePuller, packagedeploy.NewClusterPackageDeployer(c, scheme),
-		metricsRecorder,
+		metricsRecorder, packageHashModifier,
 	)
 }
 
@@ -79,6 +81,7 @@ func newGenericPackageController(
 	imagePuller imagePuller,
 	packageDeployer packageDeployer,
 	metricsRecorder metricsRecorder,
+	packageHashModifier *int32,
 ) *GenericPackageController {
 	controller := &GenericPackageController{
 		newPackage:          newPackage,
@@ -88,7 +91,7 @@ func newGenericPackageController(
 		log:                 log,
 		scheme:              scheme,
 		unpackReconciler: newUnpackReconciler(
-			imagePuller, packageDeployer, metricsRecorder),
+			imagePuller, packageDeployer, metricsRecorder, packageHashModifier),
 	}
 
 	controller.reconciler = []reconciler{

--- a/internal/controllers/packages/unpack_reconciler_test.go
+++ b/internal/controllers/packages/unpack_reconciler_test.go
@@ -20,7 +20,7 @@ import (
 func TestUnpackReconciler(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd, nil)
+	ur := newUnpackReconciler(ipm, pd, nil, nil)
 
 	const image = "test123:latest"
 
@@ -52,13 +52,13 @@ func TestUnpackReconciler(t *testing.T) {
 	assert.True(t,
 		meta.IsStatusConditionTrue(*pkg.GetConditions(),
 			corev1alpha1.PackageUnpacked))
-	assert.NotEmpty(t, pkg.GetSpecHash())
+	assert.NotEmpty(t, pkg.GetSpecHash(nil))
 }
 
 func TestUnpackReconciler_noop(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd, nil)
+	ur := newUnpackReconciler(ipm, pd, nil, nil)
 
 	const image = "test123:latest"
 
@@ -69,7 +69,7 @@ func TestUnpackReconciler_noop(t *testing.T) {
 			},
 		},
 	}
-	pkg.Package.Status.UnpackedHash = pkg.GetSpecHash()
+	pkg.Package.Status.UnpackedHash = pkg.GetSpecHash(nil)
 	ctx := context.Background()
 	res, err := ur.Reconcile(ctx, pkg)
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ var errTest = errors.New("test error")
 func TestUnpackReconciler_pullBackoff(t *testing.T) {
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(ipm, pd, nil)
+	ur := newUnpackReconciler(ipm, pd, nil, nil)
 
 	const image = "test123:latest"
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
https://issues.redhat.com/browse/MTSRE-1391

This PR adds a parameter to package operator that allows adding a value used for the generated unpacked package hash. 
This parameter enables us to force a re-deployment of all packages.

### Change Type
New Feature 

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
