### PR TITLE
Archived revisions not incrementing hash collision

### DIFF
--- a/internal/controllers/objectdeployments/new_revision_reconciler.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler.go
@@ -58,7 +58,8 @@ func (r *newRevisionReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("getting conflicting ObjectSet: %w", err)
 	}
 	controllerRef := metav1.GetControllerOf(conflictingObjectSet.ClientObject())
-	if controllerRef != nil &&
+	if !conflictingObjectSet.IsArchived() &&
+		controllerRef != nil &&
 		controllerRef.UID == objectDeployment.ClientObject().GetUID() &&
 		equality.Semantic.DeepEqual(newObjectSet.GetTemplateSpec(), conflictingObjectSet.GetTemplateSpec()) {
 		// This ObjectDeployment is controller of the conflicting ObjectSet and the ObjectSet is deep equal to the desired new ObjectSet.

--- a/internal/controllers/objectdeployments/new_revision_reconciler_test.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler_test.go
@@ -12,8 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/package-operator/internal/adapters"
 	"package-operator.run/package-operator/internal/testutil"
 )
 
@@ -44,6 +46,11 @@ func Test_newRevisionReconciler_delaysObjectSetCreation(
 }
 
 func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
+	hashCollisionOS := makeObjectSet("test-xyz", "test", 1, "xyz", true, true, false)
+	hashCollisionOS.Spec.ObjectSetTemplateSpec.Phases = []corev1alpha1.ObjectSetTemplatePhase{
+		{}, {},
+	}
+
 	testCases := []struct {
 		name                       string
 		client                     *testutil.CtrlClient
@@ -58,10 +65,10 @@ func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
 			name:   "success",
 			client: testutil.NewClient(),
 			prevRevisions: []corev1alpha1.ObjectSet{
-				makeObjectSet("rev3", "test", 3, "abcd", false, true),
-				makeObjectSet("rev1", "test", 1, "xyz", false, true),
-				makeObjectSet("rev2", "test", 2, "pqr", false, true),
-				makeObjectSet("rev4", "test", 4, "abc", true, true),
+				makeObjectSet("rev3", "test", 3, "abcd", false, true, false),
+				makeObjectSet("rev1", "test", 1, "xyz", false, true, false),
+				makeObjectSet("rev2", "test", 2, "pqr", false, true, false),
+				makeObjectSet("rev4", "test", 4, "abc", true, true, false),
 			},
 			deploymentGeneration:       5,
 			deploymentHash:             "test1",
@@ -72,15 +79,45 @@ func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
 			name:   "hash collision",
 			client: testutil.NewClient(),
 			prevRevisions: []corev1alpha1.ObjectSet{
-				makeObjectSet("rev3", "test", 3, "abcd", false, false),
-				makeObjectSet("rev1", "test", 1, "xyz", true, true),
-				makeObjectSet("rev2", "test", 2, "pqr", false, false),
-				makeObjectSet("rev4", "test", 4, "abc", false, false),
+				makeObjectSet("rev3", "test", 3, "abcd", false, false, false),
+				makeObjectSet("rev1", "test", 1, "xyz", true, true, false),
+				makeObjectSet("rev2", "test", 2, "pqr", false, false, false),
+				makeObjectSet("rev4", "test", 4, "abc", false, false, false),
 			},
 			deploymentGeneration:       5,
 			deploymentHash:             "xyz",
 			conflict:                   true,
-			conflictObject:             makeObjectSet("test-xyz", "test", 1, "xyz", true, true),
+			conflictObject:             hashCollisionOS,
+			expectedHashCollisionCount: 1,
+		},
+		{
+			name:   "hash collision - slow cache",
+			client: testutil.NewClient(),
+			prevRevisions: []corev1alpha1.ObjectSet{
+				makeObjectSet("rev3", "test", 3, "abcd", false, false, false),
+				makeObjectSet("rev1", "test", 1, "xyz", true, true, false),
+				makeObjectSet("rev2", "test", 2, "pqr", false, false, false),
+				makeObjectSet("rev4", "test", 4, "abc", false, false, false),
+			},
+			deploymentGeneration:       5,
+			deploymentHash:             "xyz",
+			conflict:                   true,
+			conflictObject:             makeObjectSet("test-xyz", "test", 1, "xyz", true, true, false),
+			expectedHashCollisionCount: 0,
+		},
+		{
+			name:   "hash collision archived",
+			client: testutil.NewClient(),
+			prevRevisions: []corev1alpha1.ObjectSet{
+				makeObjectSet("rev3", "test", 3, "abcd", false, false, false),
+				makeObjectSet("rev1", "test", 1, "xyz", true, true, true),
+				makeObjectSet("rev2", "test", 2, "pqr", false, false, false),
+				makeObjectSet("rev4", "test", 4, "abc", false, false, false),
+			},
+			deploymentGeneration:       5,
+			deploymentHash:             "xyz",
+			conflict:                   true,
+			conflictObject:             makeObjectSet("test-xyz", "test", 1, "xyz", true, true, true),
 			expectedHashCollisionCount: 1,
 		},
 	}
@@ -98,17 +135,23 @@ func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
 				scheme:       testScheme,
 			}
 
-			objectDeploymentMock := makeObjectDeploymentMock(
-				"test",
-				"test",
-				testCase.deploymentGeneration,
-				testCase.deploymentHash,
-				nil,
-			)
+			objectDeployment := adapters.NewObjectDeployment(testScheme)
+			objectDeployment.ClientObject().SetName("test")
+			objectDeployment.ClientObject().SetNamespace("test")
+			objectDeployment.ClientObject().SetGeneration(testCase.deploymentGeneration)
+			objectDeployment.SetTemplateSpec(corev1alpha1.ObjectSetTemplateSpec{
+				Phases: []corev1alpha1.ObjectSetTemplatePhase{{}},
+			})
+			objectDeployment.SetStatusTemplateHash(testCase.deploymentHash)
 
 			// If conflict object is present
 			// make the client return an AlreadyExists error
 			if testCase.conflict {
+				if err := controllerutil.SetControllerReference(
+					objectDeployment.ClientObject(), &testCase.conflictObject, testScheme); err != nil {
+					require.NoError(t, err)
+				}
+
 				clientMock.On("Create",
 					mock.Anything,
 					mock.Anything,
@@ -138,22 +181,32 @@ func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
 			revisions := make([]genericObjectSet, len(testCase.prevRevisions))
 
 			for i := range testCase.prevRevisions {
+				obj := &testCase.prevRevisions[i]
+				if err := controllerutil.SetControllerReference(
+					objectDeployment.ClientObject(), obj, testScheme); err != nil {
+					require.NoError(t, err)
+				}
+
 				revisions[i] = &GenericObjectSet{
 					testCase.prevRevisions[i],
 				}
 			}
 
 			// Invoke reconciler
-			res, err := r.Reconcile(ctx, nil, revisions, objectDeploymentMock)
+			res, err := r.Reconcile(ctx, nil, revisions, objectDeployment)
 			require.NoError(t, err, "unexpected error")
 			require.True(t, res.IsZero(), "unexpected requeue")
 
 			// assert hash collisions
 			if testCase.expectedHashCollisionCount > 0 {
 				expectedCollison := int32(testCase.expectedHashCollisionCount)
-				objectDeploymentMock.AssertCalled(t, "SetStatusCollisionCount", &expectedCollison)
+
+				actualCount := objectDeployment.GetStatusCollisionCount()
+				if assert.NotNil(t, actualCount) {
+					assert.Equal(t, expectedCollison, *actualCount)
+				}
 			} else {
-				objectDeploymentMock.AssertNotCalled(t, "SetStatusCollisionCount", mock.AnythingOfType("*int32"))
+				assert.Nil(t, objectDeployment.GetStatusCollisionCount())
 			}
 
 			// Assert correct new revision is created

--- a/internal/controllers/objectdeployments/objectset_reconciler_test.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler_test.go
@@ -32,10 +32,10 @@ func Test_ObjectSetReconciler(t *testing.T) {
 			name:   "latest revision available",
 			client: testutil.NewClient(),
 			revisions: []corev1alpha1.ObjectSet{
-				makeObjectSet("rev3", "test", 3, "abcd", false, true),
-				makeObjectSet("rev1", "test", 1, "xyz", false, true),
-				makeObjectSet("rev2", "test", 2, "pqr", false, true),
-				makeObjectSet("rev4", "test", 4, "abc", true, true),
+				makeObjectSet("rev3", "test", 3, "abcd", false, true, false),
+				makeObjectSet("rev1", "test", 1, "xyz", false, true, false),
+				makeObjectSet("rev2", "test", 2, "pqr", false, true, false),
+				makeObjectSet("rev4", "test", 4, "abc", true, true, false),
 			},
 			deploymentGeneration:    4,
 			deploymentHash:          "abc",
@@ -50,10 +50,10 @@ func Test_ObjectSetReconciler(t *testing.T) {
 			name:   "no current revision",
 			client: testutil.NewClient(),
 			revisions: []corev1alpha1.ObjectSet{
-				makeObjectSet("rev3", "test", 3, "abcd", false, true),
-				makeObjectSet("rev1", "test", 1, "xyz", false, true),
-				makeObjectSet("rev2", "test", 2, "pqr", false, true),
-				makeObjectSet("rev4", "test", 4, "abc", true, true),
+				makeObjectSet("rev3", "test", 3, "abcd", false, true, false),
+				makeObjectSet("rev1", "test", 1, "xyz", false, true, false),
+				makeObjectSet("rev2", "test", 2, "pqr", false, true, false),
+				makeObjectSet("rev4", "test", 4, "abc", true, true, false),
 			},
 			deploymentGeneration:    5,
 			deploymentHash:          "hhh",
@@ -69,7 +69,7 @@ func Test_ObjectSetReconciler(t *testing.T) {
 			name:   "latest revision unavailable",
 			client: testutil.NewClient(),
 			revisions: []corev1alpha1.ObjectSet{
-				makeObjectSet("rev4", "test", 4, "abc", false, false),
+				makeObjectSet("rev4", "test", 4, "abc", false, false, false),
 			},
 			deploymentGeneration:    4,
 			deploymentHash:          "abc",
@@ -237,13 +237,22 @@ func makeObjectDeploymentMock(name string, namespace string,
 	return res
 }
 
-func makeObjectSet(name, namespace string, deploymentRevision int64, hash string, available bool, successful bool) corev1alpha1.ObjectSet {
+func makeObjectSet(
+	name, namespace string,
+	deploymentRevision int64, hash string,
+	available bool, successful bool, archived bool,
+) corev1alpha1.ObjectSet {
 	obj := &corev1alpha1.ObjectSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
 				ObjectSetHashAnnotation: hash,
+			},
+		},
+		Spec: corev1alpha1.ObjectSetSpec{
+			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
+				Phases: []corev1alpha1.ObjectSetTemplatePhase{{}},
 			},
 		},
 		Status: corev1alpha1.ObjectSetStatus{
@@ -279,6 +288,16 @@ func makeObjectSet(name, namespace string, deploymentRevision int64, hash string
 			metav1.Condition{
 				Type:   corev1alpha1.ObjectSetSucceeded,
 				Status: metav1.ConditionFalse,
+			},
+		)
+	}
+
+	if archived {
+		obj.Spec.LifecycleState = corev1alpha1.ObjectSetLifecycleStateArchived
+		obj.Status.Conditions = append(obj.Status.Conditions,
+			metav1.Condition{
+				Type:   corev1alpha1.ObjectSetArchived,
+				Status: metav1.ConditionTrue,
 			},
 		)
 	}


### PR DESCRIPTION
### Summary
Archived ObjectSets need to trigger the hash collision detector to allow users to rollback to previously archived revisions.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
