### PR TITLE
[MTSRE-1338] Consider resource scope in isObjectSetInTransition check

### DIFF
--- a/cmd/package-operator-manager/components/objectset.go
+++ b/cmd/package-operator-manager/components/objectset.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"package-operator.run/package-operator/internal/controllers/objectsets"
@@ -20,13 +21,14 @@ func ProvideObjectSetController(
 	mgr ctrl.Manager, log logr.Logger,
 	dc *dynamiccache.Cache,
 	uncachedClient UncachedClient,
+	discoverClient discovery.DiscoveryInterface,
 	recorder *metrics.Recorder,
 ) ObjectSetController {
 	return ObjectSetController{
 		objectsets.NewObjectSetController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("ObjectSet"),
-			mgr.GetScheme(), dc, uncachedClient, recorder,
+			mgr.GetScheme(), dc, uncachedClient, discoverClient, recorder,
 			mgr.GetRESTMapper(),
 		),
 	}
@@ -35,14 +37,14 @@ func ProvideObjectSetController(
 func ProvideClusterObjectSetController(
 	mgr ctrl.Manager, log logr.Logger,
 	dc *dynamiccache.Cache,
-	uncachedClient UncachedClient,
+	uncachedClient UncachedClient, discoveryClient discovery.DiscoveryInterface,
 	recorder *metrics.Recorder,
 ) ClusterObjectSetController {
 	return ClusterObjectSetController{
 		objectsets.NewClusterObjectSetController(
 			mgr.GetClient(),
 			log.WithName("controllers").WithName("ObjectSet"),
-			mgr.GetScheme(), dc, uncachedClient, recorder,
+			mgr.GetScheme(), dc, uncachedClient, discoveryClient, recorder,
 			mgr.GetRESTMapper(),
 		),
 	}

--- a/internal/controllers/objectsets/objectsetphases_reconciler_test.go
+++ b/internal/controllers/objectsets/objectsetphases_reconciler_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"package-operator.run/package-operator/internal/testutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -48,7 +50,7 @@ func TestObjectSetPhasesReconciler_Reconcile(t *testing.T) {
 	lookup := func(_ context.Context, _ controllers.PreviousOwner) ([]controllers.PreviousObjectSet, error) {
 		return []controllers.PreviousObjectSet{}, nil
 	}
-	r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup)
+	r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup, testutil.NewClient())
 
 	phase1 := corev1alpha1.ObjectSetTemplatePhase{
 		Name: "phase1",
@@ -96,7 +98,7 @@ func TestPhaseReconciler_ReconcileBackoff(t *testing.T) {
 	lookup := func(_ context.Context, _ controllers.PreviousOwner) ([]controllers.PreviousObjectSet, error) {
 		return []controllers.PreviousObjectSet{}, nil
 	}
-	r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup)
+	r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup, testutil.NewClient())
 
 	os := &GenericObjectSet{}
 	os.Spec.Phases = []corev1alpha1.ObjectSetTemplatePhase{
@@ -139,7 +141,7 @@ func TestObjectSetPhasesReconciler_Teardown(t *testing.T) {
 			lookup := func(_ context.Context, _ controllers.PreviousOwner) ([]controllers.PreviousObjectSet, error) {
 				return []controllers.PreviousObjectSet{}, nil
 			}
-			r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup)
+			r := newObjectSetPhasesReconciler(testScheme, pr, remotePr, lookup, testutil.NewClient())
 
 			phase1 := corev1alpha1.ObjectSetTemplatePhase{
 				Name: "phase1",
@@ -252,7 +254,7 @@ func TestObjectSetPhasesReconciler_SuccessDelay(t *testing.T) {
 				Return([]corev1alpha1.ControlledObjectReference{}, controllers.ProbingResult{}, nil)
 
 			rec := newObjectSetPhasesReconciler(
-				testScheme, prm, rprm, lookup,
+				testScheme, prm, rprm, lookup, testutil.NewClient(),
 				withClock{
 					Clock: cm,
 				},

--- a/internal/testutil/ctrl_client.go
+++ b/internal/testutil/ctrl_client.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"context"
 
+	"k8s.io/client-go/discovery"
+
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,6 +15,7 @@ import (
 // CtrlClient is a mock for the controller-runtime client interface.
 type CtrlClient struct {
 	mock.Mock
+	discovery.DiscoveryInterface
 
 	StatusMock *CtrlStatusClient
 }


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
This PR tries to fix the scenario described below.

If a `Package` contains a mix of namespaced resources and cluster resource, the package gets stuck in `Progressing` state when installed because:

- `LatestRevisionPendingSuccess` condition is never removed
- to have the `LatestRevisionPendingSuccess` condition be removed, the corresponding `ObjectSet` must enter `Succeeded` state
- the underlying `ObjectSet` never reaches `Succeeded` because the `InTransition` condition never goes away
- the `InTransition` condition never gets removed because the underlying `isObjectSetInTransition` function in the code [assumes that all the resources controlled by a `Package` are part of its namespace](https://github.com/package-operator/package-operator/blob/9165fcc405c745acd8af85e805128ab346793b7a/internal/controllers/objectsets/objectsetphases_reconciler.go#L287-L289), and it fails on cluster scoped resources


### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
