### PR TITLE
Report Collision Detection Errors into API

### DIFF
--- a/internal/controllers/config.go
+++ b/internal/controllers/config.go
@@ -7,6 +7,13 @@ import (
 )
 
 const (
+	// Use this delay if you want to retry an invalid user configuration.
+	// e.g.:
+	// - referencing objects that don't exist.
+	// - object collisions.
+	// - missing permissions.
+	DefaultGlobalMissConfigurationRetry = 30 * time.Second
+
 	DefaultInitialBackoff = 10 * time.Second
 	DefaultMaxBackoff     = 300 * time.Second
 )

--- a/internal/controllers/objectsetphases/objectsetphase_adapter.go
+++ b/internal/controllers/objectsetphases/objectsetphase_adapter.go
@@ -19,6 +19,7 @@ type genericObjectSetPhase interface {
 	GetGeneration() int64
 	IsPaused() bool
 	SetStatusControllerOf([]corev1alpha1.ControlledObjectReference)
+	UpdateStatusPhase()
 }
 
 var (
@@ -97,6 +98,7 @@ func (a *GenericObjectSetPhase) IsPaused() bool {
 func (a *GenericObjectSetPhase) GetGeneration() int64 {
 	return a.Generation
 }
+func (a *GenericObjectSetPhase) UpdateStatusPhase() {}
 
 func (a *GenericObjectSetPhase) SetStatusControllerOf(controllerOf []corev1alpha1.ControlledObjectReference) {
 	a.Status.ControllerOf = controllerOf
@@ -147,3 +149,4 @@ func (a *GenericClusterObjectSetPhase) IsPaused() bool {
 func (a *GenericClusterObjectSetPhase) SetStatusControllerOf(controllerOf []corev1alpha1.ControlledObjectReference) {
 	a.Status.ControllerOf = controllerOf
 }
+func (a *GenericClusterObjectSetPhase) UpdateStatusPhase() {}

--- a/internal/controllers/objectsetphases/objectsetphase_controller_test.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller_test.go
@@ -2,7 +2,6 @@ package objectsetphases
 
 import (
 	"context"
-	goerrors "errors"
 	"testing"
 	"time"
 
@@ -22,7 +21,6 @@ import (
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/package-operator/internal/controllers"
 	"package-operator.run/package-operator/internal/ownerhandling"
-	"package-operator.run/package-operator/internal/preflight"
 	"package-operator.run/package-operator/internal/testutil"
 )
 
@@ -277,49 +275,6 @@ func TestGenericObjectSetPhaseController_reportPausedCondition(t *testing.T) {
 			}
 		})
 	}
-}
-
-var errTest = goerrors.New("explosion")
-
-func TestGenericObjectSetPhaseController_updateStatusError(t *testing.T) {
-	t.Parallel()
-
-	t.Run("just returns error", func(t *testing.T) {
-		t.Parallel()
-		objectSetPhase := &GenericObjectSetPhase{
-			ObjectSetPhase: corev1alpha1.ObjectSetPhase{},
-		}
-
-		c := &GenericObjectSetPhaseController{}
-		ctx := context.Background()
-		res, err := c.updateStatusError(ctx, objectSetPhase, errTest)
-		assert.False(t, res.IsZero())
-		assert.EqualError(t, err, "explosion")
-	})
-
-	t.Run("reports preflight error", func(t *testing.T) {
-		t.Parallel()
-		objectSetPhase := &GenericObjectSetPhase{
-			ObjectSetPhase: corev1alpha1.ObjectSetPhase{},
-		}
-
-		client := testutil.NewClient()
-		c := &GenericObjectSetPhaseController{
-			client: client,
-		}
-
-		client.StatusMock.
-			On("Update", mock.Anything, mock.Anything, mock.Anything).
-			Return(nil)
-
-		ctx := context.Background()
-		res, err := c.updateStatusError(
-			ctx, objectSetPhase, &preflight.Error{})
-		require.True(t, res.IsZero())
-		require.NoError(t, err)
-
-		client.StatusMock.AssertExpectations(t)
-	})
 }
 
 func TestInitializers(t *testing.T) {

--- a/internal/controllers/objectsets/adapter_objectset.go
+++ b/internal/controllers/objectsets/adapter_objectset.go
@@ -22,7 +22,6 @@ type genericObjectSet interface {
 	GetSuccessDelaySeconds() int32
 	SetRevision(revision int64)
 	GetRevision() int64
-	GetGeneration() int64
 	GetRemotePhases() []corev1alpha1.RemotePhaseReference
 	SetRemotePhases([]corev1alpha1.RemotePhaseReference)
 	SetStatusControllerOf([]corev1alpha1.ControlledObjectReference)
@@ -115,10 +114,6 @@ func (a *GenericObjectSet) GetRevision() int64 {
 	return a.Status.Revision
 }
 
-func (a *GenericObjectSet) GetGeneration() int64 {
-	return a.Generation
-}
-
 func (a *GenericObjectSet) GetRemotePhases() []corev1alpha1.RemotePhaseReference {
 	return a.Status.RemotePhases
 }
@@ -177,10 +172,6 @@ func (a *GenericClusterObjectSet) GetSuccessDelaySeconds() int32 {
 
 func (a *GenericClusterObjectSet) SetRevision(revision int64) {
 	a.Status.Revision = revision
-}
-
-func (a *GenericClusterObjectSet) GetGeneration() int64 {
-	return a.Generation
 }
 
 func (a *GenericClusterObjectSet) GetRevision() int64 {

--- a/internal/controllers/objectsets/objectset_controller_test.go
+++ b/internal/controllers/objectsets/objectset_controller_test.go
@@ -2,13 +2,11 @@ package objectsets
 
 import (
 	"context"
-	goerrors "errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,7 +14,6 @@ import (
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/package-operator/internal/controllers"
-	"package-operator.run/package-operator/internal/preflight"
 	"package-operator.run/package-operator/internal/testutil"
 	"package-operator.run/package-operator/internal/testutil/dynamiccachemocks"
 )
@@ -409,46 +406,6 @@ func TestGenericObjectSetController_handleDeletionAndArchival(t *testing.T) {
 			}
 		})
 	}
-}
-
-var errTest = goerrors.New("explosion")
-
-func TestGenericObjectSetController_updateStatusError(t *testing.T) {
-	t.Parallel()
-
-	t.Run("just returns error", func(t *testing.T) {
-		t.Parallel()
-
-		objectSet := &GenericObjectSet{
-			ObjectSet: corev1alpha1.ObjectSet{},
-		}
-
-		c, _, _, _, _ := newControllerAndMocks()
-		ctx := context.Background()
-		err := c.updateStatusError(ctx, objectSet, errTest)
-		assert.EqualError(t, err, "explosion")
-	})
-
-	t.Run("reports preflight error", func(t *testing.T) {
-		t.Parallel()
-
-		objectSet := &GenericObjectSet{
-			ObjectSet: corev1alpha1.ObjectSet{},
-		}
-
-		c, client, _, _, _ := newControllerAndMocks()
-
-		client.StatusMock.
-			On("Update", mock.Anything, mock.Anything, mock.Anything).
-			Return(nil)
-
-		ctx := context.Background()
-		err := c.updateStatusError(
-			ctx, objectSet, &preflight.Error{})
-		require.NoError(t, err)
-
-		client.StatusMock.AssertExpectations(t)
-	})
 }
 
 func newControllerAndMocks() (


### PR DESCRIPTION
### Summary
Collision detetor errors, like "adoption refused" where only logged and where not apperant to the user in the API. This commit adds this reporting.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
