### PR TITLE
MTSRE-1379 fix duplicate CRDs in self-bootstrap-job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Debug binary
+__debug_bin*
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/cmd/package-operator-manager/bootstrap/bootstrap_test.go
+++ b/cmd/package-operator-manager/bootstrap/bootstrap_test.go
@@ -21,6 +21,7 @@ func TestBootstrapperBootstrap(t *testing.T) {
 
 	c := testutil.NewClient()
 	var initCalled bool
+	var fixCalled bool
 	b := &Bootstrapper{
 		log:    testr.New(t),
 		client: c,
@@ -29,6 +30,10 @@ func TestBootstrapperBootstrap(t *testing.T) {
 		) {
 			initCalled = true
 			return true, nil
+		},
+		fix: func(ctx context.Context) error {
+			fixCalled = true
+			return nil
 		},
 	}
 	b.SetEnvironment(&manifestsv1alpha1.PackageEnvironment{
@@ -56,6 +61,7 @@ func TestBootstrapperBootstrap(t *testing.T) {
 		})
 	require.NoError(t, err)
 	assert.True(t, initCalled)
+	assert.True(t, fixCalled)
 
 	assert.Equal(t, os.Getenv("HTTP_PROXY"), "httpxxx")
 	assert.Equal(t, os.Getenv("HTTPS_PROXY"), "httpsxxx")

--- a/cmd/package-operator-manager/bootstrap/fix.go
+++ b/cmd/package-operator-manager/bootstrap/fix.go
@@ -1,0 +1,72 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"package-operator.run/cmd/package-operator-manager/bootstrap/fix"
+)
+
+type runChecker interface {
+	Check(ctx context.Context, fc fix.Context) (bool, error)
+	Run(ctx context.Context, fc fix.Context) error
+}
+
+// Fixes PKO problems on the cluster by checking conditions and applying appropriate fixes as needed.
+type fixer struct {
+	log          logr.Logger
+	client       client.Client
+	pkoNamespace string
+	fixes        []runChecker
+}
+
+func newFixer(c client.Client, log logr.Logger, pkoNamespace string) *fixer {
+	return &fixer{
+		log:          log.WithName("fixer"),
+		client:       c,
+		pkoNamespace: pkoNamespace,
+
+		// Order matters here, the fixes are checked against and applied sequentially one-by-one.
+		fixes: []runChecker{
+			&fix.CRDPluralizationFix{},
+		},
+	}
+}
+
+// fix iterates through all registered fixes/runCheckers, runs their checks to determine if the fix has to be executed and if so, it executes the fix.
+func (f *fixer) fix(ctx context.Context) error {
+	for _, fixRunChecker := range f.fixes {
+		fixName := reflect.TypeOf(fixRunChecker).String()
+		log := f.log.WithValues("fix", fixName)
+
+		fc := fix.Context{
+			Log:          log,
+			Client:       f.client,
+			PKONamespace: f.pkoNamespace,
+		}
+
+		// run eligibility check to find out if the fix should be executed
+		applicable, err := fixRunChecker.Check(ctx, fc)
+		if err != nil {
+			return fmt.Errorf("check failed for fix %s: %w", fixName, err)
+		}
+		log.Info("checked", "applicable", applicable)
+
+		// skip fix, if `.Check(...)` said that the fix is not applicable
+		if !applicable {
+			continue
+		}
+
+		// execute fix
+		if err := fixRunChecker.Run(ctx, fc); err != nil {
+			return fmt.Errorf("fix failed for fix %s: %w", fixName, err)
+		}
+		log.Info("executed")
+	}
+
+	return nil
+}

--- a/cmd/package-operator-manager/bootstrap/fix/1.7.0_crd-pluralization.go
+++ b/cmd/package-operator-manager/bootstrap/fix/1.7.0_crd-pluralization.go
@@ -1,0 +1,220 @@
+package fix
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mt-sre/devkube/dev"
+	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+)
+
+/*
+This fix cleans up the singular version of two pluralized CRDs.
+* An upgrade [1] to the controller-runtime dependency also upgraded the code generators that generate our CustomResourceDefinition manifests from the apis package. This upgrade fixed a pluralization library used in the generators, which in turn 'fixed' the `plural` names of the CRDs `ClusterObjectSlices` and `ObjectSlices` and appended a missing 's' to both names.
+* - `objectslice` -> `objectslices`
+* - `clusterobjectslice` -> `clusterobjectslices`
+*
+* Upgrading from an existing PKO installation with the old (singular) CRDs in place to a new version with the new (pluralized) CRDs results in a broken state because the old singular CRDs must be removed from the apiserver for the new pluralized CRDs to become ready. PKO can't handle this situation when it tries to upgrade itself and the ClusterObjectSet for PKO's new version will never be able to adopt all PKO resources, thus stalling the upgrade, leaving the old PKO version running indefinitely.
+* Luckily the old singular CRDs can just be deleted because PKO is not using this api yet.
+*
+* Rough overview of the steps this fix takes to rectify the upgrade:
+* - Needs package-operator-manager to be stopped (which the take-over bootstrap procedure already handles).
+* - Remove all ClusterObjectSets under the package-operator ClusterPackage with propagation policy set to `Orphan`, thus leaving all children objects intact. This is really important to avoid the loss of every installed package in the cluster.
+* - Remove the singular CRDs.
+* - Continue with the bootstrap process which will recreate a ClusterObjectSet, adopt all PKO resources and spin up a fresh PKO deployment which then takes over.
+
+* [1] https://github.com/package-operator/package-operator/commit/928fbace122d35d4d5002d740d7d6ca14248f315
+*/
+type CRDPluralizationFix struct{}
+
+var (
+	pkoClusterObjectSetLabelSelector = fmt.Sprintf("%s=package-operator", manifestsv1alpha1.PackageLabel)
+	deletionWaitTimeout              = time.Minute
+	deletionWaitInterval             = time.Second
+)
+
+// Organize references to CRD names together.
+var (
+	singularObjectSliceCRD        = "objectslice.package-operator.run"
+	singularClusterObjectSliceCRD = "clusterobjectslice.package-operator.run"
+
+	// The CRDs that will be removed as part of the fix.
+	crdsToBeRemoved = []string{
+		singularObjectSliceCRD,
+		singularClusterObjectSliceCRD,
+	}
+
+	crdPairs = [][2]string{
+		{
+			singularClusterObjectSliceCRD,
+			"clusterobjectslices.package-operator.run",
+		},
+		{
+			singularObjectSliceCRD,
+			"objectslices.package-operator.run",
+		},
+	}
+)
+
+func (f CRDPluralizationFix) Check(ctx context.Context, fc Context) (bool, error) {
+	// Assert cluster conditions that make fix applicable.
+	// This one is easy: when either of (cluster)objectslice(s) CRDs exist in singularized and pluralized form.
+	// The fix itself has to make sure to remove this condition as late as possible from the cluster to avoid getting stuck in an "errored fix state" which this check does not detect.
+
+	return f.atleastOneCRDPairExists(ctx, fc, crdPairs)
+}
+
+func (f CRDPluralizationFix) Run(ctx context.Context, fc Context) error {
+	// ensure ORPHANING deletion of package-operator ClusterObjectSets (the ones that are created under the package-operator Package)
+	if err := f.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, fc, pkoClusterObjectSetLabelSelector); err != nil {
+		return err
+	}
+
+	// remove singular CRDs - this step happens last, to keep the fix condition open until after the actual fix has happened
+	for _, crd := range crdsToBeRemoved {
+		if err := f.ensureCRDGone(ctx, fc, crd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mustParseLabelSelector(selector string) labels.Selector {
+	labelSelector, err := labels.Parse(selector)
+	if err != nil {
+		panic(fmt.Errorf("must be able to parse label selector string: %s, %w", selector, err))
+	}
+	return labelSelector
+}
+
+func (f CRDPluralizationFix) ensureClusterObjectSetsGoneWithOrphansLeft(ctx context.Context, fc Context, labelSelectorString string) error {
+	// build pkoLabelSelector to match PKO ClusterObjectSets
+	pkoLabelSelector := client.MatchingLabelsSelector{
+		Selector: mustParseLabelSelector(labelSelectorString),
+	}
+
+	// delete all PKO ClusterObjectSets by labelSelector
+	// the `Orphan` PropagationPolicy is important here!
+	// We don't want kube to clean up all child objects (because that would include ALL PKO CRDs and this would in turn include all installed objects!)
+	if err := fc.Client.DeleteAllOf(
+		ctx,
+		&corev1alpha1.ClusterObjectSet{},
+		pkoLabelSelector,
+		client.PropagationPolicy(metav1.DeletePropagationOrphan),
+	); err != nil {
+		return err
+	}
+
+	// list all PKO ClusterObjectSets by pkoLabelSelector,
+	list := &corev1alpha1.ClusterObjectSetList{}
+	if err := fc.Client.List(ctx, list, pkoLabelSelector); err != nil {
+		return err
+	}
+
+	// for each listed ClusterObjectSet: remove all finalizers and wait for them to be gone.
+	for i := range list.Items {
+		cos := list.Items[i]
+
+		patch := client.MergeFrom(cos.DeepCopy())
+		cos.ObjectMeta.Finalizers = []string{}
+		if err := fc.Client.Patch(ctx, &cos, patch); err != nil {
+			return err
+		}
+
+		waiter := dev.NewWaiter(fc.Client, fc.Client.Scheme(),
+			dev.WithInterval(deletionWaitInterval),
+			dev.WithTimeout(deletionWaitTimeout))
+		if err := waiter.WaitToBeGone(ctx,
+			&cos,
+			func(obj client.Object) (done bool, err error) {
+				return false, nil
+			},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Ensures that the CRD `name` is deleted and waits for the object to be fully gone.
+func (f CRDPluralizationFix) ensureCRDGone(ctx context.Context, fc Context, name string) error {
+	crd := &v1apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	err := fc.Client.Delete(ctx, crd)
+	if k8serrors.IsNotFound(err) {
+		// object is already gone
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// wait for object to be fully deleted
+	waiter := dev.NewWaiter(fc.Client, fc.Client.Scheme(),
+		dev.WithInterval(deletionWaitInterval),
+		dev.WithTimeout(deletionWaitTimeout))
+	return waiter.WaitToBeGone(ctx, crd, func(obj client.Object) (done bool, err error) { return false, nil })
+}
+
+// Checks if at least one of the given CRD pairs exists in the apiserver.
+func (f CRDPluralizationFix) atleastOneCRDPairExists(ctx context.Context, fc Context, pairs [][2]string) (bool, error) {
+	onePairExistsInBothForms := false
+
+	for _, pair := range pairs {
+		pairExists, err := f.crdPairExists(ctx, fc, pair)
+		if err != nil {
+			return false, err
+		}
+		if pairExists {
+			onePairExistsInBothForms = true
+		}
+	}
+
+	return onePairExistsInBothForms, nil
+}
+
+// Check if two CRDs exist by querying the apiserver.
+func (f CRDPluralizationFix) crdPairExists(ctx context.Context, fc Context, crdPair [2]string) (bool, error) {
+	pairExists := [2]bool{false, false}
+
+	for j := range crdPair {
+		crdName := crdPair[j]
+
+		exists, err := f.crdExists(ctx, fc.Client, crdName)
+		if err != nil {
+			return false, err
+		}
+
+		pairExists[j] = exists
+	}
+
+	return pairExists[0] && pairExists[1], nil
+}
+
+func (f CRDPluralizationFix) crdExists(ctx context.Context, c client.Client, name string) (bool, error) {
+	crd := &v1apiextensions.CustomResourceDefinition{}
+	err := c.Get(ctx, client.ObjectKey{
+		Name: name,
+	}, crd)
+
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	// crd exists if error is nil, otherwise error must be passed
+	return err == nil, err
+}

--- a/cmd/package-operator-manager/bootstrap/fix/1.7.0_crd-pluralization_test.go
+++ b/cmd/package-operator-manager/bootstrap/fix/1.7.0_crd-pluralization_test.go
@@ -1,0 +1,460 @@
+package fix
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/internal/testutil"
+)
+
+func init() {
+	deletionWaitInterval = time.Millisecond
+	deletionWaitTimeout = 10 * time.Millisecond
+}
+
+var errTest = errors.New("test")
+
+func TestMustParseLabelSelector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Parsing correct selector string must succeed.", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() {
+			mustParseLabelSelector("app.kubernetes.io/name=foo")
+		})
+	})
+
+	t.Run("Parsing incorrect selector string must fail.", func(t *testing.T) {
+		t.Parallel()
+
+		require.Panics(t, func() {
+			mustParseLabelSelector("f.,<>bla")
+		})
+	})
+
+	t.Run("Parsing `pkoClusterObjectSetLabelSelector` must not fail.", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() {
+			require.NotNil(t,
+				mustParseLabelSelector(pkoClusterObjectSetLabelSelector))
+		})
+	})
+}
+
+const labelSelectorString = "test=true"
+
+type (
+	subTestFunc func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme)
+	subTest     struct {
+		name string
+		t    subTestFunc
+	}
+)
+
+func TestCRDPluralizationFix_ensureClusterObjectSetsGoneWithOrphansLeft(t *testing.T) {
+	t.Parallel()
+
+	subTests := []subTest{
+		{
+			name: "happyPath",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("Scheme").Return(testScheme)
+
+				c.On("DeleteAllOf",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.IsType([]client.DeleteAllOfOption{})).
+					Run(func(args mock.Arguments) {
+						// Test if delete options contain the label selector and orphaning deletion!
+						opts := args.Get(2).([]client.DeleteAllOfOption)
+						assert.Contains(t, opts, client.PropagationPolicy(metav1.DeletePropagationOrphan))
+
+						assert.Condition(t, hasDeleteAllOfOption(opts, client.MatchingLabelsSelector{
+							Selector: mustParseLabelSelector(labelSelectorString),
+						}))
+					}).
+					Return(nil)
+
+				c.On("List",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSetList{}),
+					mock.IsType([]client.ListOption{})).
+					Run(func(args mock.Arguments) {
+						// mock single ClusterObjectSet with a finalizer
+						list := args.Get(1).(*corev1alpha1.ClusterObjectSetList)
+						list.Items = append(list.Items, corev1alpha1.ClusterObjectSet{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "cos",
+								Finalizers: []string{"finalizer"},
+							},
+						})
+
+						// Test if list options contain the label selector
+						opts := args.Get(2).([]client.ListOption)
+						assert.Condition(t, hasListOption(opts, client.MatchingLabelsSelector{
+							Selector: mustParseLabelSelector(labelSelectorString),
+						}))
+					}).
+					Return(nil)
+
+				c.On("Patch",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.Anything,
+					mock.Anything).
+					Run(func(args mock.Arguments) {
+						// Test if finalizers are empty.
+						cos := args.Get(1).(*corev1alpha1.ClusterObjectSet)
+						assert.Equal(t, []string{}, cos.ObjectMeta.Finalizers)
+					}).
+					Return(nil)
+
+				c.On("Get",
+					mock.Anything,
+					mock.IsType(client.ObjectKey{}),
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.Anything).
+					Return(k8serrors.NewNotFound(schema.GroupResource{}, ""))
+
+				fix := &CRDPluralizationFix{}
+				require.NoError(t, fix.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, labelSelectorString))
+			},
+		},
+		{
+			name: "deleteAllOfFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				testErr := errors.New("test") //nolint:goerr113
+
+				c.On("DeleteAllOf",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.IsType([]client.DeleteAllOfOption{})).
+					Return(testErr)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, labelSelectorString), testErr)
+			},
+		},
+		{
+			name: "listFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("DeleteAllOf",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.IsType([]client.DeleteAllOfOption{})).
+					Return(nil)
+
+				c.On("List",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSetList{}),
+					mock.IsType([]client.ListOption{})).
+					Return(errTest)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, labelSelectorString), errTest)
+			},
+		},
+		{
+			name: "patchFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				testErr := errors.New("test") //nolint:goerr113
+
+				c.On("DeleteAllOf",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.IsType([]client.DeleteAllOfOption{})).
+					Return(nil)
+
+				c.On("List",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSetList{}),
+					mock.IsType([]client.ListOption{})).
+					Run(func(args mock.Arguments) {
+						// mock single ClusterObjectSet with a finalizer
+						list := args.Get(1).(*corev1alpha1.ClusterObjectSetList)
+						list.Items = append(list.Items, corev1alpha1.ClusterObjectSet{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "cos",
+								Finalizers: []string{"finalizer"},
+							},
+						})
+					}).
+					Return(nil)
+
+				c.On("Patch",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.Anything,
+					mock.Anything).
+					Return(testErr)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, labelSelectorString), testErr)
+			},
+		},
+		{
+			name: "waitToBeGoneFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				testErr := errors.New("test") //nolint:goerr113
+
+				c.On("Scheme").Return(testScheme)
+
+				c.On("DeleteAllOf",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.IsType([]client.DeleteAllOfOption{})).
+					Return(nil)
+
+				c.On("List",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSetList{}),
+					mock.IsType([]client.ListOption{})).
+					Run(func(args mock.Arguments) {
+						// mock single ClusterObjectSet with a finalizer
+						list := args.Get(1).(*corev1alpha1.ClusterObjectSetList)
+						list.Items = append(list.Items, corev1alpha1.ClusterObjectSet{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "cos",
+								Finalizers: []string{"finalizer"},
+							},
+						})
+					}).
+					Return(nil)
+
+				c.On("Patch",
+					mock.Anything,
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.Anything,
+					mock.Anything).
+					Return(nil)
+
+				c.On("Get",
+					mock.Anything,
+					mock.IsType(client.ObjectKey{}),
+					mock.IsType(&corev1alpha1.ClusterObjectSet{}),
+					mock.Anything).
+					Return(testErr)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureClusterObjectSetsGoneWithOrphansLeft(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, labelSelectorString), context.DeadlineExceeded)
+			},
+		},
+	}
+
+	for i := range subTests {
+		subTest := subTests[i]
+
+		t.Run(subTest.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := logr.NewContext(context.Background(), testr.New(t))
+			c := testutil.NewClient()
+
+			subTest.t(t, c, ctx, testScheme)
+			c.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEnsureCRDGone(t *testing.T) {
+	t.Parallel()
+
+	subTests := []subTest{
+		{
+			name: "happyPathAlreadyGone",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("Delete",
+					mock.Anything,
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(k8serrors.NewNotFound(schema.GroupResource{}, ""))
+
+				fix := &CRDPluralizationFix{}
+				require.NoError(t, fix.ensureCRDGone(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, "foo"))
+			},
+		},
+		{
+			name: "happyPath",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("Scheme").Return(testScheme)
+
+				c.On("Delete",
+					mock.Anything,
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(nil)
+				c.On("Get",
+					mock.Anything,
+					mock.Anything,
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(k8serrors.NewNotFound(schema.GroupResource{}, ""))
+
+				fix := &CRDPluralizationFix{}
+				require.NoError(t, fix.ensureCRDGone(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, "foo"))
+			},
+		},
+		{
+			name: "deleteFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("Delete",
+					mock.Anything,
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(errTest)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureCRDGone(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, "foo"), errTest)
+			},
+		},
+		{
+			name: "waitFails",
+			t: func(t *testing.T, c *testutil.CtrlClient, ctx context.Context, scheme *runtime.Scheme) {
+				t.Helper()
+
+				log, err := logr.FromContext(ctx)
+				require.NoError(t, err)
+
+				c.On("Scheme").Return(testScheme)
+
+				c.On("Delete",
+					mock.Anything,
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(nil)
+
+				c.On("Get",
+					mock.Anything,
+					mock.IsType(client.ObjectKey{}),
+					mock.IsType(&v1apiextensions.CustomResourceDefinition{}),
+					mock.Anything).
+					Return(errTest)
+
+				fix := &CRDPluralizationFix{}
+				require.ErrorIs(t, fix.ensureCRDGone(ctx, Context{
+					Client: c,
+					Log:    log,
+				}, "foo"), context.DeadlineExceeded)
+			},
+		},
+	}
+
+	for i := range subTests {
+		subTest := subTests[i]
+
+		t.Run(subTest.name, func(t *testing.T) {
+			t.Parallel()
+			t.Helper()
+
+			ctx := logr.NewContext(context.Background(), testr.New(t))
+			c := testutil.NewClient()
+
+			subTest.t(t, c, ctx, testScheme)
+			c.AssertExpectations(t)
+		})
+	}
+}
+
+func hasDeleteAllOfOption(opts []client.DeleteAllOfOption, expected client.DeleteAllOfOption) func() bool {
+	return func() bool {
+		for _, opt := range opts {
+			if equality.Semantic.DeepEqual(opt, expected) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func hasListOption(opts []client.ListOption, expected client.ListOption) func() bool {
+	return func() bool {
+		for _, opt := range opts {
+			if equality.Semantic.DeepEqual(opt, expected) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/cmd/package-operator-manager/bootstrap/fix/scheme_test.go
+++ b/cmd/package-operator-manager/bootstrap/fix/scheme_test.go
@@ -1,0 +1,19 @@
+package fix
+
+import (
+	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	pkoapis "package-operator.run/apis"
+)
+
+var testScheme = runtime.NewScheme()
+
+func init() {
+	if err := pkoapis.AddToScheme(testScheme); err != nil {
+		panic(err)
+	}
+	if err := v1apiextensions.AddToScheme(testScheme); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/package-operator-manager/bootstrap/fix/types.go
+++ b/cmd/package-operator-manager/bootstrap/fix/types.go
@@ -1,0 +1,12 @@
+package fix
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Context struct {
+	Client       client.Client
+	Log          logr.Logger
+	PKONamespace string
+}

--- a/cmd/package-operator-manager/bootstrap/fix_test.go
+++ b/cmd/package-operator-manager/bootstrap/fix_test.go
@@ -1,0 +1,107 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"package-operator.run/cmd/package-operator-manager/bootstrap/fix"
+	"package-operator.run/internal/testutil"
+)
+
+func Test_fixer_happy_path(t *testing.T) {
+	t.Parallel()
+
+	// Two fixes, no errors, the first fix is not eligible for execution, the second is.
+	fixNoRun := newRunCheckerMock().program(t, false, nil, nil)
+	defer fixNoRun.AssertExpectations(t)
+	fixRunNoErr := newRunCheckerMock().program(t, true, nil, nil)
+	defer fixRunNoErr.AssertExpectations(t)
+
+	fixer := newTestFixer(t, []runChecker{
+		fixNoRun,
+		fixRunNoErr,
+	})
+
+	err := fixer.fix(context.Background())
+	require.NoError(t, err)
+}
+
+var errTest = errors.New("test")
+
+func Test_fixer_stops_at_error(t *testing.T) {
+	t.Parallel()
+
+	// Three fixes, the first one succeeds, the second one errors, the third one should never be looked at.
+	fixRunNoErr := newRunCheckerMock().program(t, true, nil, nil)
+	defer fixRunNoErr.AssertExpectations(t)
+	fixRunErr := newRunCheckerMock().program(t, true, nil, errTest)
+	defer fixRunErr.AssertExpectations(t)
+	fixShouldntCheckOrRun := newRunCheckerMock()
+	defer fixShouldntCheckOrRun.AssertExpectations(t)
+
+	fixer := newTestFixer(t, []runChecker{
+		fixRunNoErr,
+		fixRunErr,
+		fixShouldntCheckOrRun,
+	})
+
+	err := fixer.fix(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errTest)
+}
+
+func newTestFixer(t *testing.T, runCheckers []runChecker) *fixer {
+	t.Helper()
+
+	return &fixer{
+		log:    testr.New(t),
+		client: testutil.NewClient(),
+		fixes:  runCheckers,
+	}
+}
+
+// Force mock to implement the `runChecker` interface.
+var _ runChecker = &runCheckerMock{}
+
+type runCheckerMock struct {
+	mock.Mock
+}
+
+func newRunCheckerMock() *runCheckerMock {
+	return &runCheckerMock{}
+}
+
+func (s *runCheckerMock) program(t *testing.T, checkResult bool, checkErr error, runErr error) *runCheckerMock {
+	t.Helper()
+
+	isTypeCtx := mock.IsType(context.TODO())
+	isTypeFixCtx := mock.IsType(fix.Context{})
+
+	// program `.Check(...)` with provided return values
+	s.On("Check", isTypeCtx, isTypeFixCtx).
+		Return(checkResult, checkErr)
+
+	// program `.Run(...)` if call to `.Check(...)` results in `true` and no error
+	if checkResult && checkErr == nil {
+		s.On("Run", isTypeCtx, isTypeFixCtx).
+			Return(runErr)
+	}
+
+	return s
+}
+
+func (s *runCheckerMock) Check(ctx context.Context, fc fix.Context) (bool, error) {
+	args := s.Called(ctx, fc)
+	return args.Bool(0), args.Error(1)
+}
+
+func (s *runCheckerMock) Run(ctx context.Context, fc fix.Context) error {
+	args := s.Called(ctx, fc)
+	return args.Error(0)
+}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This fix cleans up the singular version of two pluralized CRDs and resolves [MTSRE-1379](https://issues.redhat.com//browse/MTSRE-1379) in our internal bugtracker.

An upgrade [1] to the controller-runtime dependency also upgraded the code generators that generate our CustomResourceDefinition manifests from the apis package. This upgrade fixed a pluralization library used in the generators, which in turn 'fixed' the `plural` names of the CRDs `ClusterObjectSlices` and `ObjectSlices` and appended a missing 's' to both names.
- `objectslice` -> `objectslices`
- `clusterobjectslice` -> `clusterobjectslices`

Upgrading from an existing PKO installation with the old (singular) CRDs in place to a new version with the new (pluralized) CRDs results in a broken state because the old singular CRDs must be removed from the apiserver for the new pluralized CRDs to become ready. PKO can't handle this situation when it tries to upgrade itself and the ClusterObjectSet for PKO's new version will never be able to adopt all PKO resources, thus stalling the upgrade, leaving the old PKO version running indefinitely.
Luckily the old singular CRDs can just be deleted because PKO is not using this api yet.

Rough overview of the steps this fix takes to rectify the upgrade:
- Remove all ClusterObjectSets under the package-operator ClusterPackage with propagation policy set to `Orphan`, thus leaving all children objects intact. This is really important to avoid the loss of every installed package in the cluster.
- Remove the singular CRDs.
- Continue with the bootstrap process which will recreate a ClusterObjectSet, adopt all PKO resources and spin up a fresh PKO deployment which then takes over.

[1] https://github.com/package-operator/package-operator/commit/928fbace122d35d4d5002d740d7d6ca14248f315

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] All todos have been looked at
- [ ] Fixing bootstrap is not looping until `panic: running manager for self-bootstrap: failed waiting for all runnables to end within grace period of 30s: context deadline exceeded` anymore.

### Additional Information

<!-- Report any other relevant details below -->


Helpful commands to test locally:
```bash
# set up kind cluster
./mage dev:setup

# install latest PKO version with the singularized CRDs
kubectl apply -f https://github.com/package-operator/package-operator/releases/download/v1.6.6/self-bootstrap-job.yaml

# watch PKO ClusterPackage object tree in separate terminal window
watch 'kubectl lineage clusterpackage package-operator -S package-operator-system --exclude-types Event'

# install first PKO version with pluralized CRDs to create broken upgrade
kubectl apply -f https://github.com/package-operator/package-operator/releases/download/v1.7.0/self-bootstrap-job.yaml

# you should now have 2 ClusterObjectSets under the package-operator ClusterObjectDeployment and adoption progress is halted after 2 or 3 objects

# run bootstrap job from PR code (referenced image is the v1.7.0 PKO package )
go run ./cmd/package-operator-manager -self-bootstrap=quay.io/package-operator/package-operator-package@sha256:9b74d89d189f659e2d440b722991d26ff193bea7e6731a71099518084a81439d --namespace package-operator-system
```