### PR TITLE
bump k8s-docgen dependency to 0.6.0

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -56,7 +56,7 @@ const (
 	golangciLintVersion  = "1.53.2"
 	craneVersion         = "0.15.2"
 	kindVersion          = "0.19.0"
-	k8sDocGenVersion     = "0.5.1"
+	k8sDocGenVersion     = "0.6.0"
 	helmVersion          = "3.12.0"
 
 	coverProfilingMinGoVersion = "1.20.0"


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
The new k8s-docgen release contains fixed that stop it from generating
`namespace: default` into examples of cluster scoped objects 🎉.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
