### PR TITLE
Fix adoption not patching revision

### DIFF
--- a/apis/core/v1alpha1/commonobjectset_types.go
+++ b/apis/core/v1alpha1/commonobjectset_types.go
@@ -8,6 +8,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// Revision annotations holds a revision generation number to order ObjectSets.
+const ObjectSetRevisionAnnotation = "package-operator.run/revision"
+
 // Specifies the lifecycle state of the ObjectSet.
 type ObjectSetLifecycleState string
 

--- a/internal/controllers/objectsets/objectsetphases_reconciler.go
+++ b/internal/controllers/objectsets/objectsetphases_reconciler.go
@@ -275,6 +275,10 @@ func (r *objectSetPhasesReconciler) isObjectSetInTransition(
 	objectSet genericObjectSet,
 	controllerOf []corev1alpha1.ControlledObjectReference,
 ) bool {
+	if objectSet.IsArchived() {
+		return false
+	}
+
 	controlledIndex := map[corev1alpha1.ControlledObjectReference]struct{}{}
 	for _, controlled := range controllerOf {
 		controlledIndex[controlled] = struct{}{}

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -792,11 +792,6 @@ func (c *defaultAdoptionChecker) isControlledByPreviousRevision(
 	return false
 }
 
-const (
-	// Revision annotations holds a revision generation number to order ObjectSets.
-	revisionAnnotation = "package-operator.run/revision"
-)
-
 // Retrieves the revision number from a well-known annotation on the given object.
 func getObjectRevision(obj client.Object) (int64, error) {
 	a := obj.GetAnnotations()
@@ -804,11 +799,11 @@ func getObjectRevision(obj client.Object) (int64, error) {
 		return 0, nil
 	}
 
-	if len(a[revisionAnnotation]) == 0 {
+	if len(a[corev1alpha1.ObjectSetRevisionAnnotation]) == 0 {
 		return 0, nil
 	}
 
-	return strconv.ParseInt(a[revisionAnnotation], 10, 64)
+	return strconv.ParseInt(a[corev1alpha1.ObjectSetRevisionAnnotation], 10, 64)
 }
 
 // Stores the revision number in a well-known annotation on the given object.
@@ -817,6 +812,6 @@ func setObjectRevision(obj client.Object, revision int64) {
 	if a == nil {
 		a = map[string]string{}
 	}
-	a[revisionAnnotation] = fmt.Sprintf("%d", revision)
+	a[corev1alpha1.ObjectSetRevisionAnnotation] = fmt.Sprintf("%d", revision)
 	obj.SetAnnotations(a)
 }

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -511,7 +511,7 @@ func TestPhaseReconciler_reconcileObject_update(t *testing.T) {
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					revisionAnnotation: "3",
+					corev1alpha1.ObjectSetRevisionAnnotation: "3",
 				},
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
@@ -557,7 +557,7 @@ func TestPhaseReconciler_desiredObject(t *testing.T) {
 			"kind": "test",
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					revisionAnnotation: "5",
+					corev1alpha1.ObjectSetRevisionAnnotation: "5",
 				},
 				"labels": map[string]interface{}{
 					DynamicCacheLabel: "True",
@@ -599,7 +599,7 @@ func TestPhaseReconciler_desiredObject_defaultsNamespace(t *testing.T) {
 			"kind": "test",
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					revisionAnnotation: "5",
+					corev1alpha1.ObjectSetRevisionAnnotation: "5",
 				},
 				"labels": map[string]interface{}{
 					DynamicCacheLabel: "True",
@@ -650,7 +650,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							revisionAnnotation: "15",
+							corev1alpha1.ObjectSetRevisionAnnotation: "15",
 						},
 					},
 				},
@@ -706,7 +706,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							revisionAnnotation: "100",
+							corev1alpha1.ObjectSetRevisionAnnotation: "100",
 						},
 					},
 				},
@@ -766,7 +766,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							revisionAnnotation: "100",
+							corev1alpha1.ObjectSetRevisionAnnotation: "100",
 						},
 					},
 				},

--- a/internal/ownerhandling/annotation.go
+++ b/internal/ownerhandling/annotation.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
 
 var _ ownerStrategy = (*OwnerStrategyAnnotation)(nil)
@@ -46,7 +48,8 @@ func (s *OwnerStrategyAnnotation) OwnerPatch(owner metav1.Object) ([]byte, error
 	patchMetadata := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{
-				ownerStrategyAnnotationKey: annotations[ownerStrategyAnnotationKey],
+				ownerStrategyAnnotationKey:               annotations[ownerStrategyAnnotationKey],
+				corev1alpha1.ObjectSetRevisionAnnotation: annotations[corev1alpha1.ObjectSetRevisionAnnotation],
 			},
 		},
 	}

--- a/internal/ownerhandling/annotation_test.go
+++ b/internal/ownerhandling/annotation_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/package-operator/internal/testutil"
 )
 
@@ -498,6 +499,9 @@ func TestOwnerStrategyAnnotation_OwnerPatch(t *testing.T) {
 	t.Parallel()
 	s := NewAnnotation(testScheme)
 	obj := testutil.NewSecret()
+	obj.Annotations = map[string]string{
+		corev1alpha1.ObjectSetRevisionAnnotation: "3",
+	}
 	owner := testutil.NewConfigMap()
 	owner.Namespace = obj.Namespace
 	err := s.SetControllerReference(owner, obj)
@@ -506,5 +510,5 @@ func TestOwnerStrategyAnnotation_OwnerPatch(t *testing.T) {
 	patch, err := s.OwnerPatch(obj)
 	require.NoError(t, err)
 
-	assert.Equal(t, `{"metadata":{"annotations":{"package-operator.run/owners":"[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"name\":\"cm\",\"namespace\":\"testns\",\"uid\":\"asdfjkl\",\"controller\":true}]"}}}`, string(patch))
+	assert.Equal(t, `{"metadata":{"annotations":{"package-operator.run/owners":"[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"name\":\"cm\",\"namespace\":\"testns\",\"uid\":\"asdfjkl\",\"controller\":true}]","package-operator.run/revision":"3"}}}`, string(patch))
 }

--- a/internal/ownerhandling/native.go
+++ b/internal/ownerhandling/native.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
 
 var _ ownerStrategy = (*OwnerStrategyNative)(nil)
@@ -27,8 +29,12 @@ func NewNative(scheme *runtime.Scheme) *OwnerStrategyNative {
 }
 
 func (s *OwnerStrategyNative) OwnerPatch(owner metav1.Object) ([]byte, error) {
+	annotations := owner.GetAnnotations()
 	patchMetadata := map[string]interface{}{
 		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				corev1alpha1.ObjectSetRevisionAnnotation: annotations[corev1alpha1.ObjectSetRevisionAnnotation],
+			},
 			"ownerReferences": owner.GetOwnerReferences(),
 		},
 	}

--- a/internal/ownerhandling/native_test.go
+++ b/internal/ownerhandling/native_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/package-operator/internal/testutil"
 )
 
@@ -190,6 +191,9 @@ func TestOwnerStrategyNative_OwnerPatch(t *testing.T) {
 	t.Parallel()
 	s := NewNative(testScheme)
 	obj := testutil.NewSecret()
+	obj.Annotations = map[string]string{
+		corev1alpha1.ObjectSetRevisionAnnotation: "3",
+	}
 	owner := testutil.NewConfigMap()
 	owner.Namespace = obj.Namespace
 	err := s.SetControllerReference(owner, obj)
@@ -198,5 +202,5 @@ func TestOwnerStrategyNative_OwnerPatch(t *testing.T) {
 	patch, err := s.OwnerPatch(obj)
 	require.NoError(t, err)
 
-	assert.Equal(t, `{"metadata":{"ownerReferences":[{"apiVersion":"v1","kind":"ConfigMap","name":"cm","uid":"asdfjkl","controller":true,"blockOwnerDeletion":true}]}}`, string(patch))
+	assert.Equal(t, `{"metadata":{"annotations":{"package-operator.run/revision":"3"},"ownerReferences":[{"apiVersion":"v1","kind":"ConfigMap","name":"cm","uid":"asdfjkl","controller":true,"blockOwnerDeletion":true}]}}`, string(patch))
 }

--- a/magefile.go
+++ b/magefile.go
@@ -56,7 +56,7 @@ const (
 	golangciLintVersion  = "1.53.2"
 	craneVersion         = "0.15.2"
 	kindVersion          = "0.19.0"
-	k8sDocGenVersion     = "0.5.1"
+	k8sDocGenVersion     = "0.6.0"
 	helmVersion          = "3.12.0"
 
 	coverProfilingMinGoVersion = "1.20.0"


### PR DESCRIPTION
### Summary
Package Operator relies on a revision annotation to ensure ObjectSets can negotiate ownership and don't fight over a resource.

This annotation MUST be updated at the same time the owner annotation is or it might be reset by the next reconcilation.

Making package-operator auto-adopt it's own object causes this to surface, although it might have been responsible for triggering other edge-case issues.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
