### PR TITLE
Set hypershift isolation label

### DIFF
--- a/config/packages/remote-phase/.test-fixtures/namespace-scope/package-operator-remote-phase-manager.Deployment.yaml
+++ b/config/packages/remote-phase/.test-fixtures/namespace-scope/package-operator-remote-phase-manager.Deployment.yaml
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: package-operator-remote-phase-manager
+        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       containers:
       - args:

--- a/config/packages/remote-phase/package-operator-remote-phase-manager.Deployment.yaml.gotmpl
+++ b/config/packages/remote-phase/package-operator-remote-phase-manager.Deployment.yaml.gotmpl
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: package-operator-remote-phase-manager
+        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       containers:
       - args:


### PR DESCRIPTION
### Summary
Adds labels to allow network access within the HyperShift environment.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
