### PR TITLE
make (default)ImageOrg in magefile truly configurable

### DIFF
--- a/config/self-bootstrap-job.yaml.tpl
+++ b/config/self-bootstrap-job.yaml.tpl
@@ -44,8 +44,8 @@ spec:
       serviceAccountName: package-operator
       containers:
       - name: package-operator
-        image: quay.io/package-operator/package-operator-manager:latest
-        args: ["-self-bootstrap=quay.io/package-operator/package-operator-package:latest"]
+        image: "##pko-manager-image##"
+        args: ["-self-bootstrap=##pko-package-image##"]
         env:
         - name: PKO_REGISTRY_HOST_OVERRIDES
           value: "##registry-overrides##"


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
test using 
```bash
./mage dev:teardown
IMAGE_ORG=eef-freef.io/sbubby ./mage dev:deploy

export KUBECONFIG=$PWD/.cache/dev-env/kubeconfig.yaml
kubectl get deployment -n package-operator-system package-operator-manager -o yaml \
  | yq '.spec.template.spec.containers[0].image'
# should output something like:
# eeef-freef.io/sbubby/package-operator-manager@sha256:e8d3ed5dd738dc7820f5a05bc8b4ae083686efd85827f7f821ae11f9272ba9c3
```
