### PR TITLE
MTSRE-1454 fix HTTP(S) proxy configuration coming from in-cluster objects

### DIFF
--- a/cmd/package-operator-manager/bootstrap/bootstrap.go
+++ b/cmd/package-operator-manager/bootstrap/bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
-	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +60,7 @@ func (b *Bootstrapper) Bootstrap(ctx context.Context, runManager func(ctx contex
 	ctx = logr.NewContext(ctx, b.log)
 	log := b.log
 
-	if err := proxy.RestartPKOWithEnvvarsIfNeeded(log, unix.Exec, b.GetEnvironment()); err != nil {
+	if err := proxy.RestartPKOWithEnvvarsIfNeeded(log, b.GetEnvironment()); err != nil {
 		return err
 	}
 
@@ -89,7 +88,7 @@ func (b *Bootstrapper) bootstrap(ctx context.Context, runManager func(ctx contex
 	ctx, cancel := context.WithCancel(ctx)
 	go b.cancelWhenPackageAvailable(ctx, cancel)
 
-	// TODO(erdii): investigate if it would make sense to stop using envvars and instead go through a central configuration facility (like opts?)
+	// TODO(jgwosdz): investigate if it would make sense to stop using envvars and instead go through a central configuration facility (like opts?)
 
 	// Force Adoption of objects during initial bootstrap to take ownership of
 	// CRDs, Namespace, ServiceAccount and ClusterRoleBinding.

--- a/cmd/package-operator-manager/bootstrap/proxy/proxy.go
+++ b/cmd/package-operator-manager/bootstrap/proxy/proxy.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+)
+
+const (
+	httpProxyVar  = "HTTP_PROXY"
+	httpsProxyVar = "HTTPS_PROXY"
+	noProxyVar    = "NO_PROXY"
+)
+
+// typically `unix.Exec` but configurable to make code testable
+// https://pkg.go.dev/golang.org/x/sys/unix#Exec
+type ExecveFunc func(argv0 string, argv []string, envv []string) error
+
+func RestartPKOWithEnvvarsIfNeeded(log logr.Logger, execve ExecveFunc, env *manifestsv1alpha1.PackageEnvironment) error {
+	if env.Proxy == nil {
+		log.Info("no proxy configured via PackageEnvironment")
+		// no restart needed
+		return nil
+	}
+
+	vars := proxyVars{
+		httpProxy:  os.Getenv(httpProxyVar),
+		httpsProxy: os.Getenv(httpsProxyVar),
+		noProxy:    os.Getenv(noProxyVar),
+	}
+
+	if !vars.differentFrom(*env.Proxy) {
+		log.Info("proxy settings in environment variables match those in PackageEnvironment config")
+		// no restart needed
+		return nil
+	}
+
+	vars.httpProxy = env.Proxy.HTTPProxy
+	vars.httpsProxy = env.Proxy.HTTPSProxy
+	vars.noProxy = env.Proxy.NoProxy
+
+	log.Info("proxy settings in environment variables do not match those in PackageEnvironment config")
+	log.Info("restarting with updated proxy envvars")
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+
+	return execve(executable, os.Args, vars.mergeTo(os.Environ()))
+}
+
+// small helper struct to make code readable/testable.
+type proxyVars struct {
+	httpProxy, httpsProxy, noProxy string
+}
+
+// helper to compare against proxy object from PackageEnvironment.
+func (pv proxyVars) differentFrom(proxy manifestsv1alpha1.PackageEnvironmentProxy) bool {
+	return pv.httpProxy != proxy.HTTPProxy ||
+		pv.httpsProxy != proxy.HTTPSProxy ||
+		pv.noProxy != proxy.NoProxy
+}
+
+// merges proxy envvars with environ kv-string slice (overriding pre-existing variables) and returns the result.
+func (pv proxyVars) mergeTo(environ []string) []string {
+	merged := []string{}
+
+	// copy all variables we don't override into result
+	for _, kvstr := range environ {
+		// don't copy proxy envvars
+		if strings.HasPrefix(kvstr, fmt.Sprintf("%s=", httpProxyVar)) ||
+			strings.HasPrefix(kvstr, fmt.Sprintf("%s=", httpsProxyVar)) ||
+			strings.HasPrefix(kvstr, fmt.Sprintf("%s=", noProxyVar)) {
+			continue
+		}
+
+		merged = append(merged, kvstr)
+	}
+
+	// add proxy envvars and return result
+	return append(merged,
+		fmt.Sprintf("%s=%s", httpProxyVar, pv.httpProxy),
+		fmt.Sprintf("%s=%s", httpsProxyVar, pv.httpsProxy),
+		fmt.Sprintf("%s=%s", noProxyVar, pv.noProxy),
+	)
+}

--- a/cmd/package-operator-manager/bootstrap/proxy/proxy_test.go
+++ b/cmd/package-operator-manager/bootstrap/proxy/proxy_test.go
@@ -1,0 +1,281 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+)
+
+func TestRestartPKOWithEnvvarsIfNeeded(t *testing.T) {
+	t.Parallel()
+
+	log := testr.New(t)
+
+	// nothing should happen and nil functions should not be called when env.Proxy is empty (which means that no proxy is configured in the cluster)
+	// TODO(jgwosdz): there is an edge case where PKO was started with envvars that configure a proxy but no proxy is configured in the cluster. Should pko then strip this proxy from the env and restart itself or should it just keep running with proxy settings?
+	t.Run("env.Proxy_IsNil", func(t *testing.T) {
+		t.Parallel()
+
+		var err error
+		require.NotPanics(t, func() {
+			err = restartPKOWithEnvvarsIfNeeded(log, nil, nil, nil, &manifestsv1alpha1.PackageEnvironment{
+				Proxy: nil,
+			})
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("env.ProxyEqualsOsEnv", func(t *testing.T) {
+		t.Parallel()
+
+		httpProxy := "http://http-proxy"
+		httpsProxy := "http://https-proxy"
+		noProxy := "http://no-proxy"
+
+		getenv := mockGetenv(map[string]string{
+			httpProxyVar:  httpProxy,
+			httpsProxyVar: httpsProxy,
+			noProxyVar:    noProxy,
+		})
+
+		apiEnv := &manifestsv1alpha1.PackageEnvironment{
+			Proxy: &manifestsv1alpha1.PackageEnvironmentProxy{
+				HTTPProxy:  httpProxy,
+				HTTPSProxy: httpsProxy,
+				NoProxy:    noProxy,
+			},
+		}
+
+		var err error
+		require.NotPanics(t, func() {
+			err = restartPKOWithEnvvarsIfNeeded(log, nil, getenv, nil, apiEnv)
+		})
+		require.NoError(t, err)
+	})
+
+	{
+		mockedGetenv := mockGetenv(map[string]string{
+			httpProxyVar:  "",
+			httpsProxyVar: "",
+			noProxyVar:    "",
+		})
+
+		expectedEnv := map[string]string{
+			httpProxyVar:  "http://http-proxy",
+			httpsProxyVar: "http://https-proxy",
+			noProxyVar:    "http://no-proxy",
+		}
+
+		apiEnv := &manifestsv1alpha1.PackageEnvironment{
+			Proxy: &manifestsv1alpha1.PackageEnvironmentProxy{
+				HTTPProxy:  expectedEnv[httpProxyVar],
+				HTTPSProxy: expectedEnv[httpsProxyVar],
+				NoProxy:    expectedEnv[noProxyVar],
+			},
+		}
+
+		t.Run("env.ProxyDiffersOsEnvButResolvingExecutableErrs", func(t *testing.T) {
+			t.Parallel()
+
+			errTest := errors.New("resolving executable") //nolint:goerr113
+			mockedExecutable := mockExecutable("/irrelevant", errTest)
+
+			var err error
+			require.NotPanics(t, func() {
+				err = restartPKOWithEnvvarsIfNeeded(log, nil, mockedGetenv, mockedExecutable, apiEnv)
+			})
+			require.ErrorIs(t, err, errTest)
+		})
+
+		t.Run("env.ProxyDiffersOsEnv", func(t *testing.T) {
+			t.Parallel()
+
+			expectedExecutablePath := "/random/path/for/testing"
+			mockedExecutable := mockExecutable(expectedExecutablePath, nil)
+
+			execveCalled := false
+			execve := func(argv0 string, args []string, env []string) error {
+				execveCalled = true
+
+				assert.Equal(t, argv0, expectedExecutablePath)
+				assert.Equal(t, reflect.DeepEqual(args, os.Args), true)
+
+				envMap, err := parseEnvSlice(env)
+				require.NoError(t, err)
+
+				// assert that proxy envvars would be passed to execve
+				for expectedKey, expectedValue := range expectedEnv {
+					assert.Equal(t, envMap[expectedKey], expectedValue,
+						"proxy envvars should be equal",
+						"actual", envMap[expectedKey],
+						"expected", expectedValue)
+				}
+
+				return nil
+			}
+
+			var err error
+			require.NotPanics(t, func() {
+				err = restartPKOWithEnvvarsIfNeeded(log, execve, mockedGetenv, mockedExecutable, apiEnv)
+			})
+			require.NoError(t, err)
+			assert.Equal(t, execveCalled, true)
+		})
+	}
+}
+
+func TestProxyVarsDifferentFrom(t *testing.T) {
+	t.Parallel()
+
+	pv := proxyVars{
+		httpProxy:  "foo",
+		httpsProxy: "bar",
+		noProxy:    "baz",
+	}
+
+	tcases := []struct {
+		proxy    manifestsv1alpha1.PackageEnvironmentProxy
+		expected bool
+	}{
+		{
+			proxy: manifestsv1alpha1.PackageEnvironmentProxy{
+				HTTPProxy:  "foo",
+				HTTPSProxy: "bar",
+				NoProxy:    "baz",
+			},
+			expected: false,
+		},
+		{
+			proxy: manifestsv1alpha1.PackageEnvironmentProxy{
+				HTTPProxy:  "http",
+				HTTPSProxy: "https",
+				NoProxy:    "no",
+			},
+			expected: true,
+		},
+	}
+
+	for i := range tcases {
+		tc := tcases[i]
+		assert.Equal(t, pv.differentFrom(tc.proxy), tc.expected)
+	}
+}
+
+func TestProxyVarsMergeTo(t *testing.T) {
+	t.Parallel()
+
+	pv := proxyVars{
+		httpProxy:  "foo",
+		httpsProxy: "bar",
+		noProxy:    "baz",
+	}
+
+	tcases := []struct {
+		env      []string
+		expected []string
+	}{
+		{
+			env: []string{"old_var=val"},
+			expected: []string{
+				"old_var=val",
+				fmt.Sprintf("%s=%s", httpProxyVar, pv.httpProxy),
+				fmt.Sprintf("%s=%s", httpsProxyVar, pv.httpsProxy),
+				fmt.Sprintf("%s=%s", noProxyVar, pv.noProxy),
+			},
+		},
+		{
+			env: []string{fmt.Sprintf("%s=old-proxy", httpProxyVar), "old_var=val"},
+			expected: []string{
+				"old_var=val",
+				fmt.Sprintf("%s=%s", httpProxyVar, pv.httpProxy),
+				fmt.Sprintf("%s=%s", httpsProxyVar, pv.httpsProxy),
+				fmt.Sprintf("%s=%s", noProxyVar, pv.noProxy),
+			},
+		},
+	}
+
+	for i := range tcases {
+		tc := tcases[i]
+
+		assert.Equal(t, reflect.DeepEqual(pv.mergeTo(tc.env), tc.expected), true)
+	}
+}
+
+// TEST HELPERS BELOW
+
+var errSplitEnv = errors.New("splitting entry into key and value")
+
+// Does not check for duplicate entries. Last entry wins!
+func parseEnvSlice(slice []string) (map[string]string, error) {
+	env := map[string]string{}
+
+	for _, entry := range slice {
+		kv := strings.SplitN(entry, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("%w: %s, %+v", errSplitEnv, entry, kv)
+		}
+		env[kv[0]] = kv[1]
+	}
+	return env, nil
+}
+
+func mockExecutable(executable string, err error) func() (string, error) {
+	return func() (string, error) {
+		return executable, err
+	}
+}
+
+func mockGetenv(env map[string]string) getenvFn {
+	return func(key string) string {
+		return env[key]
+	}
+}
+
+func TestHelperParseEnvSlice(t *testing.T) {
+	t.Parallel()
+
+	tcases := []struct {
+		slice    []string
+		expected map[string]string
+		errIs    error
+	}{
+		{
+			slice: []string{"A=1", "B=2", "C=three"},
+			expected: map[string]string{
+				"A": "1",
+				"B": "2",
+				"C": "three",
+			},
+		},
+		{
+			// not correctly formatted k=v pair
+			slice: []string{"A:1"},
+			errIs: errSplitEnv,
+		},
+	}
+
+	for i := range tcases {
+		tc := tcases[i]
+		actual, err := parseEnvSlice(tc.slice)
+		if tc.errIs != nil {
+			require.ErrorIs(t, err, tc.errIs)
+		} else {
+			require.NoError(t, err)
+		}
+		for expectedKey, expectedValue := range tc.expected {
+			assert.Equal(t, actual[expectedKey], expectedValue,
+				"actual[expectedKey] and expectedValue should be equal",
+				"actual", actual[expectedKey],
+				"expected", expectedValue)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/zap v1.25.0
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/mod v0.12.0
+	golang.org/x/sys v0.11.0
 	gotest.tools/v3 v3.5.0
 	k8s.io/api v0.28.1
 	k8s.io/apiextensions-apiserver v0.28.1
@@ -127,7 +128,6 @@ require (
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect


### PR DESCRIPTION
Go caches proxy settings that are read from the envvars `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY. This means that our bootstrap procedure:
1. detect if running in kube or openshift
2. (in openshift) detect if cluster proxy settings are configured and override bootstrap process proxy environment variables
3. assume that from now on all http/https calls that are not excluded via `NO_PROXY` will go through the configured proxy

will not work because the calls to the kubernetes api have already read and cached the envvars in go code.

The workaround is:
- lookup proxy settings from cluster and environment variables
- if they are different: merge proxy settings into environment variables and replace current pko process with a new instance by using unix.Exec (execve)

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
