### PR TITLE
Revert back to creating CRDs before bootstrap instead of applying the…

### DIFF
--- a/cmd/package-operator-manager/bootstrap/init.go
+++ b/cmd/package-operator-manager/bootstrap/init.go
@@ -253,7 +253,8 @@ func (init *initializer) ensureCRDs(ctx context.Context, crds []unstructured.Uns
 		crd.SetLabels(labels)
 
 		log.Info("ensuring CRD", "name", crd.GetName())
-		if err := init.client.Patch(ctx, crd, client.Apply, client.FieldOwner(controllers.FieldOwner), client.ForceOwnership); err != nil {
+		if err := init.client.Create(ctx, crd); err != nil &&
+			!errors.IsAlreadyExists(err) {
 			return err
 		}
 	}

--- a/cmd/package-operator-manager/bootstrap/init_test.go
+++ b/cmd/package-operator-manager/bootstrap/init_test.go
@@ -410,7 +410,10 @@ func Test_initializer_ensureCRDs(t *testing.T) {
 	crd := unstructured.Unstructured{}
 	crd.SetGroupVersionKind(crdGK.WithVersion("v1"))
 
-	c.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	c.On("Create", mock.Anything, mock.Anything, mock.Anything).
+		Once().
+		Return(k8serrors.NewAlreadyExists(schema.GroupResource{}, ""))
+	c.On("Create", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
 	crds := []unstructured.Unstructured{crd, crd}


### PR DESCRIPTION
…m because the apply removes all owner references at that point in time.

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->




### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
