### PR TITLE
Set controller-runtime leader election namespace to namespace namespa…

### DIFF
--- a/cmd/package-operator-manager/components/components.go
+++ b/cmd/package-operator-manager/components/components.go
@@ -103,6 +103,7 @@ func ProvideManager(
 		}),
 		LeaderElectionResourceLock: "leases",
 		LeaderElection:             opts.EnableLeaderElection,
+		LeaderElectionNamespace:    opts.Namespace,
 		LeaderElectionID:           "8a4hp84a6s.package-operator-lock",
 		MapperProvider:             apiutil.NewDynamicRESTMapper,
 		Cache: cache.Options{


### PR DESCRIPTION
…ce option.

This allows one to run the package-operator-manager out of cluster. (Mostly while developing.)

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
