### PR TITLE
Refactor HyperShift integration tests for re-run

### DIFF
--- a/config/examples/packages/test-stub.yaml
+++ b/config/examples/packages/test-stub.yaml
@@ -2,8 +2,7 @@ apiVersion: package-operator.run/v1alpha1
 kind: Package
 metadata:
   name: test-stub
-  annotations:
-    package-operator.run/test-stub-image: "quay.io/package-operator/test-stub:v1.0.0-47-g3405dde"
-    packages.package-operator.run/chunking-strategy: EachObject
 spec:
-  image: "quay.io/package-operator/test-stub-package:v1.0.0-47-g3405dde"
+  image: "quay.io/package-operator/test-stub-package:v1.8.3-2-g293f877"
+  config:
+    testStubImage: quay.io/package-operator/test-stub:v1.8.3-2-g293f877


### PR DESCRIPTION
### Summary
This refactoring should make it easier to re-run HyperShift specific tests, because it is no longer producing an error if the hostedcluster CRD is already installed.

A command like this to just run the test you are interested in: ./mage test:packageoperatorintegrationrun
TestHyperShift/ObjectSetOrphanCascadeDeletion

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
