### PR TITLE
[MTSRE-1426] Fix bootstrap controller shutdown when context is cancelled

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -74,12 +74,18 @@ func (m *Manager) Init(ctx context.Context, sinks []Sinker) error {
 func (m *Manager) Start(ctx context.Context) error {
 	t := time.NewTicker(environmentProbeInterval)
 	defer t.Stop()
-	for range t.C {
-		if err := m.do(ctx); err != nil {
-			return err
+
+	// periodically re-probe environment until context is closed
+	for {
+		select {
+		case <-t.C:
+			if err := m.do(ctx); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 func (m *Manager) do(ctx context.Context) error {


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Cancelling the manager context resulted in a failed shutdown because the environment manager runnable did not stop within the shutdown deadline of 30 seconds.
I refactored the re-probe ticker code to respect context cancelling.
Now the bootstrapper will properly shut down when the installed PKO becomes available.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
