### PR TITLE
[MTSRE-1471] Fix race condition in objectset handover integration tes…

### DIFF
--- a/integration/package-operator/objectset_test.go
+++ b/integration/package-operator/objectset_test.go
@@ -497,13 +497,6 @@ func runObjectSetHandoverTest(t *testing.T, namespace, class string) {
 	require.NotNil(t, availableCond, "Available condition is expected to be reported")
 	assert.Equal(t, "ProbeFailure", availableCond.Reason)
 
-	// expect cm-1 to still be present and now controlled by Rev2.
-	require.NoError(t, Client.Get(ctx, client.ObjectKey{
-		Name: cm1.Name, Namespace: objectSetRev1.Namespace,
-	}, currentCM1))
-
-	assertControllerNameHasPrefix(t, objectSetRev2.Name, currentCM1)
-
 	// expect cm-2 to still be present.
 	require.NoError(t, Client.Get(ctx, client.ObjectKey{
 		Name: cm2.Name, Namespace: objectSetRev2.Namespace,
@@ -518,6 +511,13 @@ func runObjectSetHandoverTest(t *testing.T, namespace, class string) {
 	// wait for Revision 1 to report "InTransition" (needed to ensure that the next assertions are not racy)
 	require.NoError(t,
 		Waiter.WaitForCondition(ctx, objectSetRev1, corev1alpha1.ObjectSetInTransition, metav1.ConditionTrue))
+
+	// expect cm-1 to still be present and now controlled by Rev2.
+	require.NoError(t, Client.Get(ctx, client.ObjectKey{
+		Name: cm1.Name, Namespace: objectSetRev1.Namespace,
+	}, currentCM1))
+
+	assertControllerNameHasPrefix(t, objectSetRev2.Name, currentCM1)
 
 	// expect only cm-2 to be reported under "ControllerOf" in revision 1
 	require.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(objectSetRev1), objectSetRev1))


### PR DESCRIPTION
…ts by moving  assertions that should happen after the new object set becomes available after the code that waits for it to become available.

Previous to this fix, testing a cpu-starved PKO would often result in a failure when the tests asserted that object had already fully been handed over, when pko only had reported that the new object set was already created and unavailable due to failing probes on an already existing object.

```
    hypershift_test.go:91:
        	Error Trace:	/home/erdii/projects/redhat/github.com/package-operator/package-operator/integration/package-operator/objectset_test.go:763
        	           				/home/erdii/projects/redhat/github.com/package-operator/package-operator/integration/package-operator/objectset_test.go:505
        	           				/home/erdii/projects/redhat/github.com/package-operator/package-operator/integration/package-operator/hypershift_test.go:91
        	Error:      	Should be true
        	Test:       	TestHyperShift/ObjectSetHandover
        	Messages:   	controller name of default-test-hc/cm-1 not prefixed with test-rev2
--- FAIL: TestHyperShift (74.36s)
    --- PASS: TestHyperShift/HyperShift_Installation (1.11s)
    --- PASS: TestHyperShift/ObjectSetSetupPauseTeardown (17.16s)
    --- FAIL: TestHyperShift/ObjectSetHandover (2.04s)
FAIL
```
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information
Supersedes https://github.com/package-operator/package-operator/pull/467. Thanks Alex for the review and making me think again. :)

<!-- Report any other relevant details below -->
Reproducing the bug can by done by patching the pko deployment template file and removing pko package test-fixtures prior to running the integration tests on main.
Validating the fix can be done by then checking out the fix (while keeping the patched deployment template), and rerunning integration tests (with a cluster teardown in between).

```bash
# removing package test fixtures
rm -rf packages/package-operator/.test-fixtures

# patching the deployment template:
git apply <(cat <<EOF
diff --git a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
index 72bc06b..6ff9b6e 100644
--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -93,10 +93,10 @@ spec:
         # default resources
         resources:
           limits:
-            cpu: 200m
+            cpu: 10m
             memory: 400Mi
           requests:
-            cpu: 200m
+            cpu: 10m
             memory: 300Mi
 {{- end}}
 {{- if hasKey . "environment" }}
EOF
)

# recreating cluster and running integration tests:
./mage dev:teardown dev:integration
```

