### PR TITLE
[MTSRE-1471] Fix orphaning of objects owned by (Cluster)ObjectSets and their phases

### DIFF
--- a/cmd/remote-phase-manager/main.go
+++ b/cmd/remote-phase-manager/main.go
@@ -190,9 +190,9 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 			},
 		})
 
-	// Create a client that does not cache resources cluster-wide.
-	uncachedClient, err := client.New(
-		mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
+	// Create a remote client that does not cache resources cluster-wide.
+	uncachedTargetClient, err := client.New(
+		targetCfg, client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
 	if err != nil {
 		return fmt.Errorf("unable to set up uncached client: %w", err)
 	}
@@ -201,7 +201,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 
 	if err = objectsetphases.NewMultiClusterObjectSetPhaseController(
 		ctrl.Log.WithName("controllers").WithName("ObjectSetPhase"),
-		mgr.GetScheme(), dc, uncachedClient,
+		mgr.GetScheme(), dc, uncachedTargetClient,
 		opts.class, managementClusterClient,
 		targetClient, targetMapper,
 	).SetupWithManager(mgr); err != nil {
@@ -212,7 +212,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 		// Only start the Cluster-Scoped controller, when we are running cluster scoped.
 		if err = objectsetphases.NewMultiClusterClusterObjectSetPhaseController(
 			ctrl.Log.WithName("controllers").WithName("ClusterObjectSetPhase"),
-			mgr.GetScheme(), dc, uncachedClient,
+			mgr.GetScheme(), dc, uncachedTargetClient,
 			opts.class, managementClusterClient,
 			targetClient, targetMapper,
 		).SetupWithManager(mgr); err != nil {

--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -33,6 +33,7 @@ type dynamicCache interface {
 
 type ownerStrategy interface {
 	IsController(owner, obj metav1.Object) bool
+	IsOwner(owner, obj metav1.Object) bool
 	ReleaseController(obj metav1.Object)
 	RemoveOwner(owner, obj metav1.Object)
 	SetOwnerReference(owner, obj metav1.Object) error

--- a/internal/controllers/objectsetphases/objectsetphase_reconciler.go
+++ b/internal/controllers/objectsetphases/objectsetphase_reconciler.go
@@ -128,7 +128,7 @@ func (r *objectSetPhaseReconciler) Reconcile(
 func (r *objectSetPhaseReconciler) Teardown(
 	ctx context.Context, objectSetPhase genericObjectSetPhase,
 ) (cleanupDone bool, err error) {
-	// objectSetPhase is deleted with the `orphan` cascade option, so we don't delete the owned objects
+	// objectSetPhase is deleted with the `orphan` cascade option, so we don't need to delete the owned objects.
 	if controllerutil.ContainsFinalizer(objectSetPhase.ClientObject(), "orphan") {
 		return true, nil
 	}

--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -125,7 +125,7 @@ func newGenericObjectSetController(
 			},
 		),
 		newObjectSetRemotePhaseReconciler(
-			client, scheme, newObjectSetPhase),
+			client, uncachedClient, scheme, newObjectSetPhase),
 		controllers.NewPreviousRevisionLookup(
 			scheme, func(s *runtime.Scheme) controllers.PreviousObjectSet {
 				return newObjectSet(s)
@@ -203,7 +203,7 @@ func (c *GenericObjectSetController) Reconcile(
 		}
 
 		if !objectSet.IsArchived() {
-			// Object was deleted an not just archived.
+			// Object was deleted and not just archived.
 			// no way to update status now :)
 			return res, nil
 		}
@@ -347,7 +347,7 @@ func (c *GenericObjectSetController) handleDeletionAndArchival(
 		return err
 	}
 
-	// Needs to be called _after_ FreeCacheAndFinalizer,
+	// Needs to be called _after_ FreeCacheAndRemoveFinalizer,
 	// because .Update is loading new state into objectSet, overriding changes to conditions.
 	if objectSet.IsArchived() {
 		meta.SetStatusCondition(objectSet.GetConditions(), metav1.Condition{

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -85,10 +85,12 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 	t.Run("already gone", func(t *testing.T) {
 		t.Parallel()
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		preflightChecker := &preflightCheckerMock{}
 		r := &PhaseReconciler{
 			dynamicCache:     dynamicCache,
+			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
 		}
@@ -105,7 +107,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			On("Watch", mock.Anything, ownerObj, mock.Anything).
 			Return(nil)
 
-		dynamicCache.
+		uncachedClient.
 			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(errors.NewNotFound(schema.GroupResource{}, ""))
 
@@ -124,17 +126,20 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		require.NoError(t, err)
 		assert.True(t, done)
 		dynamicCache.AssertCalled(t, "Watch", mock.Anything, ownerObj, mock.Anything)
+		uncachedClient.AssertExpectations(t)
 	})
 
 	t.Run("already gone on delete", func(t *testing.T) {
 		t.Parallel()
 		testClient := testutil.NewClient()
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		preflightChecker := &preflightCheckerMock{}
 		r := &PhaseReconciler{
 			writer:           testClient,
 			dynamicCache:     dynamicCache,
+			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
 		}
@@ -155,7 +160,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			On("Watch", mock.Anything, ownerObj, mock.Anything).
 			Return(nil)
 		currentObj := &unstructured.Unstructured{}
-		dynamicCache.
+		uncachedClient.
 			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				out := args.Get(2).(*unstructured.Unstructured)
@@ -182,6 +187,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		require.NoError(t, err)
 		assert.True(t, done)
 		dynamicCache.AssertCalled(t, "Watch", mock.Anything, ownerObj, mock.Anything)
+		uncachedClient.AssertExpectations(t)
 
 		// Ensure that IsController was called with currentObj and not desiredObj.
 		// If checking desiredObj, IsController will _always_ return true, which could lead to really nasty behavior.
@@ -195,11 +201,14 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		// from the apiserver after all finalizers are handled.
 		testClient := testutil.NewClient()
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		preflightChecker := &preflightCheckerMock{}
+
 		r := &PhaseReconciler{
 			writer:           testClient,
 			dynamicCache:     dynamicCache,
+			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
 		}
@@ -221,7 +230,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			On("Watch", mock.Anything, ownerObj, mock.Anything).
 			Return(nil)
 		currentObj := &unstructured.Unstructured{}
-		dynamicCache.
+		uncachedClient.
 			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				out := args.Get(2).(*unstructured.Unstructured)
@@ -248,6 +257,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		require.NoError(t, err)
 		assert.False(t, done) // wait for delete confirm
 		dynamicCache.AssertCalled(t, "Watch", mock.Anything, ownerObj, mock.Anything)
+		uncachedClient.AssertExpectations(t)
 
 		// It's super important that we don't check ownership on desiredObj on accident, because that will always return true.
 		ownerStrategy.AssertCalled(t, "IsController", ownerObj, currentObj)
@@ -257,11 +267,13 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		t.Parallel()
 
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		testClient := testutil.NewClient()
 		preflightChecker := &preflightCheckerMock{}
 		r := &PhaseReconciler{
 			dynamicCache:     dynamicCache,
+			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			writer:           testClient,
 			preflightChecker: preflightChecker,
@@ -284,7 +296,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			On("Watch", mock.Anything, ownerObj, mock.Anything).
 			Return(nil)
 		currentObj := &unstructured.Unstructured{}
-		dynamicCache.
+		uncachedClient.
 			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				out := args.Get(2).(*unstructured.Unstructured)
@@ -296,12 +308,8 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			On("IsController", ownerObj, currentObj).
 			Return(false)
 		ownerStrategy.
-			On("RemoveOwner", ownerObj, currentObj).
+			On("IsOwner", ownerObj, currentObj).
 			Return(false)
-
-		testClient.
-			On("Update", mock.Anything, mock.Anything, mock.Anything).
-			Return(nil)
 
 		ctx := context.Background()
 		done, err := r.TeardownPhase(ctx, owner, corev1alpha1.ObjectSetTemplatePhase{
@@ -314,24 +322,26 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		require.NoError(t, err)
 		assert.True(t, done)
 		dynamicCache.AssertCalled(t, "Watch", mock.Anything, ownerObj, mock.Anything)
+		uncachedClient.AssertExpectations(t)
 
 		// It's super important that we don't check ownership on desiredObj on accident, because that will always return true.
 		ownerStrategy.AssertCalled(t, "IsController", ownerObj, currentObj)
-		ownerStrategy.AssertCalled(t, "RemoveOwner", ownerObj, currentObj)
-		testClient.AssertCalled(t, "Update", mock.Anything, currentObj, mock.Anything)
+		ownerStrategy.AssertCalled(t, "IsOwner", ownerObj, currentObj)
 	})
 
 	t.Run("external objects", func(t *testing.T) {
 		t.Parallel()
 
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		testClient := testutil.NewClient()
 
 		r := &PhaseReconciler{
-			dynamicCache:  dynamicCache,
-			ownerStrategy: ownerStrategy,
-			writer:        testClient,
+			dynamicCache:   dynamicCache,
+			uncachedClient: uncachedClient,
+			ownerStrategy:  ownerStrategy,
+			writer:         testClient,
 		}
 
 		owner := &phaseObjectOwnerMock{}
@@ -372,6 +382,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 
 		owner.AssertExpectations(t)
 		dynamicCache.AssertExpectations(t)
+		uncachedClient.AssertExpectations(t)
 		ownerStrategy.AssertExpectations(t)
 		testClient.AssertExpectations(t)
 	})
@@ -380,13 +391,15 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 		t.Parallel()
 
 		dynamicCache := &dynamicCacheMock{}
+		uncachedClient := testutil.NewClient()
 		ownerStrategy := &ownerStrategyMock{}
 		testClient := testutil.NewClient()
 
 		r := &PhaseReconciler{
-			dynamicCache:  dynamicCache,
-			ownerStrategy: ownerStrategy,
-			writer:        testClient,
+			dynamicCache:   dynamicCache,
+			ownerStrategy:  ownerStrategy,
+			uncachedClient: uncachedClient,
+			writer:         testClient,
 		}
 
 		owner := &phaseObjectOwnerMock{}
@@ -427,6 +440,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 
 		owner.AssertExpectations(t)
 		dynamicCache.AssertExpectations(t)
+		uncachedClient.AssertExpectations(t)
 		ownerStrategy.AssertExpectations(t)
 		testClient.AssertExpectations(t)
 	})

--- a/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
+++ b/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
@@ -22,6 +22,11 @@ func (m *OwnerStrategyMock) IsController(owner, obj metav1.Object) bool {
 	return args.Bool(0)
 }
 
+func (m *OwnerStrategyMock) IsOwner(owner, obj metav1.Object) bool {
+	args := m.Called(owner, obj)
+	return args.Bool(0)
+}
+
 func (m *OwnerStrategyMock) RemoveOwner(owner, obj metav1.Object) {
 	m.Called(owner, obj)
 }


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Our integration tests have a flake in `TestHyperShift/ObjectSetOrphanCascadeDeletion`, that particularly manifests when PKO is running with very limited cpu resources.

This is the error:

```
    hypershift_test.go:94: 
        	Error Trace:	/home/runner/work/package-operator/package-operator/integration/package-operator/objectset_test.go:655
        	            				/home/runner/work/package-operator/package-operator/integration/package-operator/objectset_test.go:718
        	            				/home/runner/work/package-operator/package-operator/integration/package-operator/hypershift_test.go:94
        	Error:      	Received unexpected error:
        	            	configmaps "cm" not found
        	Test:       	TestHyperShift/ObjectSetOrphanCascadeDeletion
--- FAIL: TestHyperShift (54.66s)
    --- PASS: TestHyperShift/HyperShift_Installation (1.28s)
    --- PASS: TestHyperShift/ObjectSetSetupPauseTeardown (12.13s)
    --- PASS: TestHyperShift/ObjectSetHandover (7.11s)
    --- FAIL: TestHyperShift/ObjectSetOrphanCascadeDeletion (3.07s)
``` 

Often testing works on local machines but almost consistently fails on Github Actions CI. Some example CI runs:
- https://github.com/package-operator/package-operator/actions/runs/6275096714/job/17041839924
- https://github.com/package-operator/package-operator/actions/runs/6274891997/job/17042103277
- https://github.com/package-operator/package-operator/actions/runs/6265386621/job/17014127867
- https://github.com/package-operator/package-operator/actions/runs/6260816208/job/17000743949
- https://github.com/package-operator/package-operator/actions/runs/6274891997/job/17042103277
- https://github.com/package-operator/package-operator/actions/runs/6275096714/job/17041839924


### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
- Please refer to the section `Additional Information` of #495 for a patch that significantly lowers PKO cpu limits in the development environment.
- I wrote a [gist detailing the orphaning workflow inside kubernetes](https://gist.github.com/erdii/04d967f98f5892182e988a38f0ee8182) and why we can't rely on the orphan finalizer. We MUST rely on ownerReferences on the child object pointing back to the parent. If these ownerReferences are gone, then PKO MUST NOT delete the child object because it was probably orphaned by choice.
