### PR TITLE
MTSRE-1504: Add include template function

### DIFF
--- a/internal/packages/packageloader/loader_test.go
+++ b/internal/packages/packageloader/loader_test.go
@@ -111,6 +111,7 @@ func TestLoader(t *testing.T) {
 								"annotations": map[string]interface{}{
 									"other-test-helper": "other-test-helper",
 									"test-helper":       "test-helper",
+									"include-test":      "\nKEY1: VAL1\nKEY2: VAL2",
 								},
 							},
 							"spec": map[string]interface{}{"replicas": int64(1)},

--- a/internal/packages/packageloader/package_files_template_transformer.go
+++ b/internal/packages/packageloader/package_files_template_transformer.go
@@ -59,7 +59,8 @@ func NewTemplateTransformer(tmplCtx PackageFileTemplateContext) (*PackageFileTem
 }
 
 func (t *PackageFileTemplateTransformer) TransformPackageFiles(_ context.Context, fileMap packagecontent.Files) error {
-	templ := template.New("pkg").Option("missingkey=error").Funcs(transform.SprigFuncs())
+	templ := template.New("pkg").Option("missingkey=error")
+	templ = templ.Funcs(transform.SprigFuncs(templ))
 
 	// gather all templates to allow cross-file declarations and reuse of helpers.
 	for path, content := range fileMap {

--- a/internal/packages/packageloader/testdata/_helpers.gotmpl
+++ b/internal/packages/packageloader/testdata/_helpers.gotmpl
@@ -1,1 +1,6 @@
 {{- define "test-helper" -}}test-helper{{- end -}}
+
+{{- define "include-test"}}
+key1: val1
+key2: val2
+{{- end }}

--- a/internal/packages/packageloader/testdata/deployment.yml.gotmpl
+++ b/internal/packages/packageloader/testdata/deployment.yml.gotmpl
@@ -7,5 +7,6 @@ metadata:
     package-operator.run/phase: main-stuff
     test-helper: {{ template "test-helper" }}
     other-test-helper: {{ template "other-test-helper" }}
+    include-test: {{include "include-test" . | upper | quote}}
 spec:
   replicas: 1


### PR DESCRIPTION
### Summary
This commit adds the include template helper function to evaluate template blocks into a string. This helper can be used to pipe the output of a template into other functions for manipulation.

### Change Type
New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
