### PR TITLE
MTSRE-1571: Fix YAML document split breaks PEM certs

### DIFF
--- a/internal/packages/packagecontent/topackage.go
+++ b/internal/packages/packagecontent/topackage.go
@@ -92,14 +92,17 @@ func ExtractComponentPackage(pkgMap map[string]*Package, component string) (*Pac
 	return pkg, nil
 }
 
+var splitYAMLDocumentsRegEx = regexp.MustCompile(`(?m)^---$`)
+
 func parseObjects(pkg *Package, path string, content []byte) (err error) {
 	// Trim empty starting and ending objects
 	objects := []unstructured.Unstructured{}
 
 	// Split for every included yaml document.
-	for idx, yamlDocument := range bytes.Split(bytes.Trim(content, "---\n"), []byte("---\n")) {
+
+	for idx, yamlDocument := range splitYAMLDocumentsRegEx.Split(string(bytes.Trim(content, "---\n")), -1) {
 		obj := unstructured.Unstructured{}
-		if err = yaml.Unmarshal(yamlDocument, &obj); err != nil {
+		if err = yaml.Unmarshal([]byte(yamlDocument), &obj); err != nil {
 			err = packages.ViolationError{
 				Reason:  packages.ViolationReasonInvalidYAML,
 				Details: err.Error(),

--- a/internal/packages/packageloader/loader_test.go
+++ b/internal/packages/packageloader/loader_test.go
@@ -138,6 +138,7 @@ func TestLoader(t *testing.T) {
 									"foobar-from-config": foobarValue,
 									"include-test":       "\nKEY1: VAL1\nKEY2: VAL2",
 									"fileGet":            "lorem ipsum...\n",
+									"certificate-key":    "-----BEGIN CERTIFICATE-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBj08sp5++4anG\n-----END CERTIFICATE-----\n",
 								},
 							},
 							"spec": map[string]interface{}{"replicas": int64(1)},

--- a/internal/packages/packageloader/testdata/deployment.yml.gotmpl
+++ b/internal/packages/packageloader/testdata/deployment.yml.gotmpl
@@ -11,5 +11,10 @@ metadata:
     include-test: {{include "include-test" . | upper | quote}}
     fileGet: |
       {{ getFile "_stuff.txt" }}
+    # testing that it's not split on ---
+    certificate-key: |
+      -----BEGIN CERTIFICATE-----
+      MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBj08sp5++4anG
+      -----END CERTIFICATE-----
 spec:
   replicas: 1


### PR DESCRIPTION
### Summary
When loading YAML files, we did blindly split on ---, so if someone added a PEM encoded certificate that is using ------ add start/end, we where splitting the document...

This commit changes the behavior to only split if the --- is in it's own line and there are no preceding characters.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
