### PR TITLE
Fix kubectl-package tree panic with packages with config, no tests and no required props

### DIFF
--- a/integration/kubectl-package/fixtures_test.go
+++ b/integration/kubectl-package/fixtures_test.go
@@ -21,13 +21,14 @@ func sourcePathFixture(name string) string {
 	)
 
 	return map[string]string{
-		"valid_without_config":             filepath.Join(validPackages, "without_config"),
-		"valid_with_config":                filepath.Join(validPackages, "with_config"),
-		"invalid_bad_manifest":             filepath.Join(invalidPackages, "bad_manifest"),
-		"invalid_invalid_resource_label":   filepath.Join(invalidPackages, "invalid_resource_label"),
-		"invalid_missing_lock_file":        filepath.Join(invalidPackages, "missing_lock_file"),
-		"invalid_missing_phase_annotation": filepath.Join(invalidPackages, "missing_phase_annotation"),
-		"invalid_missing_resource_gvk":     filepath.Join(invalidPackages, "missing_resource_gvk"),
+		"valid_without_config":                              filepath.Join(validPackages, "without_config"),
+		"valid_with_config":                                 filepath.Join(validPackages, "with_config"),
+		"valid_with_config_no_tests_no_required_properties": filepath.Join(validPackages, "with_config_no_tests_no_required_properties"),
+		"invalid_bad_manifest":                              filepath.Join(invalidPackages, "bad_manifest"),
+		"invalid_invalid_resource_label":                    filepath.Join(invalidPackages, "invalid_resource_label"),
+		"invalid_missing_lock_file":                         filepath.Join(invalidPackages, "missing_lock_file"),
+		"invalid_missing_phase_annotation":                  filepath.Join(invalidPackages, "missing_phase_annotation"),
+		"invalid_missing_resource_gvk":                      filepath.Join(invalidPackages, "missing_resource_gvk"),
 	}[name]
 }
 

--- a/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/README.md
+++ b/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/README.md
@@ -1,0 +1,4 @@
+# Common Test Package
+
+Package used for integration testing.
+May be installed Namespaced or Cluster scoped.

--- a/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/deployment.yaml.gotmpl
+++ b/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/deployment.yaml.gotmpl
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "test-stub-{{.package.metadata.name}}"
+{{- if eq .package.metadata.namespace ""}}
+  namespace: "{{.package.metadata.name}}"
+{{- end}}
+  annotations:
+    defaulted: {{.config.defaultedConfig}}
+  labels:
+    app: test-stub
+    instance: "{{.package.metadata.name}}"
+  annotations:
+    package-operator.run/phase: deploy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test-stub
+      instance: "{{.package.metadata.name}}"
+  template:
+    metadata:
+      labels:
+        app: test-stub
+        instance: "{{.package.metadata.name}}"
+    spec:
+      containers:
+      - name: test-stub
+        # lazy image injection
+        image: '{{index .images "test"}}'

--- a/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/external-deployment.yaml.gotmpl
+++ b/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/external-deployment.yaml.gotmpl
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "test-external-{{.package.metadata.name}}"
+  namespace: external-name
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/external: "True"

--- a/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/manifest.yaml
+++ b/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/manifest.yaml
@@ -1,0 +1,33 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: test-stub
+spec:
+  scopes:
+  - Cluster
+  - Namespaced
+  phases:
+  - name: namespace
+  - name: deploy
+  availabilityProbes:
+  - probes:
+    - condition:
+        type: Available
+        status: "True"
+    - fieldsEqual:
+        fieldA: .status.updatedReplicas
+        fieldB: .status.replicas
+    selector:
+      kind:
+        group: apps
+        kind: Deployment
+  config:
+    openAPIV3Schema:
+      properties:
+        defaultedConfig:
+          type: string
+          default: "test123"
+      type: object
+  images:
+    - name: test
+      image: something:v1.0

--- a/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/namespace.template.yaml.gotmpl
+++ b/integration/kubectl-package/testdata/packages/valid/with_config_no_tests_no_required_properties/namespace.template.yaml.gotmpl
@@ -1,0 +1,8 @@
+{{if eq .package.metadata.namespace "" -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{.package.metadata.name}}"
+  annotations:
+    package-operator.run/phase: namespace
+{{- end}}

--- a/integration/kubectl-package/tree_test.go
+++ b/integration/kubectl-package/tree_test.go
@@ -58,6 +58,19 @@ var _ = DescribeTable("tree subcommand",
 			},
 		},
 	),
+	Entry("given a path of a valid package with configuration, no tests and no required properties",
+		subCommandTestCase{
+			Args:             []string{sourcePathFixture("valid_with_config_no_tests_no_required_properties")},
+			ExpectedExitCode: 0,
+			ExpectedOutput: []string{
+				"test-stub",
+				"Package namespace/name",
+				"└── Phase deploy",
+				`\s+└── apps/v1, Kind=Deployment /test-stub-name`,
+				`\s+└── apps/v1, Kind=Deployment external-name/test-external-name \(EXTERNAL\)`,
+			},
+		},
+	),
 	Entry("using '--config-testcase' flag",
 		subCommandTestCase{
 			Args: []string{

--- a/internal/cmd/tree.go
+++ b/internal/cmd/tree.go
@@ -165,7 +165,7 @@ func (t *Tree) getTemplateContext(pkg *packagecontent.Package, cfg RenderPackage
 }
 
 func (t *Tree) getConfig(pkg *packagecontent.Package, cfg RenderPackageConfig) (map[string]any, error) {
-	var config map[string]any
+	config := map[string]any{}
 
 	switch {
 	case cfg.ConfigPath != "":


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
`kubectl-package tree` subcommand panics when dealing with a package with all the following characteristics:
- contains a configuration
- its configuration contains **no required** properties
- has no tests associated

This is the panic output:

```
$ kubectl package tree my-package
panic: assignment to entry in nil map

goroutine 1 [running]:
k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting.Default({0x101cfa1e0?, 0x0?}, 0x140004caa50)
	/Users/alcosta/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.28.3/pkg/apiserver/schema/defaulting/algorithm.go:46 +0x18c
package-operator.run/internal/packages/packageadmission.AdmitPackageConfiguration({0x101fcaf58, 0x14000671300}, 0x101fab900?, 0x0?, 0x140006061a0, 0x0?)
	/Users/alcosta/Work/devel/package-operator/sources/internal/packages/packageadmission/configuration.go:59 +0xe0
package-operator.run/internal/cmd.(*Tree).RenderPackage(0x1400066a3c0, {0x101fcaf58, 0x14000671300}, {0x16f9cf61b, 0x8}, {0x14000671500, 0x4, 0x0?})
	/Users/alcosta/Work/devel/package-operator/sources/internal/cmd/tree.go:86 +0x4b0
package-operator.run/cmd/kubectl-package/treecmd.NewCmd.func1(0x14000342000, {0x14000655cf0, 0x1, 0x10184936b?})
	/Users/alcosta/Work/devel/package-operator/sources/cmd/kubectl-package/treecmd/tree.go:40 +0x19c
github.com/spf13/cobra.(*Command).execute(0x14000342000, {0x14000655cc0, 0x1, 0x1})
	/Users/alcosta/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x658
github.com/spf13/cobra.(*Command).ExecuteC(0x14000674000)
	/Users/alcosta/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/alcosta/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/alcosta/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985
main.executeRoot(0x14000674000)
	/Users/alcosta/Work/devel/package-operator/sources/cmd/kubectl-package/main.go:43 +0xc0
reflect.Value.call({0x101c989e0?, 0x101fa38c0?, 0x1400041fb38?}, {0x1018493d3, 0x4}, {0x1400062b050, 0x1, 0x0?})
	/usr/local/go/src/reflect/value.go:596 +0x994
reflect.Value.Call({0x101c989e0?, 0x101fa38c0?, 0x8?}, {0x1400062b050?, 0x14000654901?, 0x1400062b050?})
	/usr/local/go/src/reflect/value.go:380 +0x94
go.uber.org/dig.defaultInvoker({0x101c989e0?, 0x101fa38c0?, 0x140006549a0?}, {0x1400062b050?, 0x1?, 0x101fdc420?})
	/Users/alcosta/go/pkg/mod/go.uber.org/dig@v1.17.0/container.go:238 +0x28
go.uber.org/dig.(*Scope).Invoke(0x14000146c80, {0x101c989e0, 0x101fa38c0}, {0x0, 0x0, 0x101fa3a20?})
	/Users/alcosta/go/pkg/mod/go.uber.org/dig@v1.17.0/invoke.go:160 +0x4f0
go.uber.org/dig.(*Container).Invoke(0x1400041ff28?, {0x101c989e0?, 0x101fa38c0?}, {0x0?, 0x14000084728?, 0x0?})
	/Users/alcosta/go/pkg/mod/go.uber.org/dig@v1.17.0/invoke.go:82 +0x2c
main.run()
	/Users/alcosta/Work/devel/package-operator/sources/cmd/kubectl-package/main.go:36 +0x7c
main.main()
	/Users/alcosta/Work/devel/package-operator/sources/cmd/kubectl-package/main.go:23 +0x1c
```

This PR aims to fix this.

<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
