### PR TITLE
Add lll linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,6 @@ linters:
   #- interfacebloat   # WE do bloaty interfaces.
   #- inamedparam      # Not that useful.
   #- ireturn          # Not that useful/false positives.
-  #- lll              # Could be nice in the future.
   #- musttag          # Dislikes our deps.
   #- nakedret         # Naked return good return.
   #- nlreturn         # Could be nice in the future.
@@ -69,6 +68,7 @@ linters:
   - grouper
   - importas
   - ineffassign
+  - lll
   - loggercheck
   - maintidx
   - makezero

--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -4,8 +4,9 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ClusterObjectSet reconciles a collection of objects through ordered phases and aggregates their status.
 //
-// ClusterObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and being itself mostly immutable.
-// This object type is able to suspend/pause reconciliation of specific objects to facilitate the transition between revisions.
+// ClusterObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and
+// being itself mostly immutable. This object type is able to suspend/pause reconciliation of specific
+// objects to facilitate the transition between revisions.
 //
 // Archived ClusterObjectSets may stay on the cluster, to store information about previous revisions.
 //

--- a/apis/core/v1alpha1/clusterobjectsetphase_types.go
+++ b/apis/core/v1alpha1/clusterobjectsetphase_types.go
@@ -2,8 +2,9 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// ClusterObjectSetPhase is an internal API, allowing a ClusterObjectSet to delegate a single phase to another custom controller.
-// ClusterObjectSets will create subordinate ClusterObjectSetPhases when `.class` is set within the phase specification.
+// ClusterObjectSetPhase is an internal API, allowing a ClusterObjectSet to delegate a
+// single phase to another custom controller. ClusterObjectSets will create subordinate
+// ClusterObjectSetPhases when `.class` is set within the phase specification.
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjsetphase","cosp"}
 // +kubebuilder:subresource:status

--- a/apis/core/v1alpha1/commonobjectset_types.go
+++ b/apis/core/v1alpha1/commonobjectset_types.go
@@ -48,9 +48,12 @@ type ObjectSetTemplateSpec struct {
 type ObjectSetTemplatePhase struct {
 	// Name of the reconcile phase. Must be unique within a ObjectSet.
 	Name string `json:"name"`
-	// If non empty, the ObjectSet controller will delegate phase reconciliation to another controller, by creating an ObjectSetPhase object.
-	// If set to the string "default" the built-in Package Operator ObjectSetPhase controller will reconcile the object in the same way the ObjectSet would.
-	// If set to any other string, an out-of-tree controller needs to be present to handle ObjectSetPhase objects.
+	// If non empty, the ObjectSet controller will delegate phase reconciliation
+	// to another controller, by creating an ObjectSetPhase object. If set to the
+	// string "default" the built-in Package Operator ObjectSetPhase controller
+	// will reconcile the object in the same way the ObjectSet would. If set to
+	// any other string, an out-of-tree controller needs to be present to handle
+	// ObjectSetPhase objects.
 	Class string `json:"class,omitempty"`
 	// Objects belonging to this phase.
 	Objects []ObjectSetObject `json:"objects,omitempty"`
@@ -126,6 +129,7 @@ type ConditionMapping struct {
 	// Source condition type.
 	SourceType string `json:"sourceType"`
 	// Destination condition type to report into Package Operator APIs.
+	//nolint:lll
 	// +kubebuilder:validation:Pattern=`[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]`
 	DestinationType string `json:"destinationType"`
 }

--- a/apis/core/v1alpha1/commonpackage_types.go
+++ b/apis/core/v1alpha1/commonpackage_types.go
@@ -22,8 +22,8 @@ type PackageStatus struct {
 // Package condition types.
 const (
 	// A Packages "Available" condition tracks the availability of the underlying ObjectDeployment objects.
-	// When the Package is reporting "Available" = True, it's expected that whatever the Package installs is up and operational.
-	// Package "Availability" may change multiple times during it's lifecycle.
+	// When the Package is reporting "Available" = True, it's expected that whatever the Package installs
+	// is up and operational. Package "Availability" may change multiple times during it's lifecycle.
 	PackageAvailable = "Available"
 	// Progressing indicates that a new release is being rolled out.
 	PackageProgressing = "Progressing"
@@ -55,7 +55,8 @@ const (
 // PackageSpec specifies a package.
 type PackageSpec struct {
 	// the image containing the contents of the package
-	// this image will be unpacked by the package-loader to render the ObjectDeployment for propagating the installation of the package.
+	// this image will be unpacked by the package-loader to render
+	// the ObjectDeployment for propagating the installation of the package.
 	// +kubebuilder:validation:Required
 	Image string `json:"image"`
 	// Package configuration parameters.

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -6,8 +6,9 @@ import (
 
 // ObjectSet reconciles a collection of objects through ordered phases and aggregates their status.
 //
-// ObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and being itself mostly immutable.
-// This object type is able to suspend/pause reconciliation of specific objects to facilitate the transition between revisions.
+// ObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and
+// being itself mostly immutable. This object type is able to suspend/pause reconciliation of
+// specific objects to facilitate the transition between revisions.
 //
 // Archived ObjectSets may stay on the cluster, to store information about previous revisions.
 //

--- a/apis/manifests/v1alpha1/packagemanifest_types.go
+++ b/apis/manifests/v1alpha1/packagemanifest_types.go
@@ -52,12 +52,14 @@ const (
 	PackageManifestScopeNamespaced PackageManifestScope = "Namespaced"
 )
 
-// PackageManifestSpec represents the spec of the packagemanifest containing the details about phases and availability probes.
+// PackageManifestSpec represents the spec of the packagemanifest containing the
+// details about phases and availability probes.
 type PackageManifestSpec struct {
 	// Scopes declare the available installation scopes for the package.
 	// Either Cluster, Namespaced, or both.
 	Scopes []PackageManifestScope `json:"scopes"`
-	// Phases correspond to the references to the phases which are going to be the part of the ObjectDeployment/ClusterObjectDeployment.
+	// Phases correspond to the references to the phases which are going to be the
+	// part of the ObjectDeployment/ClusterObjectDeployment.
 	Phases []PackageManifestPhase `json:"phases"`
 	// Availability Probes check objects that are part of the package.
 	// All probes need to succeed for a package to be considered Available.
@@ -68,7 +70,8 @@ type PackageManifestSpec struct {
 	Config PackageManifestSpecConfig `json:"config,omitempty"`
 	// List of images to be resolved
 	Images []PackageManifestImage `json:"images"`
-	// Configuration for multi-component packages. If this field is not set it is assumed that the containing package is a single-component package.
+	// Configuration for multi-component packages. If this field is not set it is assumed
+	// that the containing package is a single-component package.
 	// +optional
 	Components *PackageManifestComponentsConfig `json:"components,omitempty"`
 }
@@ -119,6 +122,7 @@ type PackageManifestTestCaseTemplate struct {
 type PackageManifestTestKubeconform struct {
 	// Kubernetes version to use schemas from.
 	KubernetesVersion string `json:"kubernetesVersion"`
+	//nolint:lll
 	// OpenAPI schema locations for kubeconform
 	// defaults to:
 	// - https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json

--- a/cmd/kubectl-package/buildcmd/build.go
+++ b/cmd/kubectl-package/buildcmd/build.go
@@ -24,7 +24,8 @@ func NewCmd(builderFactory BuilderFactory) *cobra.Command {
 	const (
 		buildUse   = "build source_path [--tag tag]... [--output output_path] [--push]"
 		buildShort = "build an PKO package image using manifests at the given path"
-		buildLong  = "builds and optionally pushes an OCI image in the Package Operator package format from the specified build context directory."
+		buildLong  = "builds and optionally pushes an OCI image in the Package Operator" +
+			" package format from the specified build context directory."
 	)
 
 	cmd := &cobra.Command{

--- a/cmd/kubectl-package/deps/kube.go
+++ b/cmd/kubectl-package/deps/kube.go
@@ -10,7 +10,9 @@ func ProvideScheme() (*runtime.Scheme, error) {
 	return internalcmd.NewScheme()
 }
 
-func ProvideKubeClientFactory(cfgFactory internalcmd.RestConfigFactory, scheme *runtime.Scheme) internalcmd.KubeClientFactory {
+func ProvideKubeClientFactory(
+	cfgFactory internalcmd.RestConfigFactory, scheme *runtime.Scheme,
+) internalcmd.KubeClientFactory {
 	return internalcmd.NewDefaultKubeClientFactory(scheme, cfgFactory)
 }
 

--- a/cmd/kubectl-package/updatecmd/update.go
+++ b/cmd/kubectl-package/updatecmd/update.go
@@ -15,7 +15,9 @@ import (
 )
 
 type Updater interface {
-	GenerateLockData(ctx context.Context, srcPath string, opts ...internalcmd.GenerateLockDataOption) (data []byte, err error)
+	GenerateLockData(
+		ctx context.Context, srcPath string, opts ...internalcmd.GenerateLockDataOption,
+	) (data []byte, err error)
 }
 
 func NewCmd(updater Updater) *cobra.Command {

--- a/cmd/kubectl-package/validatecmd/validate.go
+++ b/cmd/kubectl-package/validatecmd/validate.go
@@ -18,7 +18,8 @@ func NewCmd(validator Validator) *cobra.Command {
 	const (
 		validateUse   = "validate [--pull] target"
 		validateShort = "validate a package."
-		validateLong  = "validate a package. Target may be a source directory, a package in a tar[.gz] or a fully qualified tag if --pull is set."
+		validateLong  = "validate a package. Target may be a source directory, " +
+			"a package in a tar[.gz] or a fully qualified tag if --pull is set."
 	)
 
 	cmd := &cobra.Command{

--- a/cmd/package-operator-manager/bootstrap/apihelper.go
+++ b/cmd/package-operator-manager/bootstrap/apihelper.go
@@ -38,8 +38,8 @@ func isPKOClusterPackageAvailable(ctx context.Context, c client.Client) (bool, e
 		return false, err
 	}
 
-	availableCond := meta.FindStatusCondition(clusterPackage.Status.Conditions, corev1alpha1.PackageAvailable)
-	return availableCond.ObservedGeneration == clusterPackage.Generation && availableCond.Status == metav1.ConditionTrue, nil
+	availCond := meta.FindStatusCondition(clusterPackage.Status.Conditions, corev1alpha1.PackageAvailable)
+	return availCond.ObservedGeneration == clusterPackage.Generation && availCond.Status == metav1.ConditionTrue, nil
 }
 
 func isPKODeploymentAvailable(ctx context.Context, c client.Client, pkoNamespace string) (bool, error) {

--- a/cmd/package-operator-manager/bootstrap/bootstrap.go
+++ b/cmd/package-operator-manager/bootstrap/bootstrap.go
@@ -87,7 +87,8 @@ func (b *Bootstrapper) bootstrap(ctx context.Context, runManager func(ctx contex
 	ctx, cancel := context.WithCancel(ctx)
 	go b.cancelWhenPackageAvailable(ctx, cancel)
 
-	// TODO(jgwosdz): investigate if it would make sense to stop using envvars and instead go through a central configuration facility (like opts?)
+	// TODO(jgwosdz): investigate if it would make sense to stop using envvars and instead go
+	// through a central configuration facility (like opts?)
 
 	// Force Adoption of objects during initial bootstrap to take ownership of
 	// CRDs, Namespace, ServiceAccount and ClusterRoleBinding.

--- a/cmd/package-operator-manager/bootstrap/fix.go
+++ b/cmd/package-operator-manager/bootstrap/fix.go
@@ -37,7 +37,8 @@ func newFixer(c client.Client, log logr.Logger, pkoNamespace string) *fixer {
 	}
 }
 
-// fix iterates through all registered fixes/runCheckers, runs their checks to determine if the fix has to be executed and if so, it executes the fix.
+// fix iterates through all registered fixes/runCheckers, runs their checks to determine if
+// the fix has to be executed and if so, it executes the fix.
 func (f *fixer) fix(ctx context.Context) error {
 	for _, fixRunChecker := range f.fixes {
 		fixName := reflect.TypeOf(fixRunChecker).String()

--- a/cmd/package-operator-manager/bootstrap/init.go
+++ b/cmd/package-operator-manager/bootstrap/init.go
@@ -29,9 +29,9 @@ const (
 	packageOperatorDeploymentDeletionTimeout       = 2 * time.Minute
 )
 
-// Initializes PKO on the cluster by installing CRDs and
-// ensuring a package-operator ClusterPackage is present.
-// Will shut down PKO prior to bootstrapping if the ClusterPackage was updated to ensure that new "non-buggy" PKO code will handle the migration.
+// Initializes PKO on the cluster by installing CRDs and ensuring a package-operator ClusterPackage is present.
+// Will shut down PKO prior to bootstrapping if the ClusterPackage was updated to ensure that new "non-buggy"
+// PKO code will handle the migration.
 type initializer struct {
 	client    client.Client
 	scheme    *runtime.Scheme
@@ -93,7 +93,9 @@ func (init *initializer) newPKOClusterPackage() *corev1alpha1.ClusterPackage {
 	}
 }
 
-// ensureUpdatedPKO compares new and old PKO ClusterPackages, looks at PKO availability, it handles eventual PKO shutdown, update of the PKO ClusterPackage and decides if bootstrap should be executed or not.
+// ensureUpdatedPKO compares new and old PKO ClusterPackages, looks at PKO availability,
+// it handles eventual PKO shutdown, update of the PKO ClusterPackage and decides if
+// bootstrap should be executed or not.
 func (init *initializer) ensureUpdatedPKO(ctx context.Context) (bool, error) {
 	bootstrapClusterPackage := init.newPKOClusterPackage()
 

--- a/cmd/package-operator-manager/bootstrap/proxy/proxy.go
+++ b/cmd/package-operator-manager/bootstrap/proxy/proxy.go
@@ -17,8 +17,10 @@ const (
 	noProxyVar    = "NO_PROXY"
 )
 
-// Compare proxy settings in environment variables with settings in `apiEnv` and replace current pko process with a new instance with updated environment variables by using unix.Exec (execve).
-// This is needed as a workaround because Go caches proxy settings that are read from the envvars `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` on the first global http(s) client call.
+// Compare proxy settings in environment variables with settings in `apiEnv` and replace current
+// pko process with a new instance with updated environment variables by using unix.Exec (execve).
+// This is needed as a workaround because Go caches proxy settings that are read from the envvars
+// `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` on the first global http(s) client call.
 func RestartPKOWithEnvvarsIfNeeded(log logr.Logger, apiEnv *manifests.PackageEnvironment) error {
 	return restartPKOWithEnvvarsIfNeeded(
 		log,
@@ -41,7 +43,13 @@ type (
 	executableFn func() (string, error)
 )
 
-func restartPKOWithEnvvarsIfNeeded(log logr.Logger, execve execveFn, getenv getenvFn, getAndResolveArgv0 executableFn, apiEnv *manifests.PackageEnvironment) error {
+func restartPKOWithEnvvarsIfNeeded(
+	log logr.Logger,
+	execve execveFn,
+	getenv getenvFn,
+	getAndResolveArgv0 executableFn,
+	apiEnv *manifests.PackageEnvironment,
+) error {
 	if apiEnv.Proxy == nil {
 		log.Info("no proxy configured via PackageEnvironment")
 		// no restart needed

--- a/cmd/package-operator-manager/bootstrap/proxy/proxy_test.go
+++ b/cmd/package-operator-manager/bootstrap/proxy/proxy_test.go
@@ -20,8 +20,11 @@ func TestRestartPKOWithEnvvarsIfNeeded(t *testing.T) {
 
 	log := testr.New(t)
 
-	// nothing should happen and nil functions should not be called when env.Proxy is empty (which means that no proxy is configured in the cluster)
-	// TODO(jgwosdz): there is an edge case where PKO was started with envvars that configure a proxy but no proxy is configured in the cluster. Should pko then strip this proxy from the env and restart itself or should it just keep running with proxy settings?
+	// nothing should happen and nil functions should not be called when env.Proxy is empty
+	// (which means that no proxy is configured in the cluster)
+	// TODO(jgwosdz): there is an edge case where PKO was started with envvars that configure
+	// a proxy but no proxy is configured in the cluster. Should pko then strip this proxy
+	// from the env and restart itself or should it just keep running with proxy settings?
 	t.Run("env.Proxy_IsNil", func(t *testing.T) {
 		t.Parallel()
 

--- a/cmd/package-operator-manager/components/options.go
+++ b/cmd/package-operator-manager/components/options.go
@@ -27,11 +27,13 @@ const (
 		" with Package Operator using the given Package Operator Package Image"
 	remotePhasePackageImageFlagDescription = "Image pointing to a package operator remote phase package. " +
 		"This image is used with the HyperShift integration to spin up the remote-phase-manager for every HostedCluster"
-	registryHostOverrides = "List of registry host overrides to change during image pulling. e.g. quay.io=localhost:123,<original-host>=<new-host>"
-	packageHashModifier   = "An additional value used for the generation of a package's unpackedHash."
-
-	subComponentAffinityFlagDescription    = "Pod affinity settings used in PKO deployed subcomponents, like remote-phase-manager."
-	subComponentTolerationsFlagDescription = "Pod tolerations settings used in PKO deployed subcomponents, like remote-phase-manager."
+	registryHostOverrides = "List of registry host overrides to change during image pulling. " +
+		"e.g. quay.io=localhost:123,<original-host>=<new-host>"
+	packageHashModifier             = "An additional value used for the generation of a package's unpackedHash."
+	subCmpntAffinityFlagDescription = "Pod affinity settings used in PKO deployed subcomponents, " +
+		"like remote-phase-manager."
+	subCmpntTolerationsFlagDescription = "Pod tolerations settings used in PKO deployed subcomponents, " +
+		"like remote-phase-manager."
 )
 
 type Options struct {
@@ -102,12 +104,12 @@ func ProvideOptions() (opts Options, err error) {
 	flag.StringVar(
 		&subComponentAffinityJSON, "sub-component-affinity",
 		os.Getenv("PKO_SUB_COMPONENT_AFFINITY"),
-		subComponentAffinityFlagDescription,
+		subCmpntAffinityFlagDescription,
 	)
 	flag.StringVar(
 		&subComponentTolerationsJSON, "sub-component-tolerations",
 		os.Getenv("PKO_SUB_COMPONENT_TOLERATIONS"),
-		subComponentAffinityFlagDescription,
+		subCmpntAffinityFlagDescription,
 	)
 	if len(subComponentAffinityJSON) > 0 {
 		if err := json.Unmarshal([]byte(subComponentAffinityJSON), &opts.SubComponentAffinity); err != nil {

--- a/cmd/package-operator-manager/components/options_test.go
+++ b/cmd/package-operator-manager/components/options_test.go
@@ -10,8 +10,16 @@ import (
 
 //nolint:paralleltest
 func TestProvideOptions(t *testing.T) {
-	t.Setenv("PKO_SUB_COMPONENT_TOLERATIONS", `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra"},{"effect":"NoSchedule","key":"hypershift.openshift.io/hosted-control-plane"}]`)
-	t.Setenv("PKO_SUB_COMPONENT_AFFINITY", `{ "nodeAffinity": { "requiredDuringSchedulingIgnoredDuringExecution": { "nodeSelectorTerms": [ { "matchExpressions": [ { "key": "node-role.kubernetes.io/infra", "operator": "Exists" } ] }, { "matchExpressions": [ { "key": "hypershift.openshift.io/hosted-control-plane", "operator": "Exists" } ] } ] } } }`)
+	t.Setenv("PKO_SUB_COMPONENT_TOLERATIONS",
+		`[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra"},`+
+			`{"effect":"NoSchedule","key":"hypershift.openshift.io/hosted-control-plane"}]`,
+	)
+	t.Setenv("PKO_SUB_COMPONENT_AFFINITY",
+		`{ "nodeAffinity": { "requiredDuringSchedulingIgnoredDuringExecution": { "nodeSelectorTerms": [ `+
+			`{ "matchExpressions": [ { "key": "node-role.kubernetes.io/infra", "operator": "Exists" } ] }, `+
+			`{ "matchExpressions": [ { "key": "hypershift.openshift.io/hosted-control-plane", "operator": "Exists" }`+
+			` ] } ] } } }`,
+	)
 	opts, err := ProvideOptions()
 	require.NoError(t, err)
 

--- a/cmd/package-operator-manager/hypershift.go
+++ b/cmd/package-operator-manager/hypershift.go
@@ -52,7 +52,8 @@ func (h *hypershift) Start(ctx context.Context) error {
 		case err == nil:
 			h.log.Info("detected hypershift installation after setup completed, restarting operator")
 			return ErrHypershiftAPIPostSetup
-		case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) ||
+			discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
 			continue
 		default:
 			return fmt.Errorf("hypershiftv1beta1 probing: %w", err)

--- a/cmd/package-operator-manager/main.go
+++ b/cmd/package-operator-manager/main.go
@@ -196,7 +196,8 @@ func (pkoMgr *packageOperatorManager) probeHyperShiftIntegration(
 				"unable to create controller for HostedCluster: %w", err)
 		}
 
-	case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+	case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) ||
+		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
 		ticker := clock.RealClock{}.NewTicker(hyperShiftPollInterval)
 		if err := pkoMgr.mgr.Add(
 			newHypershift(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -94,8 +94,9 @@ status:
 
 ClusterObjectSet reconciles a collection of objects through ordered phases and aggregates their status.
 
-ClusterObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and being itself mostly immutable.
-This object type is able to suspend/pause reconciliation of specific objects to facilitate the transition between revisions.
+ClusterObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and
+being itself mostly immutable. This object type is able to suspend/pause reconciliation of specific
+objects to facilitate the transition between revisions.
 
 Archived ClusterObjectSets may stay on the cluster, to store information about previous revisions.
 
@@ -170,8 +171,9 @@ status:
 
 ### ClusterObjectSetPhase
 
-ClusterObjectSetPhase is an internal API, allowing a ClusterObjectSet to delegate a single phase to another custom controller.
-ClusterObjectSets will create subordinate ClusterObjectSetPhases when `.class` is set within the phase specification.
+ClusterObjectSetPhase is an internal API, allowing a ClusterObjectSet to delegate a
+single phase to another custom controller. ClusterObjectSets will create subordinate
+ClusterObjectSetPhases when `.class` is set within the phase specification.
 
 
 **Example**
@@ -422,8 +424,9 @@ status:
 
 ObjectSet reconciles a collection of objects through ordered phases and aggregates their status.
 
-ObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and being itself mostly immutable.
-This object type is able to suspend/pause reconciliation of specific objects to facilitate the transition between revisions.
+ObjectSets behave similarly to Kubernetes ReplicaSets, by managing a collection of objects and
+being itself mostly immutable. This object type is able to suspend/pause reconciliation of
+specific objects to facilitate the transition between revisions.
 
 Archived ObjectSets may stay on the cluster, to store information about previous revisions.
 
@@ -971,7 +974,7 @@ ObjectSetTemplatePhase configures the reconcile phase of ObjectSets.
 | Field | Description |
 | ----- | ----------- |
 | `name` <b>required</b><br>string | Name of the reconcile phase. Must be unique within a ObjectSet. |
-| `class` <br>string | If non empty, the ObjectSet controller will delegate phase reconciliation to another controller, by creating an ObjectSetPhase object.<br>If set to the string "default" the built-in Package Operator ObjectSetPhase controller will reconcile the object in the same way the ObjectSet would.<br>If set to any other string, an out-of-tree controller needs to be present to handle ObjectSetPhase objects. |
+| `class` <br>string | If non empty, the ObjectSet controller will delegate phase reconciliation<br>to another controller, by creating an ObjectSetPhase object. If set to the<br>string "default" the built-in Package Operator ObjectSetPhase controller<br>will reconcile the object in the same way the ObjectSet would. If set to<br>any other string, an out-of-tree controller needs to be present to handle<br>ObjectSetPhase objects. |
 | `objects` <br><a href="#objectsetobject">[]ObjectSetObject</a> | Objects belonging to this phase. |
 | `externalObjects` <br><a href="#objectsetobject">[]ObjectSetObject</a> | ExternalObjects observed, but not reconciled by this phase. |
 | `slices` <br>[]string | References to ObjectSlices containing objects for this phase. |
@@ -1081,7 +1084,7 @@ PackageSpec specifies a package.
 
 | Field | Description |
 | ----- | ----------- |
-| `image` <b>required</b><br>string | the image containing the contents of the package<br>this image will be unpacked by the package-loader to render the ObjectDeployment for propagating the installation of the package. |
+| `image` <b>required</b><br>string | the image containing the contents of the package<br>this image will be unpacked by the package-loader to render<br>the ObjectDeployment for propagating the installation of the package. |
 | `config` <br>runtime.RawExtension | Package configuration parameters. |
 | `component` <br>string | Desired component to deploy from multi-component packages. |
 
@@ -1280,7 +1283,7 @@ test:
 | Field | Description |
 | ----- | ----------- |
 | `metadata` <br>metav1.ObjectMeta |  |
-| `spec` <br><a href="#packagemanifestspec">PackageManifestSpec</a> | PackageManifestSpec represents the spec of the packagemanifest containing the details about phases and availability probes. |
+| `spec` <br><a href="#packagemanifestspec">PackageManifestSpec</a> | PackageManifestSpec represents the spec of the packagemanifest containing the<br>details about phases and availability probes. |
 | `test` <br><a href="#packagemanifesttest">PackageManifestTest</a> | PackageManifestTest configures test cases. |
 
 
@@ -1432,16 +1435,17 @@ Used in:
 
 ### PackageManifestSpec
 
-PackageManifestSpec represents the spec of the packagemanifest containing the details about phases and availability probes.
+PackageManifestSpec represents the spec of the packagemanifest containing the
+details about phases and availability probes.
 
 | Field | Description |
 | ----- | ----------- |
 | `scopes` <b>required</b><br><a href="#packagemanifestscope">[]PackageManifestScope</a> | Scopes declare the available installation scopes for the package.<br>Either Cluster, Namespaced, or both. |
-| `phases` <b>required</b><br><a href="#packagemanifestphase">[]PackageManifestPhase</a> | Phases correspond to the references to the phases which are going to be the part of the ObjectDeployment/ClusterObjectDeployment. |
+| `phases` <b>required</b><br><a href="#packagemanifestphase">[]PackageManifestPhase</a> | Phases correspond to the references to the phases which are going to be the<br>part of the ObjectDeployment/ClusterObjectDeployment. |
 | `availabilityProbes` <br>[]corev1alpha1.ObjectSetProbe | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `config` <br><a href="#packagemanifestspecconfig">PackageManifestSpecConfig</a> | Configuration specification. |
 | `images` <b>required</b><br><a href="#packagemanifestimage">[]PackageManifestImage</a> | List of images to be resolved |
-| `components` <br><a href="#packagemanifestcomponentsconfig">PackageManifestComponentsConfig</a> | Configuration for multi-component packages. If this field is not set it is assumed that the containing package is a single-component package. |
+| `components` <br><a href="#packagemanifestcomponentsconfig">PackageManifestComponentsConfig</a> | Configuration for multi-component packages. If this field is not set it is assumed<br>that the containing package is a single-component package. |
 
 
 Used in:

--- a/integration/kubectl-package/fixtures_test.go
+++ b/integration/kubectl-package/fixtures_test.go
@@ -21,17 +21,19 @@ func sourcePathFixture(name string) string {
 	)
 
 	return map[string]string{
-		"valid_without_config":                                    filepath.Join(validPackages, "without_config"),
-		"valid_without_config_multi":                              filepath.Join(validPackages, "without_config_multi"),
-		"valid_with_config":                                       filepath.Join(validPackages, "with_config"),
-		"valid_with_config_multi":                                 filepath.Join(validPackages, "with_config_multi"),
-		"valid_with_config_no_tests_no_required_properties":       filepath.Join(validPackages, "with_config_no_tests_no_required_properties"),
-		"valid_with_config_no_tests_no_required_properties_multi": filepath.Join(validPackages, "with_config_no_tests_no_required_properties_multi"),
-		"invalid_bad_manifest":                                    filepath.Join(invalidPackages, "bad_manifest"),
-		"invalid_invalid_resource_label":                          filepath.Join(invalidPackages, "invalid_resource_label"),
-		"invalid_missing_lock_file":                               filepath.Join(invalidPackages, "missing_lock_file"),
-		"invalid_missing_phase_annotation":                        filepath.Join(invalidPackages, "missing_phase_annotation"),
-		"invalid_missing_resource_gvk":                            filepath.Join(invalidPackages, "missing_resource_gvk"),
+		"valid_without_config":       filepath.Join(validPackages, "without_config"),
+		"valid_without_config_multi": filepath.Join(validPackages, "without_config_multi"),
+		"valid_with_config":          filepath.Join(validPackages, "with_config"),
+		"valid_with_config_multi":    filepath.Join(validPackages, "with_config_multi"),
+		"valid_with_config_no_tests_no_required_properties": filepath.Join(validPackages,
+			"with_config_no_tests_no_required_properties"),
+		"valid_with_config_no_tests_no_required_properties_multi": filepath.Join(validPackages,
+			"with_config_no_tests_no_required_properties_multi"),
+		"invalid_bad_manifest":             filepath.Join(invalidPackages, "bad_manifest"),
+		"invalid_invalid_resource_label":   filepath.Join(invalidPackages, "invalid_resource_label"),
+		"invalid_missing_lock_file":        filepath.Join(invalidPackages, "missing_lock_file"),
+		"invalid_missing_phase_annotation": filepath.Join(invalidPackages, "missing_phase_annotation"),
+		"invalid_missing_resource_gvk":     filepath.Join(invalidPackages, "missing_resource_gvk"),
 	}[name]
 }
 
@@ -94,7 +96,8 @@ func generatePackage(dir string, opts ...generatePackageOption) {
 		lockData, err := yaml.Marshal(cfg.LockData)
 		gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
 
-		gomega.ExpectWithOffset(1, os.WriteFile(filepath.Join(dir, "manifest.lock.yaml"), lockData, 0o644)).To(gomega.Succeed())
+		act := os.WriteFile(filepath.Join(dir, "manifest.lock.yaml"), lockData, 0o644)
+		gomega.ExpectWithOffset(1, act).To(gomega.Succeed())
 	}
 }
 

--- a/integration/kubectl-package/validate_test.go
+++ b/integration/kubectl-package/validate_test.go
@@ -58,7 +58,8 @@ var _ = ginkgo.DescribeTable("validate subcommand",
 			ExpectedExitCode: 0,
 		},
 	),
-	ginkgo.Entry("given the path of a valid multi component package with configuration, no tests and no required properties",
+	ginkgo.Entry(
+		"given the path of a valid multi component package with configuration, no tests and no required properties",
 		subCommandTestCase{
 			Args:             []string{sourcePathFixture("valid_with_config_no_tests_no_required_properties_multi")},
 			ExpectedExitCode: 0,

--- a/integration/package-operator/000_upgrade_test.go
+++ b/integration/package-operator/000_upgrade_test.go
@@ -56,7 +56,8 @@ func TestUpgrade(t *testing.T) {
 	log.Info("Latest released PKO is now available")
 
 	log.Info("Apply self-bootstrap-job.yaml built from sources")
-	require.NoError(t, createAndWaitFromFiles(ctx, []string{filepath.Join("..", "..", "config", "self-bootstrap-job.yaml")}))
+	err := createAndWaitFromFiles(ctx, []string{filepath.Join("..", "..", "config", "self-bootstrap-job.yaml")})
+	require.NoError(t, err)
 	assertInstallDone(ctx, t, pkg)
 }
 
@@ -163,8 +164,8 @@ func nukeObject(ctx context.Context, obj client.Object) error {
 func removeAllFinalizersForDeletion(ctx context.Context, obj client.Object) error {
 	if len(obj.GetFinalizers()) > 0 {
 		obj.SetFinalizers([]string{})
-		if err := Client.Patch(ctx, obj,
-			client.RawPatch(client.Merge.Type(), []byte(`{"metadata": {"finalizers": null}}`))); err != nil && !apimachineryerrors.IsNotFound(err) {
+		err := Client.Patch(ctx, obj, client.RawPatch(client.Merge.Type(), []byte(`{"metadata": {"finalizers": null}}`)))
+		if err != nil && !apimachineryerrors.IsNotFound(err) {
 			return fmt.Errorf("releasing finalizers on stuck object %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 		}
 	}

--- a/integration/package-operator/hypershift_test.go
+++ b/integration/package-operator/hypershift_test.go
@@ -81,9 +81,13 @@ func TestHyperShift(t *testing.T) {
 			Namespace: ns.Name,
 		},
 	}
-	// longer timeout because PKO is restarting to enable HyperShift integration and needs a few seconds for leader election.
-	require.NoError(t,
-		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageAvailable, metav1.ConditionTrue, dev.WithTimeout(100*time.Second)))
+	// longer timeout because PKO is restarting to enable HyperShift integration and needs a
+	// few seconds for leader election.
+	err = Waiter.WaitForCondition(
+		ctx, pkg, corev1alpha1.PackageAvailable,
+		metav1.ConditionTrue, dev.WithTimeout(100*time.Second),
+	)
+	require.NoError(t, err)
 
 	// Test ObjectSetPhase integration
 	t.Run("ObjectSetSetupPauseTeardown", func(t *testing.T) {

--- a/integration/package-operator/objectdeployment_test.go
+++ b/integration/package-operator/objectdeployment_test.go
@@ -32,10 +32,11 @@ func TestObjectDeployment_availability_and_hash_collision(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 
 	testCases := []struct {
-		deploymentRevision           int
-		probe                        []corev1alpha1.ObjectSetProbe
-		phases                       []corev1alpha1.ObjectSetTemplatePhase
-		expectedRevisionAvailability metav1.ConditionStatus // Objectset for the current deployment revision availability status
+		deploymentRevision int
+		probe              []corev1alpha1.ObjectSetProbe
+		phases             []corev1alpha1.ObjectSetTemplatePhase
+		// Objectset for the current deployment revision availability status.
+		expectedRevisionAvailability metav1.ConditionStatus
 		expectedObjectSetCount       int
 		expectedHashCollisionCount   int
 		expectedDeploymentConditions map[string]metav1.ConditionStatus
@@ -303,7 +304,8 @@ func TestObjectDeployment_external_objects(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NoError(t, Waiter.WaitForObject(ctx, obj, "creating", func(_ client.Object) (bool, error) { return true, nil }))
+			err = Waiter.WaitForObject(ctx, obj, "creating", func(_ client.Object) (bool, error) { return true, nil })
+			require.NoError(t, err)
 		}
 
 		require.NoError(t,
@@ -321,10 +323,11 @@ func TestObjectDeployment_external_objects(t *testing.T) {
 func TestObjectDeployment_ObjectSetArchival(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 	testCases := []struct {
-		revision                     string
-		phases                       []corev1alpha1.ObjectSetTemplatePhase
-		probes                       []corev1alpha1.ObjectSetProbe
-		expectedRevisionAvailability metav1.ConditionStatus // Objectset for the current deployment revision availability status
+		revision string
+		phases   []corev1alpha1.ObjectSetTemplatePhase
+		probes   []corev1alpha1.ObjectSetProbe
+		// Objectset for the current deployment revision availability status.
+		expectedRevisionAvailability metav1.ConditionStatus
 		expectedObjectSetCount       int
 		expectedDeploymentConditions map[string]metav1.ConditionStatus
 		expectedArchivedRevisions    []string

--- a/integration/package-operator/objecttemplate_test.go
+++ b/integration/package-operator/objecttemplate_test.go
@@ -243,7 +243,9 @@ spec:
 	assert.Equal(t, cm1PatchedValue, envVar.Value)
 }
 
-func createCMAndObjectTemplateSource(cmKey, cmDestination, cmValue, cmName string) (corev1.ConfigMap, corev1alpha1.ObjectTemplateSource) {
+func createCMAndObjectTemplateSource(
+	cmKey, cmDestination, cmValue, cmName string,
+) (corev1.ConfigMap, corev1alpha1.ObjectTemplateSource) {
 	cm := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -318,7 +320,9 @@ spec:
   image: %s
   config:
     testStubImage: %s
-    %s: {{ b64dec .config.%s }}`, packageName, SuccessTestPackageImage, TestStubImage, secretDestination, secretDestination)
+    %s: {{ b64dec .config.%s }}`,
+		packageName, SuccessTestPackageImage, TestStubImage, secretDestination, secretDestination,
+	)
 
 	objectTemplateName := "object-template-password"
 	objectTemplate := corev1alpha1.ObjectTemplate{

--- a/internal/adapters/doc.go
+++ b/internal/adapters/doc.go
@@ -1,2 +1,3 @@
-// The adapters package contains interface implementations to use Cluster- and non Cluster- prefixed APIs via the same code.
+// The adapters package contains interface implementations to use Cluster-
+// and non Cluster- prefixed APIs via the same code.
 package adapters

--- a/internal/apis/manifests/packagemanifest_types.go
+++ b/internal/apis/manifests/packagemanifest_types.go
@@ -42,12 +42,14 @@ const (
 	PackageManifestScopeNamespaced PackageManifestScope = "Namespaced"
 )
 
-// PackageManifestSpec represents the spec of the packagemanifest containing the details about phases and availability probes.
+// PackageManifestSpec represents the spec of the packagemanifest containing
+// the details about phases and availability probes.
 type PackageManifestSpec struct {
 	// Scopes declare the available installation scopes for the package.
 	// Either Cluster, Namespaced, or both.
 	Scopes []PackageManifestScope
-	// Phases correspond to the references to the phases which are going to be the part of the ObjectDeployment/ClusterObjectDeployment.
+	// Phases correspond to the references to the phases which are going to
+	// be the part of the ObjectDeployment/ClusterObjectDeployment.
 	Phases []PackageManifestPhase
 	// Availability Probes check objects that are part of the package.
 	// All probes need to succeed for a package to be considered Available.
@@ -58,7 +60,8 @@ type PackageManifestSpec struct {
 	Config PackageManifestSpecConfig
 	// List of images to be resolved
 	Images []PackageManifestImage
-	// Configuration for multi-component packages. If this field is not set it is assumed that the containing package is a single-component package.
+	// Configuration for multi-component packages. If this field is not set it
+	// is assumed that the containing package is a single-component package.
 	// +optional
 	Components *PackageManifestComponentsConfig
 }
@@ -107,6 +110,7 @@ type PackageManifestTestKubeconform struct {
 	KubernetesVersion string
 	// OpenAPI schema locations for kubeconform
 	// defaults to:
+	//nolint:lll
 	// - https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json
 	// - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
 	SchemaLocations []string

--- a/internal/cmd/client.go
+++ b/internal/cmd/client.go
@@ -68,11 +68,11 @@ func (c *GetPackageConfig) Option(opts ...GetPackageOption) {
 	}
 }
 
-type GetPackageOption interface {
-	ConfigureGetPackage(*GetPackageConfig)
-}
+type GetPackageOption interface{ ConfigureGetPackage(*GetPackageConfig) }
 
-func (c *Client) GetObjectDeployment(ctx context.Context, name string, opts ...GetObjectDeploymentOption) (*ObjectDeployment, error) {
+func (c *Client) GetObjectDeployment(
+	ctx context.Context, name string, opts ...GetObjectDeploymentOption,
+) (*ObjectDeployment, error) {
 	var cfg GetObjectDeploymentConfig
 
 	cfg.Option(opts...)

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -65,7 +65,9 @@ type UpdateOption interface {
 	ConfigureUpdate(*UpdateConfig)
 }
 
-func (u *Update) GenerateLockData(ctx context.Context, srcPath string, opts ...GenerateLockDataOption) (data []byte, err error) {
+func (u *Update) GenerateLockData(
+	ctx context.Context, srcPath string, opts ...GenerateLockDataOption,
+) (data []byte, err error) {
 	var cfg GenerateLockDataConfig
 
 	cfg.Option(opts...)
@@ -116,7 +118,9 @@ func (u *Update) GenerateLockData(ctx context.Context, srcPath string, opts ...G
 
 var ErrLockDataUnchanged = errors.New("lock data unchanged")
 
-func (u *Update) lockImageFromManifestImage(cfg GenerateLockDataConfig, img manifests.PackageManifestImage) (manifests.PackageManifestLockImage, error) {
+func (u *Update) lockImageFromManifestImage(
+	cfg GenerateLockDataConfig, img manifests.PackageManifestImage,
+) (manifests.PackageManifestLockImage, error) {
 	overriddenImage, err := utils.ImageURLWithOverrideFromEnv(img.Image)
 	if err != nil {
 		return manifests.PackageManifestLockImage{}, fmt.Errorf("resolving image URL: %w", err)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -115,7 +115,9 @@ func getPackageFromPath(ctx context.Context, path string) (*packages.RawPackage,
 	return rawPkg, nil
 }
 
-func (v *Validate) getPackageFromRemoteRef(ctx context.Context, cfg ValidatePackageConfig) (*packages.RawPackage, error) {
+func (v *Validate) getPackageFromRemoteRef(
+	ctx context.Context, cfg ValidatePackageConfig,
+) (*packages.RawPackage, error) {
 	ref, err := name.ParseReference(cfg.RemoteReference)
 	if err != nil {
 		return nil, fmt.Errorf("parsing remote reference: %w", err)

--- a/internal/controllers/controllers.go
+++ b/internal/controllers/controllers.go
@@ -176,7 +176,9 @@ func DeleteMappedConditions(_ context.Context, conditions *[]metav1.Condition) {
 
 // AddDynamicCacheLabel ensures that the given object is labeled
 // for recognition by the dynamic cache.
-func AddDynamicCacheLabel(ctx context.Context, w client.Writer, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func AddDynamicCacheLabel(
+	ctx context.Context, w client.Writer, obj *unstructured.Unstructured,
+) (*unstructured.Unstructured, error) {
 	updated := obj.DeepCopy()
 
 	labels := updated.GetLabels()
@@ -194,7 +196,9 @@ func AddDynamicCacheLabel(ctx context.Context, w client.Writer, obj *unstructure
 	return updated, nil
 }
 
-func RemoveDynamicCacheLabel(ctx context.Context, w client.Writer, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func RemoveDynamicCacheLabel(
+	ctx context.Context, w client.Writer, obj *unstructured.Unstructured,
+) (*unstructured.Unstructured, error) {
 	updated := obj.DeepCopy()
 
 	labels := updated.GetLabels()

--- a/internal/controllers/controllers_test.go
+++ b/internal/controllers/controllers_test.go
@@ -44,7 +44,10 @@ func TestEnsureFinalizer(t *testing.T) {
 	if assert.NotNil(t, patch) {
 		j, err := patch.Data(obj)
 		require.NoError(t, err)
-		assert.Equal(t, `{"metadata":{"finalizers":["already-present","test-finalizer"],"resourceVersion":"xxx-123"}}`, string(j))
+		assert.Equal(t,
+			`{"metadata":{"finalizers":["already-present","test-finalizer"],"resourceVersion":"xxx-123"}}`,
+			string(j),
+		)
 	}
 }
 

--- a/internal/controllers/hostedclusters/hostedcluster_controller.go
+++ b/internal/controllers/hostedclusters/hostedcluster_controller.go
@@ -94,7 +94,8 @@ func (c *HostedClusterController) Reconcile(
 	}
 
 	existingPkg := &corev1alpha1.Package{}
-	if err := c.client.Get(ctx, client.ObjectKeyFromObject(desiredPkg), existingPkg); err != nil && errors.IsNotFound(err) {
+	err = c.client.Get(ctx, client.ObjectKeyFromObject(desiredPkg), existingPkg)
+	if err != nil && errors.IsNotFound(err) {
 		if err := c.client.Create(ctx, desiredPkg); err != nil {
 			return ctrl.Result{}, fmt.Errorf("creating Package: %w", err)
 		}
@@ -144,8 +145,7 @@ func (c *HostedClusterController) desiredPackage(cluster *v1beta1.HostedCluster)
 	return pkg, nil
 }
 
-// From
-// https://github.com/openshift/hypershift/blob/9c3e998b0b37bedce07163a197e0bf30339e627e/hypershift-operator/controllers/manifests/manifests.go#L13
+// From https://github.com/openshift/hypershift/blob/v0.1.13/hypershift-operator/controllers/manifests/manifests.go#L16
 func hostedClusterNamespace(cluster *v1beta1.HostedCluster) string {
 	return fmt.Sprintf("%s-%s", cluster.Namespace, strings.ReplaceAll(cluster.Name, ".", "-"))
 }

--- a/internal/controllers/hostedclusters/hostedcluster_controller_test.go
+++ b/internal/controllers/hostedclusters/hostedcluster_controller_test.go
@@ -37,7 +37,9 @@ func TestHostedClusterController_noop(t *testing.T) {
 	mockClient := testutil.NewClient()
 
 	image := "image321"
-	controller := NewHostedClusterController(mockClient, ctrl.Log.WithName("hc controller test"), testScheme, image, nil, nil)
+	controller := NewHostedClusterController(
+		mockClient, ctrl.Log.WithName("hc controller test"), testScheme, image, nil, nil,
+	)
 	hcName := "testing123"
 	now := metav1.Now()
 	hc := &hypershiftv1beta1.HostedCluster{
@@ -98,7 +100,9 @@ func TestHostedClusterController_Reconcile_waitsForClusterReady(t *testing.T) {
 	t.Parallel()
 
 	clientMock := testutil.NewClient()
-	c := NewHostedClusterController(clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil)
+	c := NewHostedClusterController(
+		clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil,
+	)
 
 	clientMock.
 		On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1beta1.HostedCluster"), mock.Anything).
@@ -119,7 +123,9 @@ func TestHostedClusterController_Reconcile_createsPackage(t *testing.T) {
 	t.Parallel()
 
 	clientMock := testutil.NewClient()
-	c := NewHostedClusterController(clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil)
+	c := NewHostedClusterController(
+		clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil,
+	)
 
 	clientMock.
 		On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1beta1.HostedCluster"), mock.Anything).
@@ -148,7 +154,9 @@ func TestHostedClusterController_Reconcile_updatesPackage(t *testing.T) {
 	t.Parallel()
 
 	clientMock := testutil.NewClient()
-	c := NewHostedClusterController(clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil)
+	c := NewHostedClusterController(
+		clientMock, ctrl.Log.WithName("hc controller test"), testScheme, "desired-image:test", nil, nil,
+	)
 
 	clientMock.
 		On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1beta1.HostedCluster"), mock.Anything).

--- a/internal/controllers/objectdeployments/adapter_test.go
+++ b/internal/controllers/objectdeployments/adapter_test.go
@@ -97,7 +97,12 @@ func TestGenericObjectSet_GetObjects(t *testing.T) {
 			},
 				nil,
 			),
-			expectedObjectIDs: []string{"/ConfigMap/namespace1/cm1", "/ConfigMap/namespace2/cm2", "apps/Deployment/default/deployment1", "/Secret/default/secret1"},
+			expectedObjectIDs: []string{
+				"/ConfigMap/namespace1/cm1",
+				"/ConfigMap/namespace2/cm2",
+				"apps/Deployment/default/deployment1",
+				"/Secret/default/secret1",
+			},
 		},
 		{
 			objectSet: genObjectSet("test-2", "default-1", map[string][]client.Object{
@@ -112,7 +117,12 @@ func TestGenericObjectSet_GetObjects(t *testing.T) {
 			},
 				nil,
 			),
-			expectedObjectIDs: []string{"/ConfigMap/default-1/cm1", "/ConfigMap/default-1/cm2", "apps/Deployment/default-1/deployment1", "/Secret/default-1/secret1"},
+			expectedObjectIDs: []string{
+				"/ConfigMap/default-1/cm1",
+				"/ConfigMap/default-1/cm2",
+				"apps/Deployment/default-1/deployment1",
+				"/Secret/default-1/secret1",
+			},
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/controllers/objectdeployments/archive_reconciler.go
+++ b/internal/controllers/objectdeployments/archive_reconciler.go
@@ -220,7 +220,9 @@ func intersection(a, b []objectIdentifier) (res []objectIdentifier) {
 	return
 }
 
-func (a *archiveReconciler) garbageCollectRevisions(ctx context.Context, previousObjectSets []genericObjectSet, objectDeployment objectDeploymentAccessor) error {
+func (a *archiveReconciler) garbageCollectRevisions(
+	ctx context.Context, previousObjectSets []genericObjectSet, objectDeployment objectDeploymentAccessor,
+) error {
 	revisionLimit := defaultRevisionLimit
 	deploymentRevisionLimit := objectDeployment.GetRevisionHistoryLimit()
 	if deploymentRevisionLimit != nil {

--- a/internal/controllers/objectdeployments/hash_reconciler.go
+++ b/internal/controllers/objectdeployments/hash_reconciler.go
@@ -9,11 +9,11 @@ import (
 	"package-operator.run/internal/utils"
 )
 
-type hashReconciler struct {
-	client client.Client
-}
+type hashReconciler struct{ client client.Client }
 
-func (h *hashReconciler) Reconcile(_ context.Context, objectSetDeployment objectDeploymentAccessor) (ctrl.Result, error) {
+func (h *hashReconciler) Reconcile(
+	_ context.Context, objectSetDeployment objectDeploymentAccessor,
+) (ctrl.Result, error) {
 	objectSetTemplate := objectSetDeployment.GetObjectSetTemplate()
 	templateHash := utils.ComputeFNV32Hash(objectSetTemplate, objectSetDeployment.GetStatusCollisionCount())
 	objectSetDeployment.SetStatusTemplateHash(templateHash)

--- a/internal/controllers/objectdeployments/new_revision_reconciler.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler.go
@@ -67,8 +67,9 @@ func (r *newRevisionReconciler) Reconcile(ctx context.Context,
 		controllerRef != nil &&
 		controllerRef.UID == objectDeployment.ClientObject().GetUID() &&
 		equality.Semantic.DeepEqual(newObjectSet.GetTemplateSpec(), conflictingObjectSet.GetTemplateSpec()) {
-		// This ObjectDeployment is controller of the conflicting ObjectSet and the ObjectSet is deep equal to the desired new ObjectSet.
-		// So no conflict :) This case can happen if the local cache is a little bit slow to record the ObjectSet Create event.
+		// This ObjectDeployment is controller of the conflicting ObjectSet and the ObjectSet is deep equal to the
+		// desired new ObjectSet. So no conflict :) This case can happen if the local cache is a little bit slow to
+		// record the ObjectSet Create event.
 		log.Info("Slow cache, no collision")
 		return ctrl.Result{}, nil
 	}

--- a/internal/controllers/objectdeployments/objectset_reconciler.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler.go
@@ -20,15 +20,19 @@ type objectSetReconciler struct {
 }
 
 type objectSetSubReconciler interface {
-	Reconcile(ctx context.Context,
-		currentObjectSet genericObjectSet, prevObjectSets []genericObjectSet, objectDeployment objectDeploymentAccessor) (ctrl.Result, error)
+	Reconcile(
+		ctx context.Context, currentObjectSet genericObjectSet,
+		prevObjectSets []genericObjectSet, objectDeployment objectDeploymentAccessor,
+	) (ctrl.Result, error)
 }
 
 type listObjectSetsForDeploymentFn func(
 	ctx context.Context, objectDeployment objectDeploymentAccessor,
 ) ([]genericObjectSet, error)
 
-func (o *objectSetReconciler) Reconcile(ctx context.Context, objectDeployment objectDeploymentAccessor) (ctrl.Result, error) {
+func (o *objectSetReconciler) Reconcile(
+	ctx context.Context, objectDeployment objectDeploymentAccessor,
+) (ctrl.Result, error) {
 	objectSets, err := o.listObjectSetsForDeployment(ctx, objectDeployment)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("listing objectsets under deployment errored: %w", err)
@@ -166,7 +170,9 @@ func (o *objectSetReconciler) setObjectDeploymentStatus(ctx context.Context,
 	)
 
 	if !currentObjectSet.IsAvailable() {
-		objectDeployment.SetStatusConditions(conditionFromPreviousObjectSets(objectDeployment.GetGeneration(), prevObjectSets...))
+		objectDeployment.SetStatusConditions(
+			conditionFromPreviousObjectSets(objectDeployment.GetGeneration(), prevObjectSets...),
+		)
 
 		return
 	}
@@ -221,7 +227,9 @@ func findAvailableRevision(objectSets ...genericObjectSet) (bool, string) {
 	return false, ""
 }
 
-func newAvailableCondition(status metav1.ConditionStatus, reason availableReason, msg string, generation int64) metav1.Condition {
+func newAvailableCondition(
+	status metav1.ConditionStatus, reason availableReason, msg string, generation int64,
+) metav1.Condition {
 	return metav1.Condition{
 		Type:               corev1alpha1.ObjectDeploymentAvailable,
 		Status:             status,
@@ -242,7 +250,9 @@ const (
 	availableReasonObjectSetUnready availableReason = "ObjectSetUnready"
 )
 
-func newProgressingCondition(status metav1.ConditionStatus, reason progressingReason, msg string, generation int64) metav1.Condition {
+func newProgressingCondition(
+	status metav1.ConditionStatus, reason progressingReason, msg string, generation int64,
+) metav1.Condition {
 	return metav1.Condition{
 		Type:               corev1alpha1.ObjectDeploymentProgressing,
 		Status:             status,

--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -253,7 +253,9 @@ func (c *GenericObjectSetPhaseController) Reconcile(
 	return res, c.updateStatus(ctx, objectSetPhase)
 }
 
-func (c *GenericObjectSetPhaseController) reportPausedCondition(_ context.Context, objectSetPhase genericObjectSetPhase) {
+func (c *GenericObjectSetPhaseController) reportPausedCondition(
+	_ context.Context, objectSetPhase genericObjectSetPhase,
+) {
 	if objectSetPhase.IsPaused() {
 		meta.SetStatusCondition(objectSetPhase.GetConditions(), metav1.Condition{
 			Type:               corev1alpha1.ObjectSetPhasePaused,
@@ -307,6 +309,8 @@ func (c *GenericObjectSetPhaseController) SetupWithManager(
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(objectSetPhase).
-		WatchesRawSource(c.dynamicCache.Source(), c.ownerStrategy.EnqueueRequestForOwner(objectSetPhase, mgr.GetRESTMapper(), false)).
-		Complete(c)
+		WatchesRawSource(
+			c.dynamicCache.Source(),
+			c.ownerStrategy.EnqueueRequestForOwner(objectSetPhase, mgr.GetRESTMapper(), false),
+		).Complete(c)
 }

--- a/internal/controllers/objectsetphases/objectsetphase_controller_test.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller_test.go
@@ -63,7 +63,9 @@ func (c *objectSetPhaseReconcilerMock) Teardown(
 	return args.Bool(0), args.Error(1)
 }
 
-func newControllerAndMocks() (*GenericObjectSetPhaseController, *testutil.CtrlClient, *dynamicCacheMock, *objectSetPhaseReconcilerMock) {
+func newControllerAndMocks() (
+	*GenericObjectSetPhaseController, *testutil.CtrlClient, *dynamicCacheMock, *objectSetPhaseReconcilerMock,
+) {
 	dc := &dynamicCacheMock{}
 
 	scheme := testutil.NewTestSchemeWithCoreV1Alpha1()

--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -286,7 +286,9 @@ func (c *GenericObjectSetController) reportPausedCondition(ctx context.Context, 
 	return nil
 }
 
-func (c *GenericObjectSetController) areRemotePhasesPaused(ctx context.Context, objectSet genericObjectSet) (arePaused, unknown bool, err error) {
+func (c *GenericObjectSetController) areRemotePhasesPaused(
+	ctx context.Context, objectSet genericObjectSet,
+) (arePaused, unknown bool, err error) {
 	var pausedPhases int
 	for _, phaseRef := range objectSet.GetRemotePhases() {
 		phase := c.newObjectSetPhase(c.scheme)

--- a/internal/controllers/objectsets/remotephase_reconciler.go
+++ b/internal/controllers/objectsets/remotephase_reconciler.go
@@ -76,8 +76,10 @@ func (r *objectSetRemotePhaseReconciler) Teardown(
 
 	// If ObjectSet is namespace-scoped check if that namespace is already in the process of being deleted.
 	// If so, remove finalizers from the Phase object to let it go immediately.
-	// This is  hypershift-specific behavior because Phases live in the same namespace as the guest cluster apiserver pods and ACM just kills the full namespace to uninstall a guest cluster.
-	// TODO(erdii): I think we should probably just patch-remove all of OUR finalizers so we can't accidentally wipe finalizers of other owners.
+	// This is  hypershift-specific behavior because Phases live in the same namespace as the guest cluster apiserver
+	// pods and ACM just kills the full namespace to uninstall a guest cluster.
+	// TODO(erdii): I think we should probably just patch-remove all of OUR finalizers so we can't accidentally wipe
+	// finalizers of other owners.
 	if len(objectSet.ClientObject().GetNamespace()) != 0 {
 		ns := corev1.Namespace{}
 

--- a/internal/controllers/objectsets/remotephase_reconciler_test.go
+++ b/internal/controllers/objectsets/remotephase_reconciler_test.go
@@ -300,7 +300,8 @@ func TestObjectSetRemotePhaseReconciler_TeardownNamespaceDeletion_ObjectSet(t *t
 			require.Empty(t, out.ObjectMeta.Finalizers)
 		}).Return(nil)
 
-	c.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+	c.On("Delete", mock.Anything, mock.Anything, mock.Anything).
+		Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
 
 	r := &objectSetRemotePhaseReconciler{
 		client:            c,
@@ -357,7 +358,8 @@ func TestObjectSetRemotePhaseReconciler_TeardownNamespaceDeletion_ClusterObjectS
 			require.Empty(t, out.ObjectMeta.Finalizers)
 		}).Return(nil)
 
-	c.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+	c.On("Delete", mock.Anything, mock.Anything, mock.Anything).
+		Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
 
 	r := &objectSetRemotePhaseReconciler{
 		client:            c,

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -144,7 +144,9 @@ func (c *GenericObjectTemplateController) Reconcile(
 	return res, c.updateStatus(ctx, objectTemplate)
 }
 
-func (c *GenericObjectTemplateController) updateStatus(ctx context.Context, objectTemplate genericObjectTemplate) error {
+func (c *GenericObjectTemplateController) updateStatus(
+	ctx context.Context, objectTemplate genericObjectTemplate,
+) error {
 	objectTemplate.UpdatePhase()
 	if err := c.client.Status().Update(ctx, objectTemplate.ClientObject()); err != nil {
 		return fmt.Errorf("updating ObjectTemplate status: %w", err)

--- a/internal/controllers/packages/object_deployment_status_reconciler.go
+++ b/internal/controllers/packages/object_deployment_status_reconciler.go
@@ -19,23 +19,25 @@ type objectDeploymentStatusReconciler struct {
 	newObjectDeployment adapters.ObjectDeploymentFactory
 }
 
-func (r *objectDeploymentStatusReconciler) Reconcile(ctx context.Context, packageObj adapters.GenericPackageAccessor) (ctrl.Result, error) {
+func (r *objectDeploymentStatusReconciler) Reconcile(
+	ctx context.Context, packageObj adapters.GenericPackageAccessor,
+) (ctrl.Result, error) {
 	objDep := r.newObjectDeployment(r.scheme)
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(packageObj.ClientObject()), objDep.ClientObject()); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	objDepAvailableCondition := meta.FindStatusCondition(*objDep.GetConditions(), corev1alpha1.ObjectDeploymentAvailable)
-	if objDepAvailableCondition != nil && objDepAvailableCondition.ObservedGeneration == objDep.ClientObject().GetGeneration() {
-		packageAvailableCond := objDepAvailableCondition.DeepCopy()
+	objDepAvailableCond := meta.FindStatusCondition(*objDep.GetConditions(), corev1alpha1.ObjectDeploymentAvailable)
+	if objDepAvailableCond != nil && objDepAvailableCond.ObservedGeneration == objDep.ClientObject().GetGeneration() {
+		packageAvailableCond := objDepAvailableCond.DeepCopy()
 		packageAvailableCond.ObservedGeneration = packageObj.ClientObject().GetGeneration()
 
 		meta.SetStatusCondition(packageObj.GetConditions(), *packageAvailableCond)
 	}
 
-	objDepProgressingCondition := meta.FindStatusCondition(*objDep.GetConditions(), corev1alpha1.ObjectDeploymentProgressing)
-	if objDepProgressingCondition != nil && objDepProgressingCondition.ObservedGeneration == objDep.ClientObject().GetGeneration() {
-		packageProgressingCond := objDepProgressingCondition.DeepCopy()
+	objDepProgressingCond := meta.FindStatusCondition(*objDep.GetConditions(), corev1alpha1.ObjectDeploymentProgressing)
+	if objDepProgressingCond != nil && objDepProgressingCond.ObservedGeneration == objDep.ClientObject().GetGeneration() {
+		packageProgressingCond := objDepProgressingCond.DeepCopy()
 		packageProgressingCond.ObservedGeneration = packageObj.ClientObject().GetGeneration()
 
 		meta.SetStatusCondition(packageObj.GetConditions(), *packageProgressingCond)

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -1005,8 +1005,7 @@ func Test_defaultPatcher_patchObject_update_no_metadata(t *testing.T) {
 		patch, err := patches[0].Data(updatedObj)
 		require.NoError(t, err)
 
-		assert.Equal(t,
-			`{"metadata":{"labels":{"my-cool-label":"hans"},"ownerReferences":[{"apiVersion":"v1","blockOwnerDeletion":true,"controller":true,"kind":"ConfigMap","name":"","uid":""}]},"spec":{"key":"val"}}`, string(patch))
+		assert.Equal(t, `{"metadata":{"labels":{"my-cool-label":"hans"},"ownerReferences":[{"apiVersion":"v1","blockOwnerDeletion":true,"controller":true,"kind":"ConfigMap","name":"","uid":""}]},"spec":{"key":"val"}}`, string(patch)) //nolint: lll
 	}
 }
 

--- a/internal/dynamiccache/enqueue_watching.go
+++ b/internal/dynamiccache/enqueue_watching.go
@@ -38,7 +38,8 @@ func NewEnqueueWatchingObjects(watcherRefGetter ownerRefGetter,
 		scheme:           scheme,
 	}
 	if err := e.parseWatcherTypeGroupKind(scheme); err != nil {
-		// This (passing a type that is not in the scheme) HAS to be a programmer error and can't be recovered at runtime anyways.
+		// This (passing a type that is not in the scheme) HAS
+		// to be a programmer error and can't be recovered at runtime anyways.
 		panic(err)
 	}
 	return e

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -153,7 +153,8 @@ func (m *Manager) openShiftEnvironment(ctx context.Context) (
 	}, clusterVersion)
 
 	switch {
-	case apimachinerymeta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+	case apimachinerymeta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) ||
+		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
 		// API not registered in cluster
 		return nil, false, nil
 	case err != nil:

--- a/internal/ownerhandling/annotation.go
+++ b/internal/ownerhandling/annotation.go
@@ -68,7 +68,8 @@ func (s *OwnerStrategyAnnotation) EnqueueRequestForOwner(
 		ownerStrategy: s,
 	}
 	if err := a.parseOwnerTypeGroupKind(s.scheme); err != nil {
-		// This (passing a type that is not in the scheme) HAS to be a programmer error and can't be recovered at runtime anyways.
+		// This (passing a type that is not in the scheme) HAS to be a
+		// programmer error and can't be recovered at runtime anyways.
 		panic(err)
 	}
 	return a
@@ -307,14 +308,18 @@ type AnnotationEnqueueRequestForOwner struct {
 }
 
 // Create implements EventHandler.
-func (e *AnnotationEnqueueRequestForOwner) Create(_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (e *AnnotationEnqueueRequestForOwner) Create(
+	_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface,
+) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}
 }
 
 // Update implements EventHandler.
-func (e *AnnotationEnqueueRequestForOwner) Update(_ context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e *AnnotationEnqueueRequestForOwner) Update(
+	_ context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface,
+) {
 	for _, req := range e.getOwnerReconcileRequest(evt.ObjectOld) {
 		q.Add(req)
 	}
@@ -324,14 +329,18 @@ func (e *AnnotationEnqueueRequestForOwner) Update(_ context.Context, evt event.U
 }
 
 // Delete implements EventHandler.
-func (e *AnnotationEnqueueRequestForOwner) Delete(_ context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (e *AnnotationEnqueueRequestForOwner) Delete(
+	_ context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface,
+) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}
 }
 
 // Generic implements EventHandler.
-func (e *AnnotationEnqueueRequestForOwner) Generic(_ context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (e *AnnotationEnqueueRequestForOwner) Generic(
+	_ context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface,
+) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}

--- a/internal/ownerhandling/annotation_test.go
+++ b/internal/ownerhandling/annotation_test.go
@@ -511,7 +511,10 @@ func TestOwnerStrategyAnnotation_OwnerPatch(t *testing.T) {
 	patch, err := s.OwnerPatch(obj)
 	require.NoError(t, err)
 
-	assert.Equal(t, `{"metadata":{"annotations":{"package-operator.run/owners":"[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"name\":\"cm\",\"namespace\":\"testns\",\"uid\":\"asdfjkl\",\"controller\":true}]","package-operator.run/revision":"3"}}}`, string(patch))
+	expected := `{"metadata":{"annotations":{"package-operator.run/owners":"[{\"apiVersion\":\"v1\",` +
+		`\"kind\":\"ConfigMap\",\"name\":\"cm\",\"namespace\":\"testns\",\"uid\":\"asdfjkl\",` +
+		`\"controller\":true}]","package-operator.run/revision":"3"}}}`
+	assert.Equal(t, expected, string(patch))
 }
 
 func TestOwnerStrategyAnnotation_EnqueueRequestForOwner(t *testing.T) {

--- a/internal/ownerhandling/native_test.go
+++ b/internal/ownerhandling/native_test.go
@@ -202,5 +202,7 @@ func TestOwnerStrategyNative_OwnerPatch(t *testing.T) {
 	patch, err := s.OwnerPatch(obj)
 	require.NoError(t, err)
 
-	assert.Equal(t, `{"metadata":{"annotations":{"package-operator.run/revision":"3"},"ownerReferences":[{"apiVersion":"v1","kind":"ConfigMap","name":"cm","uid":"asdfjkl","controller":true,"blockOwnerDeletion":true}]}}`, string(patch))
+	expected := `{"metadata":{"annotations":{"package-operator.run/revision":"3"},"ownerReferences":` +
+		`[{"apiVersion":"v1","kind":"ConfigMap","name":"cm","uid":"asdfjkl","controller":true,"blockOwnerDeletion":true}]}}`
+	assert.Equal(t, expected, string(patch))
 }

--- a/internal/packages/internal/packagedeploy/chunking.go
+++ b/internal/packages/internal/packagedeploy/chunking.go
@@ -18,7 +18,8 @@ type (
 type (
 	chunkingStrategy string
 
-	// objectChunker implements how to offload objects within a phase into multiple ObjectSlices to reduce load on etcd and the api server.
+	// objectChunker implements how to offload objects within a phase
+	// into multiple ObjectSlices to reduce load on etcd and the api server.
 	objectChunker interface {
 		Chunk(ctx context.Context, phase *corev1alpha1.ObjectSetTemplatePhase) ([][]corev1alpha1.ObjectSetObject, error)
 	}
@@ -48,11 +49,15 @@ func determineChunkingStrategyForPackage(pkg adapters.GenericPackageAccessor) ob
 	}
 }
 
-func (c *NoOpChunker) Chunk(context.Context, *corev1alpha1.ObjectSetTemplatePhase) ([][]corev1alpha1.ObjectSetObject, error) {
+func (c *NoOpChunker) Chunk(
+	context.Context, *corev1alpha1.ObjectSetTemplatePhase,
+) ([][]corev1alpha1.ObjectSetObject, error) {
 	return nil, nil
 }
 
-func (c *EachObjectChunker) Chunk(_ context.Context, phase *corev1alpha1.ObjectSetTemplatePhase) ([][]corev1alpha1.ObjectSetObject, error) {
+func (c *EachObjectChunker) Chunk(
+	_ context.Context, phase *corev1alpha1.ObjectSetTemplatePhase,
+) ([][]corev1alpha1.ObjectSetObject, error) {
 	out := make([][]corev1alpha1.ObjectSetObject, len(phase.Objects))
 	for i, obj := range phase.Objects {
 		out[i] = []corev1alpha1.ObjectSetObject{obj}

--- a/internal/packages/internal/packagedeploy/deployer.go
+++ b/internal/packages/internal/packagedeploy/deployer.go
@@ -78,8 +78,13 @@ func NewClusterPackageDeployer(c client.Client, scheme *runtime.Scheme) *Package
 		newObjectDeployment: adapters.NewClusterObjectDeployment,
 		structuralLoader:    packagestructure.DefaultStructuralLoader,
 
-		deploymentReconciler: newDeploymentReconciler(scheme, c, adapters.NewClusterObjectDeployment, adapters.NewClusterObjectSlice,
-			adapters.NewClusterObjectSliceList, newGenericClusterObjectSetList,
+		deploymentReconciler: newDeploymentReconciler(
+			scheme,
+			c,
+			adapters.NewClusterObjectDeployment,
+			adapters.NewClusterObjectSlice,
+			adapters.NewClusterObjectSliceList,
+			newGenericClusterObjectSetList,
 		),
 		packageValidators: append(
 			packagevalidation.DefaultPackageValidators,
@@ -88,8 +93,9 @@ func NewClusterPackageDeployer(c client.Client, scheme *runtime.Scheme) *Package
 	}
 }
 
-// ImageWithDigest replaces the tag/digest part of the given reference with the digest specified by digest.
-// It does not sanitize the reference and expands well known registries.
+// ImageWithDigest replaces the tag/digest part of the given reference
+// with the digest specified by digest. It does not sanitize the
+// reference and expands well known registries.
 func ImageWithDigest(reference string, digest string) (string, error) {
 	// Parse reference into something we can use.
 	ref, err := name.ParseReference(reference)
@@ -97,7 +103,8 @@ func ImageWithDigest(reference string, digest string) (string, error) {
 		return "", fmt.Errorf("parse image reference: %w", err)
 	}
 
-	// Create a new digest reference from the context of the parsed reference with the parameter digest and return the string.
+	// Create a new digest reference from the context of the parsed reference
+	// with the parameter digest and return the string.
 	return ref.Context().Digest(digest).String(), nil
 }
 

--- a/internal/packages/internal/packagedeploy/deployer_test.go
+++ b/internal/packages/internal/packagedeploy/deployer_test.go
@@ -24,7 +24,8 @@ import (
 var (
 	_          deploymentReconciler = (*deploymentReconcilerMock)(nil)
 	errExample                      = errors.New("example error")
-	testDgst                        = "sha256:52a6b1268e32ed5b6f59da8222f7627979bfb739f32aae3fb5b5ed31b8bf80c4" //nolint:gosec // no credential.
+	//nolint:gosec // not a credential.
+	testDgst = "sha256:52a6b1268e32ed5b6f59da8222f7627979bfb739f32aae3fb5b5ed31b8bf80c4"
 )
 
 func TestNewPackageDeployer(t *testing.T) {

--- a/internal/packages/internal/packagedeploy/deployment_reconciler.go
+++ b/internal/packages/internal/packagedeploy/deployment_reconciler.go
@@ -141,7 +141,9 @@ func (r *DeploymentReconciler) Reconcile(
 }
 
 // GarbageCollect Slices that are no longer referenced.
-func (r *DeploymentReconciler) sliceGarbageCollection(ctx context.Context, deploy adapters.ObjectDeploymentAccessor) error {
+func (r *DeploymentReconciler) sliceGarbageCollection(
+	ctx context.Context, deploy adapters.ObjectDeploymentAccessor,
+) error {
 	objectSets, err := r.listObjectSetsForDeployment(ctx, deploy)
 	if err != nil {
 		return fmt.Errorf("listing Deployments ObjectSets for GC evaluation: %w", err)
@@ -214,7 +216,8 @@ func (r *DeploymentReconciler) listObjectSetsForDeployment(
 }
 
 func (r *DeploymentReconciler) chunkPhase(
-	ctx context.Context, deploy adapters.ObjectDeploymentAccessor, phase *corev1alpha1.ObjectSetTemplatePhase, chunker objectChunker,
+	ctx context.Context, deploy adapters.ObjectDeploymentAccessor,
+	phase *corev1alpha1.ObjectSetTemplatePhase, chunker objectChunker,
 ) error {
 	log := logr.FromContextOrDiscard(ctx)
 
@@ -274,7 +277,8 @@ func (r *DeploymentReconciler) reconcileSlice(
 func (e sliceCollisionError) Error() string { return "ObjectSlice collision with " + e.key.String() }
 
 func (r *DeploymentReconciler) reconcileSliceWithCollisionCount(
-	ctx context.Context, deploy adapters.ObjectDeploymentAccessor, slice adapters.ObjectSliceAccessor, collisionCount int32,
+	ctx context.Context, deploy adapters.ObjectDeploymentAccessor,
+	slice adapters.ObjectSliceAccessor, collisionCount int32,
 ) error {
 	hash := utils.ComputeFNV32Hash(slice.GetObjects(), &collisionCount)
 	name := deploy.ClientObject().GetName() + "-" + hash

--- a/internal/packages/internal/packageexport/oci.go
+++ b/internal/packages/internal/packageexport/oci.go
@@ -16,9 +16,15 @@ import (
 
 // Exports the package as OCI (Open Container Image).
 func ToOCI(pkg *packagetypes.RawPackage) (containerregistrypkgv1.Image, error) {
-	// Hardcoded to linux/amd64 or kubernetes will refuse to pull the image on our target architecture.
-	// We will drop this after refactoring our in-cluster package loading process to make it architecture agnostic.
-	configFile := &containerregistrypkgv1.ConfigFile{Architecture: "amd64", OS: "linux", Config: containerregistrypkgv1.Config{}, RootFS: containerregistrypkgv1.RootFS{Type: "layers"}}
+	// Hardcoded to linux/amd64 or kubernetes will refuse to pull the image on
+	// our target architecture. We will drop this after refactoring our in-cluster
+	// package loading process to make it architecture agnostic.
+	configFile := &containerregistrypkgv1.ConfigFile{
+		Architecture: "amd64",
+		OS:           "linux",
+		Config:       containerregistrypkgv1.Config{},
+		RootFS:       containerregistrypkgv1.RootFS{Type: "layers"},
+	}
 	image, err := mutate.ConfigFile(empty.Image, configFile)
 	if err != nil {
 		return nil, err

--- a/internal/packages/internal/packagemanifestvalidation/helpers.go
+++ b/internal/packages/internal/packagemanifestvalidation/helpers.go
@@ -25,7 +25,11 @@ var (
 	openapiV3Types = sets.NewString("string", "number", "integer", "boolean", openapiV3TypeArray, OpenapiV3TypeObject)
 	// unbounded uses nil to represent an unbounded cardinality value.
 	unbounded                 *uint64
-	allowedFieldsAtRootSchema = []string{"Description", "Type", "Format", "Title", "Maximum", "ExclusiveMaximum", "Minimum", "ExclusiveMinimum", "MaxLength", "MinLength", "Pattern", "MaxItems", "MinItems", "UniqueItems", "MultipleOf", "Required", "Items", "Properties", "ExternalDocs", "Example", "XPreserveUnknownFields", "XValidations"}
+	allowedFieldsAtRootSchema = []string{
+		"Description", "Type", "Format", "Title", "Maximum", "ExclusiveMaximum", "Minimum",
+		"ExclusiveMinimum", "MaxLength", "MinLength", "Pattern", "MaxItems", "MinItems", "UniqueItems",
+		"MultipleOf", "Required", "Items", "Properties", "ExternalDocs", "Example", "XPreserveUnknownFields", "XValidations",
+	}
 
 	newlineMatcher = regexp.MustCompile(`[\n\r]+`) // valid newline chars in CEL grammar
 )
@@ -64,7 +68,11 @@ func getCostErrorMessage(costName string, expressionCost, costLimit uint64) stri
 		factor = fmt.Sprintf("%.1fx", exceedFactor)
 	}
 
-	return fmt.Sprintf("%s exceeds budget by factor of %s (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)", costName, factor)
+	return fmt.Sprintf(
+		"%s exceeds budget by factor of %s (try simplifying the rule, or adding maxItems, "+
+			"maxProperties, and maxLength where arrays, maps, and strings are declared)",
+		costName, factor,
+	)
 }
 
 func hasNewlines(s string) bool {
@@ -86,7 +94,10 @@ func validateMapListKeysMapSet(schema *apiextensions.JSONSchemaProps, fldPath *f
 
 	// set and map list items cannot be nullable
 	if schema.Items.Schema.Nullable {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("items").Child("nullable"), "cannot be nullable when x-kubernetes-list-type is "+*schema.XListType))
+		allErrs = append(allErrs,
+			field.Forbidden(fldPath.Child("items").Child("nullable"),
+				"cannot be nullable when x-kubernetes-list-type is "+*schema.XListType),
+		)
 	}
 
 	switch *schema.XListType {
@@ -100,16 +111,27 @@ func validateMapListKeysMapSet(schema *apiextensions.JSONSchemaProps, fldPath *f
 		for _, k := range schema.XListMapKeys {
 			obj, ok := schema.Items.Schema.Properties[k]
 			if !ok {
-				// we validate that all XListMapKeys are existing properties in ValidateCustomResourceDefinitionOpenAPISchema, so skipping here is ok
+				// we validate that all XListMapKeys are existing properties in
+				// ValidateCustomResourceDefinitionOpenAPISchema, so skipping here is ok.
 				continue
 			}
 
 			if !isRequired[k] && obj.Default == nil {
-				allErrs = append(allErrs, field.Required(fldPath.Child("items").Child("properties").Key(k).Child("default"), "this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property"))
+				allErrs = append(allErrs,
+					field.Required(
+						fldPath.Child("items").Child("properties").Key(k).Child("default"),
+						"this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property",
+					),
+				)
 			}
 
 			if obj.Nullable {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("items").Child("properties").Key(k).Child("nullable"), "this property is in x-kubernetes-list-map-keys, so it cannot be nullable"))
+				allErrs = append(allErrs,
+					field.Forbidden(
+						fldPath.Child("items").Child("properties").Key(k).Child("nullable"),
+						"this property is in x-kubernetes-list-map-keys, so it cannot be nullable",
+					),
+				)
 			}
 		}
 	case xListTypeSet:

--- a/internal/packages/internal/packagemanifestvalidation/validator.go
+++ b/internal/packages/internal/packagemanifestvalidation/validator.go
@@ -94,15 +94,21 @@ func (v *specStandardValidatorV3) validate(schema *apiextensions.JSONSchemaProps
 	}
 
 	if schema.Type == "null" {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("type"), "type cannot be set to null, use nullable as an alternative"))
+		allErrs = append(allErrs,
+			field.Forbidden(fldPath.Child("type"), "type cannot be set to null, use nullable as an alternative"),
+		)
 	}
 
 	if schema.Items != nil && len(schema.Items.JSONSchemas) != 0 {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("items"), "items must be a schema object and not an array"))
+		allErrs = append(allErrs,
+			field.Forbidden(fldPath.Child("items"), "items must be a schema object and not an array"),
+		)
 	}
 
 	if v.isInsideResourceMeta && schema.XEmbeddedResource {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-embedded-resource"), "must not be used inside of resource meta"))
+		allErrs = append(allErrs,
+			field.Forbidden(fldPath.Child("x-kubernetes-embedded-resource"), "must not be used inside of resource meta"),
+		)
 	}
 
 	return allErrs

--- a/internal/packages/internal/packagerender/conditionmap_test.go
+++ b/internal/packages/internal/packagerender/conditionmap_test.go
@@ -25,7 +25,8 @@ func Test_parseConditionMap(t *testing.T) {
 				Object: map[string]any{
 					"metadata": map[string]any{
 						"annotations": map[string]any{
-							manifestsv1alpha1.PackageConditionMapAnnotation: "Available => my-prefix/Available\nSomethingElse => my-prefix/SomethingElse",
+							manifestsv1alpha1.PackageConditionMapAnnotation: "Available => my-prefix/Available\nSomethingElse " +
+								"=> my-prefix/SomethingElse",
 						},
 					},
 				},

--- a/internal/packages/internal/packagerender/objectsettemplate.go
+++ b/internal/packages/internal/packagerender/objectsettemplate.go
@@ -12,7 +12,9 @@ import (
 )
 
 // Renders a ObjectSetTemplateSpec from a PackageInstance to use with ObjectSet and ObjectDeployment APIs.
-func RenderObjectSetTemplateSpec(pkgInstance *packagetypes.PackageInstance) (templateSpec corev1alpha1.ObjectSetTemplateSpec) {
+func RenderObjectSetTemplateSpec(
+	pkgInstance *packagetypes.PackageInstance,
+) (templateSpec corev1alpha1.ObjectSetTemplateSpec) {
 	collector := newPhaseCollector(pkgInstance.Manifest.Spec.Phases...)
 	collector.AddObjects(pkgInstance.Objects...)
 
@@ -56,7 +58,8 @@ func (c phaseCollector) AddObjects(objs ...unstructured.Unstructured) {
 			// This is important!
 			// When submitted to the API server empty maps will be dropped.
 			// Semantic equality checking is considering a nil map not equal to an empty map.
-			// And if semantic equality checking fails, hash collision checks will always find a hash collision if the ObjectSlice already exists.
+			// And if semantic equality checking fails, hash collision checks will always
+			// find a hash collision if the ObjectSlice already exists.
 			annotations = nil
 		}
 

--- a/internal/packages/internal/packagerender/template.go
+++ b/internal/packages/internal/packagerender/template.go
@@ -69,8 +69,10 @@ func templateContext(tmplCtx packagetypes.PackageRenderContext) (map[string]any,
 
 func workaroundnovalue(actualCtx map[string]any) {
 	// The go templating engine substitutes missing values in map with "<no value>".
-	// For our case we would like to raise an error in case of missing values, which can be done by setting the templater option missingkey=error...
-	// except that it is ignored if the map is of type map[string]any for some reason ʕ •ᴥ•ʔ. See https://github.com/golang/go/issues/24963.
+	// For our case we would like to raise an error in case of missing values, which
+	// can be done by setting the templater option missingkey=error... except that
+	// it is ignored if the map is of type map[string]any for some reason
+	// ʕ •ᴥ•ʔ. See https://github.com/golang/go/issues/24963.
 	// Circumventing this by defaulting annotations and labels maps in metadata.
 
 	metadata := actualCtx["package"].(map[string]any)["metadata"].(map[string]any)

--- a/internal/packages/internal/packagestructure/manifest.go
+++ b/internal/packages/internal/packagestructure/manifest.go
@@ -10,7 +10,9 @@ import (
 	"package-operator.run/internal/packages/internal/packagetypes"
 )
 
-func manifestFromFiles(ctx context.Context, scheme *runtime.Scheme, files packagetypes.Files) (*manifests.PackageManifest, error) {
+func manifestFromFiles(
+	ctx context.Context, scheme *runtime.Scheme, files packagetypes.Files,
+) (*manifests.PackageManifest, error) {
 	if bothExtensions(files, packagetypes.PackageManifestFilename) {
 		return nil, packagetypes.ViolationError{
 			Reason: packagetypes.ViolationReasonPackageManifestDuplicated,

--- a/internal/packages/internal/packagestructure/structure.go
+++ b/internal/packages/internal/packagestructure/structure.go
@@ -66,7 +66,9 @@ func (l *StructuralLoader) LoadComponent(
 	return l.load(ctx, cFiles, componentName)
 }
 
-func (l *StructuralLoader) load(ctx context.Context, files packagetypes.Files, componentName string) (*packagetypes.Package, error) {
+func (l *StructuralLoader) load(
+	ctx context.Context, files packagetypes.Files, componentName string,
+) (*packagetypes.Package, error) {
 	pkg := &packagetypes.Package{}
 
 	// PackageManifest

--- a/internal/packages/internal/packagestructure/structure_test.go
+++ b/internal/packages/internal/packagestructure/structure_test.go
@@ -163,7 +163,10 @@ func TestStructuralLoader_Load(t *testing.T) {
 	t.Run("components-enabled/invalid-files-in-components-dir", func(t *testing.T) {
 		t.Parallel()
 		ctx := logr.NewContext(context.Background(), testr.New(t))
-		rawPkg, err := packageimport.FromFolder(ctx, "testdata/multi-component/components-enabled/invalid-files-in-components-dir")
+		rawPkg, err := packageimport.FromFolder(
+			ctx,
+			"testdata/multi-component/components-enabled/invalid-files-in-components-dir",
+		)
 		require.NoError(t, err)
 
 		_, err = sl.Load(ctx, rawPkg)

--- a/internal/packages/internal/packagetypes/types.go
+++ b/internal/packages/internal/packagetypes/types.go
@@ -81,5 +81,7 @@ var (
 	// PackageManifestGroupKind is the kubernetes schema group kind of a PackageManifest.
 	PackageManifestGroupKind = schema.GroupKind{Group: manifestsv1alpha1.GroupVersion.Group, Kind: "PackageManifest"}
 	// PackageManifestLockGroupKind is the kubernetes schema group kind of a PackageManifestLock.
-	PackageManifestLockGroupKind = schema.GroupKind{Group: manifestsv1alpha1.GroupVersion.Group, Kind: "PackageManifestLock"}
+	PackageManifestLockGroupKind = schema.GroupKind{
+		Group: manifestsv1alpha1.GroupVersion.Group, Kind: "PackageManifestLock",
+	}
 )

--- a/internal/packages/internal/packagetypes/violation.go
+++ b/internal/packages/internal/packagetypes/violation.go
@@ -14,7 +14,7 @@ type ViolationError struct {
 	Path      string          // Path shows which file path in the package is responsible for this error.
 	Component string          // Component indicates which component the error is associated with
 	Index     *int            // Index is the index of the YAML document within Path.
-	Subject   string          // Complete subject that produced the error, may be the whole yaml file, a single document, etc.
+	Subject   string          // Complete subject producing the error, may be the whole yaml file, a single document, etc.
 }
 
 func (v ViolationError) Error() string {
@@ -63,7 +63,7 @@ const (
 	ViolationReasonPackageManifestLockInvalid    ViolationReason = "PackageManifestLock invalid"
 	ViolationReasonPackageManifestLockDuplicated ViolationReason = "PackageManifestLock present multiple times"
 	ViolationReasonInvalidYAML                   ViolationReason = "Invalid YAML"
-	ViolationReasonMissingPhaseAnnotation        ViolationReason = "Missing " + manifests.PackagePhaseAnnotation + " Annotation"
+	ViolationReasonMissingPhaseAnnotation        ViolationReason = "Missing " + manifests.PackagePhaseAnnotation + " Annotation" //nolint: lll
 	ViolationReasonMissingGVK                    ViolationReason = "GroupVersionKind not set"
 	ViolationReasonDuplicateObject               ViolationReason = "Duplicate Object"
 	ViolationReasonLabelsInvalid                 ViolationReason = "Labels invalid"
@@ -74,7 +74,7 @@ const (
 	ViolationReasonInvalidComponentPath          ViolationReason = "Invalid component path"
 	ViolationReasonUnknown                       ViolationReason = "Unknown reason"
 	ViolationReasonNestedMultiComponentPkg       ViolationReason = "Nesting multi-component packages not allowed"
-	ViolationReasonInvalidFileInComponentsDir    ViolationReason = "The components directory may only contain folders and dot files"
+	ViolationReasonInvalidFileInComponentsDir    ViolationReason = "The components directory may only contain folders and dot files" //nolint: lll
 	ViolationReasonKubeconform                   ViolationReason = "Kubeconform rejected schema"
 )
 

--- a/internal/packages/internal/packagetypes/violation_test.go
+++ b/internal/packages/internal/packagetypes/violation_test.go
@@ -45,6 +45,10 @@ func TestViolationErrorDetailPath(t *testing.T) {
 func TestViolationErrorDetailPathSubject(t *testing.T) {
 	t.Parallel()
 
-	v := ViolationError{Reason: ViolationReason("cheese reason"), Details: "zoom 200x", Path: "a/b", Subject: "yaml: test\n"}
+	v := ViolationError{
+		Reason:  ViolationReason("cheese reason"),
+		Details: "zoom 200x",
+		Path:    "a/b", Subject: "yaml: test\n",
+	}
 	require.EqualError(t, v, "cheese reason in a/b: zoom 200x\nyaml: test")
 }

--- a/internal/packages/internal/packagevalidation/kubeconform.go
+++ b/internal/packages/internal/packagevalidation/kubeconform.go
@@ -23,8 +23,10 @@ func (nv *noopKubeconformValidator) Validate(_ string, _ io.ReadCloser) []valida
 }
 
 const (
-	defaultKubeSchemaLocation = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json"
-	defaultCRDSSchemaLocation = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+	defaultKubeSchemaLocation = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/" +
+		"master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json"
+	defaultCRDSSchemaLocation = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/" +
+		"{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
 )
 
 func defaultKubeconformSchemaLocations(

--- a/internal/preflight/apis_exist_test.go
+++ b/internal/preflight/apis_exist_test.go
@@ -18,7 +18,9 @@ import (
 
 type sub struct{ mock.Mock }
 
-func (s *sub) Check(ctx context.Context, owner client.Object, obj client.Object) (violations []preflight.Violation, err error) {
+func (s *sub) Check(
+	ctx context.Context, owner client.Object, obj client.Object,
+) (violations []preflight.Violation, err error) {
 	ret := s.Called(ctx, owner, obj)
 
 	return ret.Get(0).([]preflight.Violation), ret.Error(1)
@@ -64,7 +66,9 @@ func TestAPIExistenceNotExists(t *testing.T) {
 
 	checkVios := []preflight.Violation{{Position: "kind /", Error: "/3, Kind=kind not registered on the api server."}}
 
-	m.On("RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"}).Once().Return(&meta.RESTMapping{}, &meta.NoResourceMatchError{})
+	m.On(
+		"RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"},
+	).Once().Return(&meta.RESTMapping{}, &meta.NoResourceMatchError{})
 	violations, err := preflight.NewAPIExistence(m, s).Check(ctx, owner, obj)
 
 	require.NoError(t, err)
@@ -82,7 +86,9 @@ func TestAPIExistenceErr(t *testing.T) {
 
 	checkErr := fmt.Errorf("smth") //nolint: goerr113
 
-	m.On("RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"}).Once().Return(&meta.RESTMapping{}, checkErr)
+	m.On(
+		"RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"},
+	).Once().Return(&meta.RESTMapping{}, checkErr)
 
 	violations, err := preflight.NewAPIExistence(m, s).Check(ctx, owner, obj)
 

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -105,14 +105,18 @@ func TestPreflightListOk(t *testing.T) {
 	var called1, called2 bool
 
 	list := PhasesCheckerList{
-		phasesCheckerFn(func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
-			called1 = true
-			return
-		}),
-		phasesCheckerFn(func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
-			called2 = true
-			return
-		}),
+		phasesCheckerFn(
+			func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
+				called1 = true
+				return
+			},
+		),
+		phasesCheckerFn(
+			func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
+				called2 = true
+				return
+			},
+		),
 	}
 
 	phases := []corev1alpha1.ObjectSetTemplatePhase{
@@ -133,18 +137,24 @@ func TestPreflightListWithError(t *testing.T) {
 	var called1, called2, called3 bool
 
 	list := PhasesCheckerList{
-		phasesCheckerFn(func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
-			called1 = true
-			return
-		}),
-		phasesCheckerFn(func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
-			called2 = true
-			return violations, errChecker
-		}),
-		phasesCheckerFn(func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
-			called3 = true
-			return
-		}),
+		phasesCheckerFn(
+			func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
+				called1 = true
+				return
+			},
+		),
+		phasesCheckerFn(
+			func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
+				called2 = true
+				return violations, errChecker
+			},
+		),
+		phasesCheckerFn(
+			func(ctx context.Context, phases []corev1alpha1.ObjectSetTemplatePhase) (violations []Violation, err error) {
+				called3 = true
+				return
+			},
+		),
 	}
 
 	phases := []corev1alpha1.ObjectSetTemplatePhase{

--- a/internal/probing/parse.go
+++ b/internal/probing/parse.go
@@ -35,7 +35,9 @@ func Parse(ctx context.Context, packageProbes []corev1alpha1.ObjectSetProbe) (pr
 
 // ParseSelector reads a corev1alpha1.ProbeSelector and wraps a Prober,
 // only executing the Prober when the selector criteria match.
-func ParseSelector(_ context.Context, selector corev1alpha1.ProbeSelector, probe probing.Prober) (probing.Prober, error) {
+func ParseSelector(
+	_ context.Context, selector corev1alpha1.ProbeSelector, probe probing.Prober,
+) (probing.Prober, error) {
 	if selector.Kind != nil {
 		probe = &probing.GroupKindSelector{
 			Prober: probe,

--- a/internal/testutil/ctrl_client.go
+++ b/internal/testutil/ctrl_client.go
@@ -49,7 +49,9 @@ func (c *CtrlClient) Status() client.StatusWriter {
 
 // Reader interface
 
-func (c *CtrlClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+func (c *CtrlClient) Get(
+	ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption,
+) error {
 	args := c.Called(ctx, key, obj, opts)
 	return args.Error(0)
 }
@@ -76,7 +78,9 @@ func (c *CtrlClient) Update(ctx context.Context, obj client.Object, opts ...clie
 	return args.Error(0)
 }
 
-func (c *CtrlClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+func (c *CtrlClient) Patch(
+	ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption,
+) error {
 	args := c.Called(ctx, obj, patch, opts)
 	return args.Error(0)
 }
@@ -116,7 +120,9 @@ func (c *CtrlStatusClient) Patch(
 	return args.Error(0)
 }
 
-func (c *CtrlStatusClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+func (c *CtrlStatusClient) Create(
+	ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption,
+) error {
 	args := c.Called(ctx, obj, subResource, opts)
 	return args.Error(0)
 }

--- a/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
+++ b/internal/testutil/ownerhandlingmocks/ownerstrategy_mock.go
@@ -45,7 +45,9 @@ func (m *OwnerStrategyMock) SetControllerReference(owner, obj metav1.Object) err
 	return args.Error(0)
 }
 
-func (m *OwnerStrategyMock) EnqueueRequestForOwner(ownerType client.Object, mapper meta.RESTMapper, isController bool) handler.EventHandler {
+func (m *OwnerStrategyMock) EnqueueRequestForOwner(
+	ownerType client.Object, mapper meta.RESTMapper, isController bool,
+) handler.EventHandler {
 	args := m.Called(ownerType, mapper, isController)
 	return args.Get(0).(handler.EventHandler)
 }

--- a/pkg/probing/observedgeneration.go
+++ b/pkg/probing/observedgeneration.go
@@ -2,9 +2,9 @@ package probing
 
 import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-// ObservedGenerationProbe wraps the given Prober and ensures that .status.observedGeneration is equal to .metadata.generation,
-// before running the given probe. If the probed object does not contain the .status.observedGeneration field,
-// the given prober is executed directly.
+// ObservedGenerationProbe wraps the given Prober and ensures that .status.observedGeneration is equal to
+// .metadata.generation, before running the given probe. If the probed object does not contain the
+// .status.observedGeneration field, the given prober is executed directly.
 type ObservedGenerationProbe struct {
 	Prober
 }


### PR DESCRIPTION
Enable the golangci-lint `lll` linters which ensures that code lines may not be longer that 120 chars (non whitespace)
