### PR TITLE
Replace interface{} usage with any

### DIFF
--- a/cmd/package-operator-manager/components/components.go
+++ b/cmd/package-operator-manager/components/components.go
@@ -34,7 +34,7 @@ import (
 // Returns a new pre-configured DI container.
 func NewComponents() (*dig.Container, error) {
 	container := dig.New()
-	providers := []interface{}{
+	providers := []any{
 		ProvideScheme, ProvideRestConfig, ProvideManager,
 		ProvideMetricsRecorder, ProvideDynamicCache,
 		ProvideUncachedClient, ProvideOptions, ProvideLogger,

--- a/cmd/package-operator-manager/components/setups.go
+++ b/cmd/package-operator-manager/components/setups.go
@@ -54,8 +54,8 @@ type AllControllers struct {
 	ClusterObjectTemplate ClusterObjectTemplateController
 }
 
-func (ac AllControllers) List() []interface{} {
-	return []interface{}{
+func (ac AllControllers) List() []any {
+	return []any{
 		ac.ObjectSet, ac.ClusterObjectSet,
 		ac.ObjectSetPhase, ac.ClusterObjectSetPhase,
 		ac.ObjectDeployment, ac.ClusterObjectDeployment,
@@ -118,8 +118,8 @@ type BootstrapControllers struct {
 	ClusterObjectSet        ClusterObjectSetController
 }
 
-func (bc BootstrapControllers) List() []interface{} {
-	return []interface{}{
+func (bc BootstrapControllers) List() []any {
+	return []any{
 		bc.ClusterObjectSet, bc.ClusterObjectDeployment, bc.ClusterPackage,
 	}
 }

--- a/integration/package-operator/objecttemplate_test.go
+++ b/integration/package-operator/objecttemplate_test.go
@@ -169,7 +169,7 @@ spec:
 		}, dev.WithTimeout(20*time.Second)))
 
 	assert.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(pkg), pkg))
-	packageConfig := map[string]interface{}{}
+	packageConfig := map[string]any{}
 
 	assert.NoError(t, yaml.Unmarshal(pkg.Spec.Config.Raw, &packageConfig))
 	assert.Equal(t, cm1Value, packageConfig[cm1Destination])
@@ -190,7 +190,7 @@ spec:
 
 	// check that config value was updated
 	assert.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(pkg), pkg))
-	packageConfig2 := map[string]interface{}{}
+	packageConfig2 := map[string]any{}
 
 	assert.NoError(t, yaml.Unmarshal(pkg.Spec.Config.Raw, &packageConfig2))
 	assert.Equal(t, cm1PatchedValue, packageConfig2[cm1Destination])
@@ -208,7 +208,7 @@ spec:
 		}, dev.WithTimeout(20*time.Second)))
 
 	assert.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(clusterPkg), clusterPkg))
-	clusterPackageConfig := map[string]interface{}{}
+	clusterPackageConfig := map[string]any{}
 	assert.NoError(t, yaml.Unmarshal(clusterPkg.Spec.Config.Raw, &clusterPackageConfig))
 	assert.Equal(t, cm1PatchedValue, clusterPackageConfig[cm1Destination])
 	assert.Equal(t, cm2Value, clusterPackageConfig[cm2Destination])
@@ -342,7 +342,7 @@ spec:
 		}, dev.WithTimeout(20*time.Second)))
 
 	assert.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(pkg), pkg))
-	packageConfig := map[string]interface{}{}
+	packageConfig := map[string]any{}
 
 	assert.NoError(t, yaml.Unmarshal(pkg.Spec.Config.Raw, &packageConfig))
 	assert.Equal(t, secretValue, packageConfig[secretDestination])

--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -164,7 +164,7 @@ func TestPackage_success(t *testing.T) {
 }
 
 // assert len but print json output.
-func assertLenWithJSON[T interface{}](t *testing.T, obj []T, l int) {
+func assertLenWithJSON[T any](t *testing.T, obj []T, l int) {
 	t.Helper()
 	if len(obj) == l {
 		return

--- a/internal/apis/manifests/conversion_generated.go
+++ b/internal/apis/manifests/conversion_generated.go
@@ -23,192 +23,192 @@ func init() {
 // RegisterConversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterConversions(s *runtime.Scheme) error {
-	if err := s.AddGeneratedConversionFunc((*PackageEnvironment)(nil), (*v1alpha1.PackageEnvironment)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageEnvironment)(nil), (*v1alpha1.PackageEnvironment)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageEnvironment_To_v1alpha1_PackageEnvironment(a.(*PackageEnvironment), b.(*v1alpha1.PackageEnvironment), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironment)(nil), (*PackageEnvironment)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironment)(nil), (*PackageEnvironment)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageEnvironment_To_manifests_PackageEnvironment(a.(*v1alpha1.PackageEnvironment), b.(*PackageEnvironment), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentKubernetes)(nil), (*v1alpha1.PackageEnvironmentKubernetes)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentKubernetes)(nil), (*v1alpha1.PackageEnvironmentKubernetes)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageEnvironmentKubernetes_To_v1alpha1_PackageEnvironmentKubernetes(a.(*PackageEnvironmentKubernetes), b.(*v1alpha1.PackageEnvironmentKubernetes), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentKubernetes)(nil), (*PackageEnvironmentKubernetes)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentKubernetes)(nil), (*PackageEnvironmentKubernetes)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageEnvironmentKubernetes_To_manifests_PackageEnvironmentKubernetes(a.(*v1alpha1.PackageEnvironmentKubernetes), b.(*PackageEnvironmentKubernetes), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentOpenShift)(nil), (*v1alpha1.PackageEnvironmentOpenShift)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentOpenShift)(nil), (*v1alpha1.PackageEnvironmentOpenShift)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageEnvironmentOpenShift_To_v1alpha1_PackageEnvironmentOpenShift(a.(*PackageEnvironmentOpenShift), b.(*v1alpha1.PackageEnvironmentOpenShift), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentOpenShift)(nil), (*PackageEnvironmentOpenShift)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentOpenShift)(nil), (*PackageEnvironmentOpenShift)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageEnvironmentOpenShift_To_manifests_PackageEnvironmentOpenShift(a.(*v1alpha1.PackageEnvironmentOpenShift), b.(*PackageEnvironmentOpenShift), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentProxy)(nil), (*v1alpha1.PackageEnvironmentProxy)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageEnvironmentProxy)(nil), (*v1alpha1.PackageEnvironmentProxy)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageEnvironmentProxy_To_v1alpha1_PackageEnvironmentProxy(a.(*PackageEnvironmentProxy), b.(*v1alpha1.PackageEnvironmentProxy), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentProxy)(nil), (*PackageEnvironmentProxy)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageEnvironmentProxy)(nil), (*PackageEnvironmentProxy)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageEnvironmentProxy_To_manifests_PackageEnvironmentProxy(a.(*v1alpha1.PackageEnvironmentProxy), b.(*PackageEnvironmentProxy), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifest)(nil), (*v1alpha1.PackageManifest)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifest)(nil), (*v1alpha1.PackageManifest)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifest_To_v1alpha1_PackageManifest(a.(*PackageManifest), b.(*v1alpha1.PackageManifest), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifest)(nil), (*PackageManifest)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifest)(nil), (*PackageManifest)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifest_To_manifests_PackageManifest(a.(*v1alpha1.PackageManifest), b.(*PackageManifest), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestComponentsConfig)(nil), (*v1alpha1.PackageManifestComponentsConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestComponentsConfig)(nil), (*v1alpha1.PackageManifestComponentsConfig)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestComponentsConfig_To_v1alpha1_PackageManifestComponentsConfig(a.(*PackageManifestComponentsConfig), b.(*v1alpha1.PackageManifestComponentsConfig), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestComponentsConfig)(nil), (*PackageManifestComponentsConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestComponentsConfig)(nil), (*PackageManifestComponentsConfig)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestComponentsConfig_To_manifests_PackageManifestComponentsConfig(a.(*v1alpha1.PackageManifestComponentsConfig), b.(*PackageManifestComponentsConfig), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestImage)(nil), (*v1alpha1.PackageManifestImage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestImage)(nil), (*v1alpha1.PackageManifestImage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestImage_To_v1alpha1_PackageManifestImage(a.(*PackageManifestImage), b.(*v1alpha1.PackageManifestImage), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestImage)(nil), (*PackageManifestImage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestImage)(nil), (*PackageManifestImage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestImage_To_manifests_PackageManifestImage(a.(*v1alpha1.PackageManifestImage), b.(*PackageManifestImage), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestLock)(nil), (*v1alpha1.PackageManifestLock)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestLock)(nil), (*v1alpha1.PackageManifestLock)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestLock_To_v1alpha1_PackageManifestLock(a.(*PackageManifestLock), b.(*v1alpha1.PackageManifestLock), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLock)(nil), (*PackageManifestLock)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLock)(nil), (*PackageManifestLock)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestLock_To_manifests_PackageManifestLock(a.(*v1alpha1.PackageManifestLock), b.(*PackageManifestLock), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestLockImage)(nil), (*v1alpha1.PackageManifestLockImage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestLockImage)(nil), (*v1alpha1.PackageManifestLockImage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestLockImage_To_v1alpha1_PackageManifestLockImage(a.(*PackageManifestLockImage), b.(*v1alpha1.PackageManifestLockImage), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLockImage)(nil), (*PackageManifestLockImage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLockImage)(nil), (*PackageManifestLockImage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestLockImage_To_manifests_PackageManifestLockImage(a.(*v1alpha1.PackageManifestLockImage), b.(*PackageManifestLockImage), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestLockSpec)(nil), (*v1alpha1.PackageManifestLockSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestLockSpec)(nil), (*v1alpha1.PackageManifestLockSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestLockSpec_To_v1alpha1_PackageManifestLockSpec(a.(*PackageManifestLockSpec), b.(*v1alpha1.PackageManifestLockSpec), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLockSpec)(nil), (*PackageManifestLockSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestLockSpec)(nil), (*PackageManifestLockSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestLockSpec_To_manifests_PackageManifestLockSpec(a.(*v1alpha1.PackageManifestLockSpec), b.(*PackageManifestLockSpec), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestPhase)(nil), (*v1alpha1.PackageManifestPhase)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestPhase)(nil), (*v1alpha1.PackageManifestPhase)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestPhase_To_v1alpha1_PackageManifestPhase(a.(*PackageManifestPhase), b.(*v1alpha1.PackageManifestPhase), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestPhase)(nil), (*PackageManifestPhase)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestPhase)(nil), (*PackageManifestPhase)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestPhase_To_manifests_PackageManifestPhase(a.(*v1alpha1.PackageManifestPhase), b.(*PackageManifestPhase), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestSpec)(nil), (*v1alpha1.PackageManifestSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestSpec)(nil), (*v1alpha1.PackageManifestSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestSpec_To_v1alpha1_PackageManifestSpec(a.(*PackageManifestSpec), b.(*v1alpha1.PackageManifestSpec), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestSpec)(nil), (*PackageManifestSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestSpec)(nil), (*PackageManifestSpec)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestSpec_To_manifests_PackageManifestSpec(a.(*v1alpha1.PackageManifestSpec), b.(*PackageManifestSpec), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestSpecConfig)(nil), (*v1alpha1.PackageManifestSpecConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestSpecConfig)(nil), (*v1alpha1.PackageManifestSpecConfig)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestSpecConfig_To_v1alpha1_PackageManifestSpecConfig(a.(*PackageManifestSpecConfig), b.(*v1alpha1.PackageManifestSpecConfig), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestSpecConfig)(nil), (*PackageManifestSpecConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestSpecConfig)(nil), (*PackageManifestSpecConfig)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestSpecConfig_To_manifests_PackageManifestSpecConfig(a.(*v1alpha1.PackageManifestSpecConfig), b.(*PackageManifestSpecConfig), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestTest)(nil), (*v1alpha1.PackageManifestTest)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestTest)(nil), (*v1alpha1.PackageManifestTest)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestTest_To_v1alpha1_PackageManifestTest(a.(*PackageManifestTest), b.(*v1alpha1.PackageManifestTest), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTest)(nil), (*PackageManifestTest)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTest)(nil), (*PackageManifestTest)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestTest_To_manifests_PackageManifestTest(a.(*v1alpha1.PackageManifestTest), b.(*PackageManifestTest), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestTestCaseTemplate)(nil), (*v1alpha1.PackageManifestTestCaseTemplate)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestTestCaseTemplate)(nil), (*v1alpha1.PackageManifestTestCaseTemplate)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestTestCaseTemplate_To_v1alpha1_PackageManifestTestCaseTemplate(a.(*PackageManifestTestCaseTemplate), b.(*v1alpha1.PackageManifestTestCaseTemplate), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTestCaseTemplate)(nil), (*PackageManifestTestCaseTemplate)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTestCaseTemplate)(nil), (*PackageManifestTestCaseTemplate)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestTestCaseTemplate_To_manifests_PackageManifestTestCaseTemplate(a.(*v1alpha1.PackageManifestTestCaseTemplate), b.(*PackageManifestTestCaseTemplate), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*PackageManifestTestKubeconform)(nil), (*v1alpha1.PackageManifestTestKubeconform)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*PackageManifestTestKubeconform)(nil), (*v1alpha1.PackageManifestTestKubeconform)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_PackageManifestTestKubeconform_To_v1alpha1_PackageManifestTestKubeconform(a.(*PackageManifestTestKubeconform), b.(*v1alpha1.PackageManifestTestKubeconform), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTestKubeconform)(nil), (*PackageManifestTestKubeconform)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.PackageManifestTestKubeconform)(nil), (*PackageManifestTestKubeconform)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_PackageManifestTestKubeconform_To_manifests_PackageManifestTestKubeconform(a.(*v1alpha1.PackageManifestTestKubeconform), b.(*PackageManifestTestKubeconform), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*TemplateContext)(nil), (*v1alpha1.TemplateContext)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*TemplateContext)(nil), (*v1alpha1.TemplateContext)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_TemplateContext_To_v1alpha1_TemplateContext(a.(*TemplateContext), b.(*v1alpha1.TemplateContext), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContext)(nil), (*TemplateContext)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContext)(nil), (*TemplateContext)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_TemplateContext_To_manifests_TemplateContext(a.(*v1alpha1.TemplateContext), b.(*TemplateContext), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*TemplateContextObjectMeta)(nil), (*v1alpha1.TemplateContextObjectMeta)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*TemplateContextObjectMeta)(nil), (*v1alpha1.TemplateContextObjectMeta)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_TemplateContextObjectMeta_To_v1alpha1_TemplateContextObjectMeta(a.(*TemplateContextObjectMeta), b.(*v1alpha1.TemplateContextObjectMeta), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContextObjectMeta)(nil), (*TemplateContextObjectMeta)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContextObjectMeta)(nil), (*TemplateContextObjectMeta)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_TemplateContextObjectMeta_To_manifests_TemplateContextObjectMeta(a.(*v1alpha1.TemplateContextObjectMeta), b.(*TemplateContextObjectMeta), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*TemplateContextPackage)(nil), (*v1alpha1.TemplateContextPackage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*TemplateContextPackage)(nil), (*v1alpha1.TemplateContextPackage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_manifests_TemplateContextPackage_To_v1alpha1_TemplateContextPackage(a.(*TemplateContextPackage), b.(*v1alpha1.TemplateContextPackage), scope)
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContextPackage)(nil), (*TemplateContextPackage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	if err := s.AddGeneratedConversionFunc((*v1alpha1.TemplateContextPackage)(nil), (*TemplateContextPackage)(nil), func(a, b any, scope conversion.Scope) error {
 		return Convert_v1alpha1_TemplateContextPackage_To_manifests_TemplateContextPackage(a.(*v1alpha1.TemplateContextPackage), b.(*TemplateContextPackage), scope)
 	}); err != nil {
 		return err

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -156,7 +156,7 @@ type digestResolverMock struct {
 }
 
 func (m *digestResolverMock) ResolveDigest(ref string, opts ...ResolveDigestOption) (string, error) {
-	actualArgs := []interface{}{ref}
+	actualArgs := []any{ref}
 
 	for _, opt := range opts {
 		actualArgs = append(actualArgs, opt)

--- a/internal/controllers/controllers.go
+++ b/internal/controllers/controllers.go
@@ -41,8 +41,8 @@ func EnsureFinalizer(
 	}
 
 	controllerutil.AddFinalizer(obj, finalizer)
-	patch := map[string]interface{}{
-		"metadata": map[string]interface{}{
+	patch := map[string]any{
+		"metadata": map[string]any{
 			"resourceVersion": obj.GetResourceVersion(),
 			"finalizers":      obj.GetFinalizers(),
 		},
@@ -69,8 +69,8 @@ func RemoveFinalizer(
 
 	controllerutil.RemoveFinalizer(obj, finalizer)
 
-	patch := map[string]interface{}{
-		"metadata": map[string]interface{}{
+	patch := map[string]any{
+		"metadata": map[string]any{
 			"resourceVersion": obj.GetResourceVersion(),
 			"finalizers":      obj.GetFinalizers(),
 		},

--- a/internal/controllers/controllers_test.go
+++ b/internal/controllers/controllers_test.go
@@ -256,9 +256,9 @@ func TestRemoveDynamicCacheLabel(t *testing.T) {
 	expectedLabels := map[string]string{}
 
 	object := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"labels": map[string]any{
 					DynamicCacheLabel: "True",
 				},
 			},

--- a/internal/controllers/hostedclusters/hostedcluster_controller.go
+++ b/internal/controllers/hostedclusters/hostedcluster_controller.go
@@ -125,7 +125,7 @@ func (c *HostedClusterController) desiredPackage(cluster *v1beta1.HostedCluster)
 		},
 	}
 
-	config := map[string]interface{}{}
+	config := map[string]any{}
 	if c.remotePhaseAffinity != nil {
 		config["affinity"] = c.remotePhaseAffinity
 	}

--- a/internal/controllers/objectdeployments/new_revision_reconciler_test.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler_test.go
@@ -217,7 +217,7 @@ func Test_newRevisionReconciler_createsObjectSet(t *testing.T) {
 				t,
 				"Create",
 				mock.Anything,
-				mock.MatchedBy(func(item interface{}) bool {
+				mock.MatchedBy(func(item any) bool {
 					obj := item.(*corev1alpha1.ObjectSet)
 					requireObject(t, obj, testCase.deploymentHash, testCase.prevRevisions)
 

--- a/internal/controllers/objectdeployments/objectset_reconciler_test.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler_test.go
@@ -154,14 +154,14 @@ func Test_ObjectSetReconciler(t *testing.T) {
 				t,
 				"Reconcile",
 				mock.Anything,
-				mock.MatchedBy(func(item interface{}) bool {
+				mock.MatchedBy(func(item any) bool {
 					if len(testCase.expectedCurrentRevision) == 0 {
 						return item == nil
 					}
 					obj := item.(*GenericObjectSet)
 					return obj.Name == testCase.expectedCurrentRevision
 				}),
-				mock.MatchedBy(func(obj interface{}) bool {
+				mock.MatchedBy(func(obj any) bool {
 					objs := obj.([]genericObjectSet)
 					if len(objs) != len(testCase.expectedPrevRevisions) {
 						return false

--- a/internal/controllers/objectsets/objectsliceload_reconciler_test.go
+++ b/internal/controllers/objectsets/objectsliceload_reconciler_test.go
@@ -27,8 +27,8 @@ func TestObjectSliceLoadReconciler(t *testing.T) {
 
 	object1 := corev1alpha1.ObjectSetObject{
 		Object: unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			Object: map[string]any{
+				"metadata": map[string]any{
 					"name": "o-1",
 				},
 			},
@@ -37,8 +37,8 @@ func TestObjectSliceLoadReconciler(t *testing.T) {
 
 	object2 := corev1alpha1.ObjectSetObject{
 		Object: unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			Object: map[string]any{
+				"metadata": map[string]any{
 					"name": "o-2",
 				},
 			},

--- a/internal/controllers/objectsets/remotephase_reconciler.go
+++ b/internal/controllers/objectsets/remotephase_reconciler.go
@@ -145,11 +145,11 @@ func (r *objectSetRemotePhaseReconciler) Reconcile(
 	// Pause/Unpause
 	if currentObjectSetPhase.IsPaused() != desiredObjectSetPhase.IsPaused() {
 		current := currentObjectSetPhase.ClientObject()
-		patch := map[string]interface{}{
-			"metadata": map[string]interface{}{
+		patch := map[string]any{
+			"metadata": map[string]any{
 				"resourceVersion": current.GetResourceVersion(),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"paused": desiredObjectSetPhase.IsPaused(),
 			},
 		}

--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -97,66 +97,66 @@ func Test_copySourceItems(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
-		object   map[string]interface{}
+		object   map[string]any
 		source   string
 		dest     string
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name: "string stays string",
-			object: map[string]interface{}{
-				"data": map[string]interface{}{
+			object: map[string]any{
+				"data": map[string]any{
 					"something": "123",
 				},
 			},
 			source: ".data.something",
 			dest:   ".banana",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"banana": "123",
 			},
 		},
 		{
 			name: "number stays number",
-			object: map[string]interface{}{
-				"data": map[string]interface{}{
+			object: map[string]any{
+				"data": map[string]any{
 					"something": 123,
 				},
 			},
 			source: ".data.something",
 			dest:   ".banana",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"banana": float64(123), // json numbers are floats
 			},
 		},
 		{
 			name: "supports dots",
-			object: map[string]interface{}{
-				"data": map[string]interface{}{
+			object: map[string]any{
+				"data": map[string]any{
 					"some.thing": "123",
 				},
 			},
 			source: `.data['some\.thing']`,
 			dest:   ".banana",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"banana": "123",
 			},
 		},
 		{
 			name: "multiple results",
-			object: map[string]interface{}{
-				"data": []interface{}{
-					map[string]interface{}{
+			object: map[string]any{
+				"data": []any{
+					map[string]any{
 						"name": "123",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "456",
 					},
 				},
 			},
 			source: ".data..name",
 			dest:   ".banana",
-			expected: map[string]interface{}{
-				"banana": []interface{}{"123", "456"},
+			expected: map[string]any{
+				"banana": []any{"123", "456"},
 			},
 		},
 	}
@@ -169,7 +169,7 @@ func Test_copySourceItems(t *testing.T) {
 			sourceObj := &unstructured.Unstructured{
 				Object: test.object,
 			}
-			sourcesConfig := map[string]interface{}{}
+			sourcesConfig := map[string]any{}
 			items := []corev1alpha1.ObjectTemplateSourceItem{
 				{Key: test.source, Destination: test.dest},
 			}
@@ -184,9 +184,9 @@ func Test_copySourceItems(t *testing.T) {
 func Test_copySourceItems_notfound(t *testing.T) {
 	t.Parallel()
 	sourceObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{},
+		Object: map[string]any{},
 	}
-	sourcesConfig := map[string]interface{}{}
+	sourcesConfig := map[string]any{}
 	items := []corev1alpha1.ObjectTemplateSourceItem{
 		{Key: ".data.something", Destination: ".banana"},
 	}
@@ -198,13 +198,13 @@ func Test_copySourceItems_notfound(t *testing.T) {
 func Test_copySourceItems_nonJSONPath_destination(t *testing.T) {
 	t.Parallel()
 	sourceObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"data": map[string]interface{}{
+		Object: map[string]any{
+			"data": map[string]any{
 				"something": "123",
 			},
 		},
 	}
-	sourcesConfig := map[string]interface{}{}
+	sourcesConfig := map[string]any{}
 	items := []corev1alpha1.ObjectTemplateSourceItem{
 		{Key: ".data.something", Destination: "banana"},
 	}
@@ -251,7 +251,7 @@ func Test_templateReconciler_templateObject(t *testing.T) {
 			}
 
 			pkg := &corev1alpha1.Package{}
-			sourcesConfig := map[string]interface{}{
+			sourcesConfig := map[string]any{
 				"Database":      "asdf",
 				"username1":     "user",
 				"auth_password": "hunter2",
@@ -263,7 +263,7 @@ func Test_templateReconciler_templateObject(t *testing.T) {
 			require.NoError(t, err)
 
 			for key, value := range sourcesConfig {
-				config := map[string]interface{}{}
+				config := map[string]any{}
 				require.NoError(t, yaml.Unmarshal(pkg.Spec.Config.Raw, &config))
 				assert.Equal(t, value, config[key])
 			}
@@ -287,13 +287,13 @@ func Test_updateStatusConditionsFromOwnedObject(t *testing.T) {
 		{
 			name: "conditions reported",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Available",
 								"status":             "True",
 								"observedGeneration": int64(4),
@@ -301,7 +301,7 @@ func Test_updateStatusConditionsFromOwnedObject(t *testing.T) {
 								"message":            "",
 							},
 							// outdated
-							map[string]interface{}{
+							map[string]any{
 								"type":               "Test",
 								"status":             "True",
 								"observedGeneration": int64(2),
@@ -322,14 +322,14 @@ func Test_updateStatusConditionsFromOwnedObject(t *testing.T) {
 		{
 			name: "status outdated",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
-					"status": map[string]interface{}{
+					"status": map[string]any{
 						"observedGeneration": int64(2),
-						"conditions": []interface{}{
-							map[string]interface{}{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Available",
 								"status":             "True",
 								"observedGeneration": int64(4),

--- a/internal/controllers/objecttemplate/template_transformer.go
+++ b/internal/controllers/objecttemplate/template_transformer.go
@@ -9,12 +9,12 @@ import (
 )
 
 type TemplateContext struct {
-	Config      map[string]interface{} `json:"config"`
-	Environment map[string]interface{} `json:"environment"`
+	Config      map[string]any `json:"config"`
+	Environment map[string]any `json:"environment"`
 }
 
 type TemplateTransformer struct {
-	tctx map[string]interface{}
+	tctx map[string]any
 }
 
 func NewTemplateTransformer(tmplCtx TemplateContext) (*TemplateTransformer, error) {
@@ -23,7 +23,7 @@ func NewTemplateTransformer(tmplCtx TemplateContext) (*TemplateTransformer, erro
 		return nil, err
 	}
 
-	actualCtx := map[string]interface{}{}
+	actualCtx := map[string]any{}
 	if err := json.Unmarshal(p, &actualCtx); err != nil {
 		return nil, err
 	}

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -526,13 +526,13 @@ func TestPhaseReconciler_reconcileObject_update(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					corev1alpha1.ObjectSetRevisionAnnotation: "3",
 				},
-				"ownerReferences": []interface{}{
-					map[string]interface{}{
+				"ownerReferences": []any{
+					map[string]any{
 						"apiVersion": "",
 						"kind":       "",
 						"name":       "",
@@ -568,20 +568,20 @@ func TestPhaseReconciler_desiredObject(t *testing.T) {
 
 	phaseObject := corev1alpha1.ObjectSetObject{
 		Object: unstructured.Unstructured{
-			Object: map[string]interface{}{"kind": "test"},
+			Object: map[string]any{"kind": "test"},
 		},
 	}
 	desiredObj, err := r.desiredObject(ctx, owner, phaseObject)
 	require.NoError(t, err)
 
 	assert.Equal(t, &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind": "test",
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					corev1alpha1.ObjectSetRevisionAnnotation: "5",
 				},
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					DynamicCacheLabel:                      "True",
 					manifestsv1alpha1.PackageLabel:         "pkg-label",
 					manifestsv1alpha1.PackageInstanceLabel: "pkg-instance-label",
@@ -612,20 +612,20 @@ func TestPhaseReconciler_desiredObject_defaultsNamespace(t *testing.T) {
 
 	phaseObject := corev1alpha1.ObjectSetObject{
 		Object: unstructured.Unstructured{
-			Object: map[string]interface{}{"kind": "test"},
+			Object: map[string]any{"kind": "test"},
 		},
 	}
 	desiredObj, err := r.desiredObject(ctx, owner, phaseObject)
 	require.NoError(t, err)
 
 	assert.Equal(t, &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind": "test",
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					corev1alpha1.ObjectSetRevisionAnnotation: "5",
 				},
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					DynamicCacheLabel: "True",
 				},
 				"namespace": "my-owner-ns",
@@ -642,7 +642,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 		mockPrepare   func(*ownerStrategyMock, *phaseObjectOwnerMock)
 		object        client.Object
 		previous      []PreviousObjectSet
-		errorAs       interface{}
+		errorAs       any
 		needsAdoption bool
 	}{
 		{
@@ -654,7 +654,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				owner *phaseObjectOwnerMock,
 			) {
 				ownerObj := &unstructured.Unstructured{
-					Object: map[string]interface{}{},
+					Object: map[string]any{},
 				}
 				owner.On("ClientObject").Return(ownerObj)
 				osm.
@@ -671,9 +671,9 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					&unstructured.Unstructured{}),
 			},
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							corev1alpha1.ObjectSetRevisionAnnotation: "15",
 						},
 					},
@@ -690,7 +690,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				owner *phaseObjectOwnerMock,
 			) {
 				ownerObj := &unstructured.Unstructured{
-					Object: map[string]interface{}{},
+					Object: map[string]any{},
 				}
 				owner.On("ClientObject").Return(ownerObj)
 				osm.
@@ -698,7 +698,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					Return(true)
 			},
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{},
+				Object: map[string]any{},
 			},
 			needsAdoption: false,
 		},
@@ -710,7 +710,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 				owner *phaseObjectOwnerMock,
 			) {
 				ownerObj := &unstructured.Unstructured{
-					Object: map[string]interface{}{},
+					Object: map[string]any{},
 				}
 				owner.On("ClientObject").Return(ownerObj)
 				osm.
@@ -727,9 +727,9 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					&unstructured.Unstructured{}),
 			},
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							corev1alpha1.ObjectSetRevisionAnnotation: "100",
 						},
 					},
@@ -748,7 +748,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					On("IsController", mock.Anything, mock.Anything).
 					Return(false)
 				ownerObj := &unstructured.Unstructured{
-					Object: map[string]interface{}{},
+					Object: map[string]any{},
 				}
 				owner.On("ClientObject").Return(ownerObj)
 				owner.On("GetRevision").Return(int64(1))
@@ -758,7 +758,7 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					&unstructured.Unstructured{}),
 			},
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{},
+				Object: map[string]any{},
 			},
 			errorAs:       &ObjectNotOwnedByPreviousRevisionError{},
 			needsAdoption: false,
@@ -787,9 +787,9 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 					&corev1.ConfigMap{}),
 			},
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							corev1alpha1.ObjectSetRevisionAnnotation: "100",
 						},
 					},
@@ -916,19 +916,19 @@ func Test_defaultPatcher_patchObject_update_metadata(t *testing.T) {
 
 	// no need to patch anything, all objects are the same
 	desiredObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"labels": map[string]any{
 					"my-cool-label": "hans",
 				},
 			},
 		},
 	}
 	currentObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"resourceVersion": "123",
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"banana": "hans",
 				},
 			},
@@ -967,27 +967,27 @@ func Test_defaultPatcher_patchObject_update_no_metadata(t *testing.T) {
 		Return(nil)
 
 	desiredObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"labels": map[string]any{
 					"my-cool-label": "hans",
 				},
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"key": "val",
 			},
 		},
 	}
 	currentObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"resourceVersion": "123",
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"banana":        "hans", // we don't care about extra labels
 					"my-cool-label": "hans",
 				},
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"key": "something else",
 			},
 		},
@@ -1023,8 +1023,8 @@ func Test_defaultPatcher_fixFieldManagers(t *testing.T) {
 		Return(nil)
 
 	currentObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"name": "test",
 			},
 		},
@@ -1057,8 +1057,8 @@ func Test_defaultPatcher_fixFieldManagers_error(t *testing.T) {
 		Return(errTest)
 
 	currentObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"name": "test",
 			},
 		},
@@ -1087,8 +1087,8 @@ func Test_defaultPatcher_fixFieldManagers_nowork(t *testing.T) {
 	ctx := context.Background()
 
 	currentObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": "test"},
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "test"},
 		},
 	}
 	currentObj.SetManagedFields([]metav1.ManagedFieldsEntry{{
@@ -1152,19 +1152,19 @@ func Test_mapConditions(t *testing.T) {
 		{
 			name: "no condition observedGeneration",
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(9),
 					},
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":    "Available",
 								"status":  "True",
 								"reason":  reason,
 								"message": message,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"type":   "Other Condition",
 								"status": "True",
 							},
@@ -1177,13 +1177,13 @@ func Test_mapConditions(t *testing.T) {
 		{
 			name: "observedGeneration outdated",
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(9),
 					},
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"observedGeneration": 8,
 								"type":               "Available",
 								"status":             "True",
@@ -1206,8 +1206,8 @@ func Test_mapConditions(t *testing.T) {
 			ctx := context.Background()
 			owner := &phaseObjectOwnerMock{}
 			ownerObj := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
 				},
@@ -1234,7 +1234,7 @@ func Test_mapConditions(t *testing.T) {
 	}
 }
 
-func TestPhaseReconciler_observeExternalObject(t *testing.T) {
+func TestPhaseReconciler_observeExternalObject(t *testing.T) { //nolint:maintidx
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -1246,8 +1246,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 		"external object does not exist": {
 			ExternalObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name": "external",
 						},
 					},
@@ -1258,8 +1258,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 		"cached external object exists/owner namespace": {
 			OwnerObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "owner",
 							"namespace": "owner-ns",
 						},
@@ -1268,8 +1268,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ExternalObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name": "external",
 						},
 					},
@@ -1277,11 +1277,11 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ObservedObject: &corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "external",
 							"namespace": "owner-ns",
-							"labels": map[string]interface{}{
+							"labels": map[string]any{
 								DynamicCacheLabel: "True",
 							},
 						},
@@ -1292,8 +1292,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 		"uncached external object exists/owner namespace": {
 			OwnerObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "owner",
 							"namespace": "owner-ns",
 						},
@@ -1302,8 +1302,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ExternalObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name": "external",
 						},
 					},
@@ -1311,8 +1311,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ObservedObject: &corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "external",
 							"namespace": "owner-ns",
 						},
@@ -1323,8 +1323,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 		"uncached external object exists/external namespace": {
 			OwnerObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "owner",
 							"namespace": "owner-ns",
 						},
@@ -1333,8 +1333,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ExternalObject: corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "external",
 							"namespace": "external-ns",
 						},
@@ -1343,8 +1343,8 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 			},
 			ObservedObject: &corev1alpha1.ObjectSetObject{
 				Object: unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
+					Object: map[string]any{
+						"metadata": map[string]any{
 							"name":      "external",
 							"namespace": "external-ns",
 						},

--- a/internal/dynamiccache/cache_reader.go
+++ b/internal/dynamiccache/cache_reader.go
@@ -106,7 +106,7 @@ func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out client.Ob
 
 // List lists items out of the indexer and writes them to out.
 func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...client.ListOption) error {
-	var objs []interface{}
+	var objs []any
 	var err error
 
 	listOpts := client.ListOptions{}

--- a/internal/dynamiccache/informer_map.go
+++ b/internal/dynamiccache/informer_map.go
@@ -223,8 +223,8 @@ func indexByField(indexer cache.SharedIndexInformer, field string, extractor cli
 	return indexer.AddIndexers(cache.Indexers{FieldIndexName(field): indexFuncForExtractor(extractor)})
 }
 
-func indexFuncForExtractor(extractor client.IndexerFunc) func(objRaw interface{}) ([]string, error) {
-	return func(objRaw interface{}) ([]string, error) {
+func indexFuncForExtractor(extractor client.IndexerFunc) func(objRaw any) ([]string, error) {
+	return func(objRaw any) ([]string, error) {
 		// TODO(directxman12): check if this is the correct type?
 		obj, isObj := objRaw.(client.Object)
 		if !isObj {

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -37,7 +37,7 @@ type serverVersionDiscoverer interface {
 	ServerVersion() (*version.Info, error)
 }
 
-func ImplementsSinker(i []interface{}) []Sinker {
+func ImplementsSinker(i []any) []Sinker {
 	var envSinks []Sinker
 	for _, c := range i {
 		envSink, ok := c.(Sinker)

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -35,7 +35,7 @@ func TestImplementsSinker(t *testing.T) {
 	type somethingElse struct{}
 
 	s := &testSink{}
-	res := ImplementsSinker([]interface{}{s, &somethingElse{}})
+	res := ImplementsSinker([]any{s, &somethingElse{}})
 	assert.Equal(t, []Sinker{s}, res)
 }
 

--- a/internal/ownerhandling/annotation.go
+++ b/internal/ownerhandling/annotation.go
@@ -48,9 +48,9 @@ func (s *OwnerStrategyAnnotation) OwnerPatch(owner metav1.Object) ([]byte, error
 	if len(annotations[ownerStrategyAnnotationKey]) == 0 {
 		return nil, nil
 	}
-	patchMetadata := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
+	patchMetadata := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
 				ownerStrategyAnnotationKey:               annotations[ownerStrategyAnnotationKey],
 				corev1alpha1.ObjectSetRevisionAnnotation: annotations[corev1alpha1.ObjectSetRevisionAnnotation],
 			},

--- a/internal/ownerhandling/native.go
+++ b/internal/ownerhandling/native.go
@@ -33,9 +33,9 @@ func NewNative(scheme *runtime.Scheme) *OwnerStrategyNative {
 
 func (s *OwnerStrategyNative) OwnerPatch(owner metav1.Object) ([]byte, error) {
 	annotations := owner.GetAnnotations()
-	patchMetadata := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
+	patchMetadata := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
 				corev1alpha1.ObjectSetRevisionAnnotation: annotations[corev1alpha1.ObjectSetRevisionAnnotation],
 			},
 			"ownerReferences": owner.GetOwnerReferences(),

--- a/internal/packages/internal/packagedeploy/deployer.go
+++ b/internal/packages/internal/packagedeploy/deployer.go
@@ -115,7 +115,7 @@ func (l *PackageDeployer) Deploy(
 
 	// prepare package render/template context
 	tmplCtx := apiPkg.TemplateContext()
-	configuration := map[string]interface{}{}
+	configuration := map[string]any{}
 	if tmplCtx.Config != nil {
 		if err := json.Unmarshal(tmplCtx.Config.Raw, &configuration); err != nil {
 			return fmt.Errorf("unmarshal config: %w", err)

--- a/internal/packages/internal/packagedeploy/deployer_test.go
+++ b/internal/packages/internal/packagedeploy/deployer_test.go
@@ -62,7 +62,7 @@ func TestPackageDeployer_Deploy(t *testing.T) {
 
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 
-	obj1 := unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj1 := unstructured.Unstructured{Object: map[string]any{}}
 	obj1.SetAnnotations(map[string]string{
 		manifests.PackagePhaseAnnotation: "phase-1",
 	})
@@ -141,7 +141,7 @@ func TestPackageDeployer_Deploy_Error(t *testing.T) {
 		On("LoadComponent", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errExample)
 
-	obj1 := unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj1 := unstructured.Unstructured{Object: map[string]any{}}
 	obj1.SetAnnotations(map[string]string{
 		manifests.PackagePhaseAnnotation: "phase-1",
 	})

--- a/internal/packages/internal/packagemanifestvalidation/configuration.go
+++ b/internal/packages/internal/packagemanifestvalidation/configuration.go
@@ -14,7 +14,7 @@ import (
 // Validates configuration against the PackageManifests OpenAPISchema.
 func ValidatePackageConfiguration(
 	ctx context.Context, mc *manifests.PackageManifestSpecConfig,
-	configuration map[string]interface{}, fldPath *field.Path,
+	configuration map[string]any, fldPath *field.Path,
 ) (field.ErrorList, error) {
 	if mc.OpenAPIV3Schema == nil {
 		return nil, nil
@@ -25,7 +25,7 @@ func ValidatePackageConfiguration(
 
 // Prunes, Defaults and Validates configuration against the PackageManifests OpenAPISchema so it's ready to be used.
 func AdmitPackageConfiguration(
-	ctx context.Context, configuration map[string]interface{},
+	ctx context.Context, configuration map[string]any,
 	manifest *manifests.PackageManifest, fldPath *field.Path,
 ) (field.ErrorList, error) {
 	if manifest.Spec.Config.OpenAPIV3Schema == nil {

--- a/internal/packages/internal/packagemanifestvalidation/configuration_test.go
+++ b/internal/packages/internal/packagemanifestvalidation/configuration_test.go
@@ -19,7 +19,7 @@ func TestValidatePackageConfiguration(t *testing.T) {
 	tests := []struct {
 		name                  string
 		packageManifestConfig *manifests.PackageManifestSpecConfig
-		config                map[string]interface{}
+		config                map[string]any
 		expectedErrors        []string
 	}{
 		{
@@ -35,7 +35,7 @@ func TestValidatePackageConfiguration(t *testing.T) {
 					Required: []string{"test", "banana"},
 				},
 			},
-			config: map[string]interface{}{"test": float64(42)},
+			config: map[string]any{"test": float64(42)},
 			expectedErrors: []string{
 				`test: Invalid value: "number": test in body must be of type string: "number"`,
 				"banana: Required value",
@@ -137,8 +137,8 @@ func TestAdmitPackageConfiguration_Prune(t *testing.T) {
 
 	ctx := context.Background()
 
-	inputCfg := map[string]interface{}{"chicken": "🐔", "banana": "🍌"}
-	expectedOutputConfig := map[string]interface{}{"chicken": "🐔"}
+	inputCfg := map[string]any{"chicken": "🐔", "banana": "🍌"}
+	expectedOutputConfig := map[string]any{"chicken": "🐔"}
 	chicken := apiextensions.JSON(`🐔`)
 	man := &manifests.PackageManifest{
 		Spec: manifests.PackageManifestSpec{
@@ -162,8 +162,8 @@ func TestAdmitPackageConfiguration_Default(t *testing.T) {
 
 	ctx := context.Background()
 
-	inputCfg := map[string]interface{}{"banana": "🍌"}
-	expectedOutputConfig := map[string]interface{}{"chicken": "🐔"}
+	inputCfg := map[string]any{"banana": "🍌"}
+	expectedOutputConfig := map[string]any{"chicken": "🐔"}
 	chicken := apiextensions.JSON(`🐔`)
 	man := &manifests.PackageManifest{
 		Spec: manifests.PackageManifestSpec{
@@ -187,8 +187,8 @@ func TestAdmitPackageConfigurationTemplating_Default(t *testing.T) {
 
 	ctx := context.Background()
 
-	inputCfg := map[string]interface{}{"banana": "🍌"}
-	expectedOutputConfig := map[string]interface{}{"chicken": "🐔"}
+	inputCfg := map[string]any{"banana": "🍌"}
+	expectedOutputConfig := map[string]any{"chicken": "🐔"}
 	chicken := apiextensions.JSON(`🐔`)
 	man := &manifests.PackageManifest{
 		Spec: manifests.PackageManifestSpec{

--- a/internal/packages/internal/packagemanifestvalidation/manifest.go
+++ b/internal/packages/internal/packagemanifestvalidation/manifest.go
@@ -84,7 +84,7 @@ func ValidatePackageManifest(ctx context.Context, obj *manifests.PackageManifest
 		}
 
 		if len(configErrors) == 0 {
-			configuration := map[string]interface{}{}
+			configuration := map[string]any{}
 			if template.Context.Config != nil {
 				if err := json.Unmarshal(template.Context.Config.Raw, &configuration); err != nil {
 					return nil, fmt.Errorf("unmarshal config at test %s: %w", template.Name, err)

--- a/internal/packages/internal/packagemanifestvalidation/private.go
+++ b/internal/packages/internal/packagemanifestvalidation/private.go
@@ -213,7 +213,7 @@ func validateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 	//
 	// In other words:
 	// - properties are for structs,
-	// - additionalProperties are for map[string]interface{}
+	// - additionalProperties are for map[string]any
 	//
 	// Note: when patternProperties is added to OpenAPI some day, this will have to be
 	//       restricted like additionalProperties.
@@ -527,7 +527,7 @@ func validatePackageManifestConfig(ctx context.Context, config *manifests.Packag
 	return allErrs
 }
 
-func validatePackageConfigurationBySchema(_ context.Context, schema *apiextensions.JSONSchemaProps, config map[string]interface{}, fldPath *field.Path) (field.ErrorList, error) {
+func validatePackageConfigurationBySchema(_ context.Context, schema *apiextensions.JSONSchemaProps, config map[string]any, fldPath *field.Path) (field.ErrorList, error) {
 	if schema == nil {
 		return nil, nil
 	}

--- a/internal/packages/internal/packagerender/conditionmap_test.go
+++ b/internal/packages/internal/packagerender/conditionmap_test.go
@@ -22,9 +22,9 @@ func Test_parseConditionMap(t *testing.T) {
 		{
 			name: "success",
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							manifestsv1alpha1.PackageConditionMapAnnotation: "Available => my-prefix/Available\nSomethingElse => my-prefix/SomethingElse",
 						},
 					},
@@ -91,9 +91,9 @@ func TestParseConditionMap_error(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			obj := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							manifestsv1alpha1.PackageConditionMapAnnotation: test.annotation,
 						},
 					},

--- a/internal/packages/internal/packagerender/template.go
+++ b/internal/packages/internal/packagerender/template.go
@@ -53,13 +53,13 @@ func RenderTemplates(_ context.Context, pkg *packagetypes.Package, tmplCtx packa
 	return nil
 }
 
-func templateContext(tmplCtx packagetypes.PackageRenderContext) (map[string]interface{}, error) {
+func templateContext(tmplCtx packagetypes.PackageRenderContext) (map[string]any, error) {
 	p, err := json.Marshal(tmplCtx)
 	if err != nil {
 		return nil, err
 	}
 
-	actualCtx := map[string]interface{}{}
+	actualCtx := map[string]any{}
 	if err := json.Unmarshal(p, &actualCtx); err != nil {
 		return nil, err
 	}
@@ -67,13 +67,13 @@ func templateContext(tmplCtx packagetypes.PackageRenderContext) (map[string]inte
 	return actualCtx, nil
 }
 
-func workaroundnovalue(actualCtx map[string]interface{}) {
+func workaroundnovalue(actualCtx map[string]any) {
 	// The go templating engine substitutes missing values in map with "<no value>".
 	// For our case we would like to raise an error in case of missing values, which can be done by setting the templater option missingkey=error...
-	// except that it is ignored if the map is of type map[string]interface{} for some reason ʕ •ᴥ•ʔ. See https://github.com/golang/go/issues/24963.
+	// except that it is ignored if the map is of type map[string]any for some reason ʕ •ᴥ•ʔ. See https://github.com/golang/go/issues/24963.
 	// Circumventing this by defaulting annotations and labels maps in metadata.
 
-	metadata := actualCtx["package"].(map[string]interface{})["metadata"].(map[string]interface{})
+	metadata := actualCtx["package"].(map[string]any)["metadata"].(map[string]any)
 	if metadata["annotations"] == nil {
 		metadata["annotations"] = map[string]string{}
 	}

--- a/internal/packages/internal/packagetypes/types.go
+++ b/internal/packages/internal/packagetypes/types.go
@@ -44,7 +44,7 @@ type PackageInstance struct {
 // PackageRenderContext contains all data that is needed to render a Package into a PackageInstance.
 type PackageRenderContext struct {
 	Package     manifests.TemplateContextPackage `json:"package"`
-	Config      map[string]interface{}           `json:"config"`
+	Config      map[string]any                   `json:"config"`
 	Images      map[string]string                `json:"images"`
 	Environment manifests.PackageEnvironment     `json:"environment"`
 }

--- a/internal/packages/internal/packagevalidation/templatevalidation.go
+++ b/internal/packages/internal/packagevalidation/templatevalidation.go
@@ -69,7 +69,7 @@ func (v TemplateTestValidator) runTestCase(
 	log := logr.FromContextOrDiscard(ctx)
 	pkg = pkg.DeepCopy()
 
-	configuration := map[string]interface{}{}
+	configuration := map[string]any{}
 	if testCase.Context.Config != nil {
 		if err := json.Unmarshal(testCase.Context.Config.Raw, &configuration); err != nil {
 			return err

--- a/internal/testutil/rate_limiting_queue.go
+++ b/internal/testutil/rate_limiting_queue.go
@@ -10,7 +10,7 @@ type RateLimitingQueue struct {
 	mock.Mock
 }
 
-func (q *RateLimitingQueue) Add(item interface{}) {
+func (q *RateLimitingQueue) Add(item any) {
 	q.Called(item)
 }
 
@@ -19,12 +19,12 @@ func (q *RateLimitingQueue) Len() int {
 	return args.Int(0)
 }
 
-func (q *RateLimitingQueue) Get() (item interface{}, shutdown bool) {
+func (q *RateLimitingQueue) Get() (item any, shutdown bool) {
 	args := q.Called()
 	return args.Get(0), args.Bool(1)
 }
 
-func (q *RateLimitingQueue) Done(item interface{}) {
+func (q *RateLimitingQueue) Done(item any) {
 	q.Called(item)
 }
 
@@ -41,19 +41,19 @@ func (q *RateLimitingQueue) ShuttingDown() bool {
 	return args.Bool(0)
 }
 
-func (q *RateLimitingQueue) AddAfter(item interface{}, duration time.Duration) {
+func (q *RateLimitingQueue) AddAfter(item any, duration time.Duration) {
 	q.Called(item, duration)
 }
 
-func (q *RateLimitingQueue) AddRateLimited(item interface{}) {
+func (q *RateLimitingQueue) AddRateLimited(item any) {
 	q.Called(item)
 }
 
-func (q *RateLimitingQueue) Forget(item interface{}) {
+func (q *RateLimitingQueue) Forget(item any) {
 	q.Called(item)
 }
 
-func (q *RateLimitingQueue) NumRequeues(item interface{}) int {
+func (q *RateLimitingQueue) NumRequeues(item any) int {
 	args := q.Called(item)
 	return args.Int(0)
 }

--- a/internal/transform/transformfiles_funcs.go
+++ b/internal/transform/transformfiles_funcs.go
@@ -232,7 +232,7 @@ func SprigFuncs(t *template.Template) template.FuncMap {
 	// Use this helper function if you need to modify the resulting output via e.g. | indent.
 	// Example:
 	// {{- define "test-helper" -}}{{.}}{{- end -}}{{- include "test-helper" . | upper -}}
-	allowedFuncs["include"] = func(name string, data interface{}) (string, error) {
+	allowedFuncs["include"] = func(name string, data any) (string, error) {
 		var buf strings.Builder
 		if v, ok := includedNames[name]; ok {
 			if v > recursionDepth {
@@ -252,10 +252,10 @@ func SprigFuncs(t *template.Template) template.FuncMap {
 	return allowedFuncs
 }
 
-func base64decodeMap(data map[string]interface{}) (
-	map[string]interface{}, error,
+func base64decodeMap(data map[string]any) (
+	map[string]any, error,
 ) {
-	decodedData := map[string]interface{}{}
+	decodedData := map[string]any{}
 	for k, vi := range data {
 		v, ok := vi.(string)
 		if !ok {
@@ -273,7 +273,7 @@ func base64decodeMap(data map[string]interface{}) (
 	return decodedData, nil
 }
 
-func toYAML(v interface{}) (string, error) {
+func toYAML(v any) (string, error) {
 	data, err := yaml.Marshal(v)
 	if err != nil {
 		return "", err
@@ -283,7 +283,7 @@ func toYAML(v interface{}) (string, error) {
 
 var ErrInvalidType = errors.New("invalid type")
 
-func fromYAML(y interface{}) (out interface{}, err error) {
+func fromYAML(y any) (out any, err error) {
 	var b []byte
 	switch v := y.(type) {
 	case string:

--- a/internal/transform/transformfiles_funcs_test.go
+++ b/internal/transform/transformfiles_funcs_test.go
@@ -127,13 +127,13 @@ func Test_include_recursionError(t *testing.T) {
 
 func Test_base64decodeMap(t *testing.T) {
 	t.Parallel()
-	d := map[string]interface{}{
+	d := map[string]any{
 		"test": "YWJjZGVm",
 	}
 	out, err := base64decodeMap(d)
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"test": "abcdef",
 	}, out)
 }
@@ -157,7 +157,7 @@ func Test_fromYAML(t *testing.T) {
 
 		y, err := fromYAML(`t: "2"`)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]interface{}{
+		assert.Equal(t, map[string]any{
 			"t": "2",
 		}, y)
 	})
@@ -167,7 +167,7 @@ func Test_fromYAML(t *testing.T) {
 
 		y, err := fromYAML([]byte(`t: "2"`))
 		require.NoError(t, err)
-		assert.Equal(t, map[string]interface{}{
+		assert.Equal(t, map[string]any{
 			"t": "2",
 		}, y)
 	})
@@ -175,7 +175,7 @@ func Test_fromYAML(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := fromYAML(map[string]interface{}{})
+		_, err := fromYAML(map[string]any{})
 		require.ErrorIs(t, err, ErrInvalidType)
 	})
 }

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -15,7 +15,7 @@ import (
 // ComputeHash returns a fnv32 hash value calculated from pod template and
 // a collisionCount to avoid hash collision. The hash will be safe encoded to
 // avoid bad words.
-func ComputeFNV32Hash(obj interface{}, collisionCount *int32) string {
+func ComputeFNV32Hash(obj any, collisionCount *int32) string {
 	hasher := fnv.New32a()
 	DeepHashObject(hasher, obj)
 
@@ -33,7 +33,7 @@ func ComputeFNV32Hash(obj interface{}, collisionCount *int32) string {
 // ComputeHash returns a sha236 hash value calculated from pod template and
 // a collisionCount to avoid hash collision. The hash will be safe encoded to
 // avoid bad words.
-func ComputeSHA256Hash(obj interface{}, collisionCount *int32) string {
+func ComputeSHA256Hash(obj any, collisionCount *int32) string {
 	hasher := sha256.New()
 	DeepHashObject(hasher, obj)
 
@@ -51,7 +51,7 @@ func ComputeSHA256Hash(obj interface{}, collisionCount *int32) string {
 // DeepHashObject writes specified object to hash using the spew library
 // which follows pointers and prints actual values of the nested objects
 // ensuring the hash does not change when a pointer changes.
-func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+func DeepHashObject(hasher hash.Hash, objectToWrite any) {
 	hasher.Reset()
 	printer := spew.ConfigState{
 		Indent:         " ",

--- a/magefiles/config.go
+++ b/magefiles/config.go
@@ -19,8 +19,8 @@ func init() {
 	os.Setenv("PATH", locations.Deps().Bin()+":"+locations.bin+":"+os.Getenv("PATH"))
 
 	// Extra dependencies must be specified here to avoid a circular dependency.
-	packageImages[pkoPackageName].ExtraDeps = []interface{}{Generate.PackageOperatorPackage}
-	packageImages[remotePhasePackageName].ExtraDeps = []interface{}{Generate.RemotePhasePackage}
+	packageImages[pkoPackageName].ExtraDeps = []any{Generate.PackageOperatorPackage}
+	packageImages[remotePhasePackageName].ExtraDeps = []any{Generate.RemotePhasePackage}
 
 	ctrl.SetLogger(logger)
 }
@@ -54,7 +54,7 @@ type (
 		BinaryName string
 	}
 	PackageImage struct {
-		ExtraDeps  []interface{}
+		ExtraDeps  []any
 		Push       bool
 		SourcePath string
 	}

--- a/magefiles/ns_build.go
+++ b/magefiles/ns_build.go
@@ -17,7 +17,7 @@ type Build mg.Namespace
 
 // Build all PKO binaries for the architecture of this machine.
 func (Build) Binaries() {
-	targets := []interface{}{mg.F(Build.Binary, "mage", "", "")}
+	targets := []any{mg.F(Build.Binary, "mage", "", "")}
 	for name := range commands {
 		targets = append(targets, mg.F(Build.Binary, name, nativeArch.OS, nativeArch.Arch))
 	}
@@ -26,7 +26,7 @@ func (Build) Binaries() {
 }
 
 func (Build) ReleaseBinaries() {
-	targets := []interface{}{}
+	targets := []any{}
 	for name, cmd := range commands {
 		for _, arch := range cmd.ReleaseArchitectures {
 			targets = append(targets, mg.F(Build.Binary, name, arch.OS, arch.Arch))
@@ -67,7 +67,7 @@ func (Build) Binary(cmd string, goos, goarch string) {
 
 // Builds all PKO container images.
 func (Build) Images() {
-	deps := []interface{}{}
+	deps := []any{}
 	for k := range commandImages {
 		deps = append(deps, mg.F(Build.Image, k))
 	}
@@ -112,7 +112,7 @@ func (Build) PushImage(imageName string) {
 
 // Builds and pushes all container images to the default registry.
 func (Build) PushImages() {
-	deps := []interface{}{Generate.SelfBootstrapJob}
+	deps := []any{Generate.SelfBootstrapJob}
 	for k, opts := range commandImages {
 		if opts.Push {
 			deps = append(deps, mg.F(Build.PushImage, k))
@@ -185,7 +185,7 @@ func (b Build) buildCmdImage(imageName string) {
 		cmd = opts.BinaryName
 	}
 
-	deps := []interface{}{
+	deps := []any{
 		mg.F(Build.Binary, cmd, linuxAMD64Arch.OS, linuxAMD64Arch.Arch),
 		mg.F(Build.cleanImageCacheDir, imageName),
 		mg.F(Build.populateCacheCmd, cmd, imageName),
@@ -224,7 +224,7 @@ func (b Build) buildPackageImage(name string) {
 		panic(fmt.Sprintf("unknown package: %s", name))
 	}
 
-	predeps := []interface{}{
+	predeps := []any{
 		mg.F(Build.Binary, cliCmdName, linuxAMD64Arch.OS, linuxAMD64Arch.Arch),
 		mg.F(Build.cleanImageCacheDir, name),
 	}

--- a/magefiles/ns_dev.go
+++ b/magefiles/ns_dev.go
@@ -37,7 +37,7 @@ func (d Dev) Load() {
 		"remote-phase-manager", "test-stub", "test-stub-package",
 		remotePhasePackageName, pkoPackageName,
 	}
-	deps := make([]interface{}, len(images))
+	deps := make([]any, len(images))
 	for i := range images {
 		deps[i] = mg.F(Build.PushImage, images[i])
 	}

--- a/magefiles/ns_generate.go
+++ b/magefiles/ns_generate.go
@@ -233,7 +233,7 @@ func includeInPackageOperatorPackage(file string, outDir string) {
 
 		var (
 			subfolder    string
-			objToMarshal interface{}
+			objToMarshal any
 		)
 		switch gk {
 		case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:

--- a/pkg/probing/cel_test.go
+++ b/pkg/probing/cel_test.go
@@ -29,8 +29,8 @@ func Test_celProbe(t *testing.T) {
 			rule:    `self.metadata.name == "hans"`,
 			message: "aaaaaah!",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"name": "hans",
 					},
 				},
@@ -42,8 +42,8 @@ func Test_celProbe(t *testing.T) {
 			rule:    `self.metadata.name == "hans"`,
 			message: "aaaaaah!",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"name": "nothans",
 					},
 				},
@@ -55,14 +55,14 @@ func Test_celProbe(t *testing.T) {
 			rule:    `self.status.ingress.all(i, i.conditions.all(c, c.type == "Ready" && c.status == "True"))`,
 			message: "aaaaaah!",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"test": []interface{}{"1", "2", "3"},
-						"ingress": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"test": []any{"1", "2", "3"},
+						"ingress": []any{
+							map[string]any{
 								"host": "hostname.xxx.xxx",
-								"conditions": []interface{}{
-									map[string]interface{}{
+								"conditions": []any{
+									map[string]any{
 										"type":   "Ready",
 										"status": "True",
 									},
@@ -79,23 +79,23 @@ func Test_celProbe(t *testing.T) {
 			rule:    `self.status.ingress.all(i, i.conditions.all(c, c.type == "Ready" && c.status == "True"))`,
 			message: "aaaaaah!",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"test": []interface{}{"1", "2", "3"},
-						"ingress": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"test": []any{"1", "2", "3"},
+						"ingress": []any{
+							map[string]any{
 								"host": "hostname.xxx.xxx",
-								"conditions": []interface{}{
-									map[string]interface{}{
+								"conditions": []any{
+									map[string]any{
 										"type":   "Ready",
 										"status": "True",
 									},
 								},
 							},
-							map[string]interface{}{
+							map[string]any{
 								"host": "otherhost.xxx.xxx",
-								"conditions": []interface{}{
-									map[string]interface{}{
+								"conditions": []any{
+									map[string]any{
 										"type":   "Ready",
 										"status": "False",
 									},

--- a/pkg/probing/condition.go
+++ b/pkg/probing/condition.go
@@ -24,7 +24,7 @@ func (cp *ConditionProbe) Probe(obj *unstructured.Unstructured) (success bool, m
 
 	rawConditions, exist, err := unstructured.NestedFieldNoCopy(
 		obj.Object, "status", "conditions")
-	conditions, ok := rawConditions.([]interface{})
+	conditions, ok := rawConditions.([]any)
 	if err != nil || !exist {
 		return false, "missing .status.conditions"
 	}
@@ -33,7 +33,7 @@ func (cp *ConditionProbe) Probe(obj *unstructured.Unstructured) (success bool, m
 	}
 
 	for _, condI := range conditions {
-		cond, ok := condI.(map[string]interface{})
+		cond, ok := condI.(map[string]any)
 		if !ok {
 			// no idea what this is supposed to be
 			return false, "malformed"

--- a/pkg/probing/condition_test.go
+++ b/pkg/probing/condition_test.go
@@ -23,22 +23,22 @@ func TestCondition(t *testing.T) {
 		{
 			name: "succeeds",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Banana",
 								"status":             "True",
 								"observedGeneration": int64(1), // up to date
 							},
-							map[string]interface{}{
+							map[string]any{
 								"type":               "Available",
 								"status":             "False",
 								"observedGeneration": int64(1), // up to date
 							},
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -49,17 +49,17 @@ func TestCondition(t *testing.T) {
 		{
 			name: "outdated",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Available",
 								"status":             "False",
 								"observedGeneration": int64(1), // up to date
 							},
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(42),
 					},
 				},
@@ -70,17 +70,17 @@ func TestCondition(t *testing.T) {
 		{
 			name: "wrong status",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Available",
 								"status":             "Unknown",
 								"observedGeneration": int64(1), // up to date
 							},
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -91,17 +91,17 @@ func TestCondition(t *testing.T) {
 		{
 			name: "not reported",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":               "Banana",
 								"status":             "True",
 								"observedGeneration": int64(1), // up to date
 							},
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -112,13 +112,13 @@ func TestCondition(t *testing.T) {
 		{
 			name: "malformed condition type int",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
 							42, 56,
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -129,13 +129,13 @@ func TestCondition(t *testing.T) {
 		{
 			name: "malformed condition type string",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
 							"42", "56",
 						},
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -146,11 +146,11 @@ func TestCondition(t *testing.T) {
 		{
 			name: "malformed conditions array",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{
 						"conditions": 42,
 					},
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -161,9 +161,9 @@ func TestCondition(t *testing.T) {
 		{
 			name: "missing conditions",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{},
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"status": map[string]any{},
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},
@@ -174,8 +174,8 @@ func TestCondition(t *testing.T) {
 		{
 			name: "missing status",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(1),
 					},
 				},

--- a/pkg/probing/fieldsequal_test.go
+++ b/pkg/probing/fieldsequal_test.go
@@ -23,8 +23,8 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "simple succeeds",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"fieldA": "test",
 						"fieldB": "test",
 					},
@@ -35,8 +35,8 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "simple not equal",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"fieldA": "test",
 						"fieldB": "not test",
 					},
@@ -48,12 +48,12 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "complex succeeds",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"fieldA": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"fieldA": map[string]any{
 							"fk": "fv",
 						},
-						"fieldB": map[string]interface{}{
+						"fieldB": map[string]any{
 							"fk": "fv",
 						},
 					},
@@ -64,12 +64,12 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "simple not equal",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"fieldA": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"fieldA": map[string]any{
 							"fk": "fv",
 						},
-						"fieldB": map[string]interface{}{
+						"fieldB": map[string]any{
 							"fk": "something else",
 						},
 					},
@@ -81,12 +81,12 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "int not equal",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"fieldA": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"fieldA": map[string]any{
 							"fk": 1.0,
 						},
-						"fieldB": map[string]interface{}{
+						"fieldB": map[string]any{
 							"fk": 2.0,
 						},
 					},
@@ -98,8 +98,8 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "fieldA missing",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"fieldB": "test",
 					},
 				},
@@ -110,8 +110,8 @@ func TestFieldsEqual(t *testing.T) {
 		{
 			name: "fieldB missing",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"fieldA": "test",
 					},
 				},

--- a/pkg/probing/observedgeneration_test.go
+++ b/pkg/probing/observedgeneration_test.go
@@ -26,11 +26,11 @@ func TestStatusObservedGeneration(t *testing.T) {
 		{
 			name: "outdated",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
-					"status": map[string]interface{}{
+					"status": map[string]any{
 						"observedGeneration": int64(2),
 					},
 				},
@@ -41,11 +41,11 @@ func TestStatusObservedGeneration(t *testing.T) {
 		{
 			name: "up-to-date",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
-					"status": map[string]interface{}{
+					"status": map[string]any{
 						"observedGeneration": int64(4),
 					},
 				},
@@ -56,11 +56,11 @@ func TestStatusObservedGeneration(t *testing.T) {
 		{
 			name: "not reported",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{
 						"generation": int64(4),
 					},
-					"status": map[string]interface{}{},
+					"status": map[string]any{},
 				},
 			},
 			succeeds: true,


### PR DESCRIPTION
Replace all occurreces of `interface{}` with `any`. `any` is an alias from `interface{}` and defines more clearly that you want to use "anything" instead of "specifically something that does not need to do anything though"