### PR TITLE
Remove labels config from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
-  labels: [ dependencies, ok-to-test]
 - package-ecosystem: gomod
   directory: /apis
   schedule:
@@ -19,7 +18,6 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
-  labels: [ dependencies, ok-to-test]
 - package-ecosystem: gomod
   directory: /pkg
   schedule:
@@ -29,11 +27,9 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
-  labels: [ dependencies, ok-to-test]
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
-  labels: [ dependencies, ok-to-test]


### PR DESCRIPTION
Let dependabot not try to assign labels to PRs because said labels got deleted.