### PR TITLE
Fix nil pointer dereference on packages with non existent image

### DIFF
--- a/internal/packages/internal/packageimport/registry.go
+++ b/internal/packages/internal/packageimport/registry.go
@@ -111,9 +111,13 @@ func (r *Registry) handleResponse(image string, res response) {
 	defer r.inFlightLock.Unlock()
 
 	for _, recv := range r.inFlight[image] {
-		recv <- response{
+		var rawPkg *packagetypes.RawPackage
+		if res.RawPackage != nil {
 			// DeepCopy to ensure clients can work concurrently on the returned files map.
-			RawPackage: res.RawPackage.DeepCopy(),
+			rawPkg = res.RawPackage.DeepCopy()
+		}
+		recv <- response{
+			RawPackage: rawPkg,
 			Err:        res.Err,
 		}
 	}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
Package Operator manager crashes when a `Package` or `ClusterPackage` containing a non existent image reference in the `spec.image` field is created.

Here is an example package that triggers the error:

```
apiVersion: package-operator.run/v1alpha1
kind: Package
metadata:
  name: test-unknown-pko
spec:
  image: quay.io/package-operator/non-existent:v123
```

Here is the full error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x106c388d4]

goroutine 388 [running]:
package-operator.run/internal/packages/internal/packagetypes.(*RawPackage).DeepCopy(0x0)
        /Users/alcosta/Work/devel/package-operator/sources/internal/packages/internal/packagetypes/types.go:61 +0x24
package-operator.run/internal/packages/internal/packageimport.(*Registry).handleResponse(0x14000685740, {0x14000239240, 0x31}, {0x0, {0x1074a9e40, 0x1400071a5c0}})
        /Users/alcosta/Work/devel/package-operator/sources/internal/packages/internal/packageimport/registry.go:116 +0x120
package-operator.run/internal/packages/internal/packageimport.(*Registry).handleRequest.func1({0x1074c36c0, 0x140005c1980}, {0x14000239240, 0x31})
        /Users/alcosta/Work/devel/package-operator/sources/internal/packages/internal/packageimport/registry.go:86 +0x12c
created by package-operator.run/internal/packages/internal/packageimport.(*Registry).handleRequest in goroutine 328
        /Users/alcosta/Work/devel/package-operator/sources/internal/packages/internal/packageimport/registry.go:83 +0x268
Exiting.

```
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
