### PR TITLE
Package Operator should not touch existing meta

### DIFF
--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -712,9 +712,7 @@ func (p *defaultPatcher) Patch(
 	// deepCopy of currentObj, already updated for owner handling
 	updatedObj *unstructured.Unstructured,
 ) error {
-	// Ensure desired labels, annotations and owners are present
-	desiredObj.SetLabels(mergeKeysFrom(updatedObj.GetLabels(), desiredObj.GetLabels()))
-	desiredObj.SetAnnotations(mergeKeysFrom(updatedObj.GetAnnotations(), desiredObj.GetAnnotations()))
+	// Ensure owners are present
 	desiredObj.SetOwnerReferences(updatedObj.GetOwnerReferences())
 
 	patch := desiredObj.DeepCopy()

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -944,8 +944,9 @@ func Test_defaultPatcher_patchObject_update_metadata(t *testing.T) {
 		patch, err := patches[0].Data(updatedObj)
 		require.NoError(t, err)
 
+		// ensure patch does NOT contain existing labels
 		assert.Equal(t,
-			`{"metadata":{"labels":{"banana":"hans","my-cool-label":"hans"}}}`, string(patch))
+			`{"metadata":{"labels":{"my-cool-label":"hans"}}}`, string(patch))
 	}
 }
 
@@ -1005,7 +1006,7 @@ func Test_defaultPatcher_patchObject_update_no_metadata(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t,
-			`{"metadata":{"labels":{"banana":"hans","my-cool-label":"hans"},"ownerReferences":[{"apiVersion":"v1","blockOwnerDeletion":true,"controller":true,"kind":"ConfigMap","name":"","uid":""}]},"spec":{"key":"val"}}`, string(patch))
+			`{"metadata":{"labels":{"my-cool-label":"hans"},"ownerReferences":[{"apiVersion":"v1","blockOwnerDeletion":true,"controller":true,"kind":"ConfigMap","name":"","uid":""}]},"spec":{"key":"val"}}`, string(patch))
 	}
 }
 


### PR DESCRIPTION
### Summary
Now that PKO is using server-side-apply, we do no longer have to merge existing annotations and labels into our patch, as SSA takes care of keeping them.

This leads to problems with e.g. Cert Manager using annotations and labels to save settings during certificate request and PKO resetting them.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
