### PR TITLE
WIP: Added object kinds annotations

### DIFF
--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -97,6 +97,8 @@ func (b *Build) BuildFromSource(ctx context.Context, srcPath string, opts ...Bui
 		return fmt.Errorf("loading package from files: %w", err)
 	}
 
+	rawPkg.Permissions, err = packages.Permissions(ctx, rawPkg.Files)
+
 	if cfg.OutputPath != "" {
 		b.cfg.Log.Info("writing tagged image to disk", "path", cfg.OutputPath)
 

--- a/internal/packages/export_types.go
+++ b/internal/packages/export_types.go
@@ -32,4 +32,6 @@ var (
 	PackageManifestGroupKind = packagetypes.PackageManifestGroupKind
 	// PackageManifestLockGroupKind is the kubernetes schema group kind of a PackageManifestLock.
 	PackageManifestLockGroupKind = packagetypes.PackageManifestLockGroupKind
+	// Returns a list managed and external objects the package needs permissions for.
+	Permissions = packagetypes.Permissions
 )

--- a/internal/packages/internal/packagetypes/permissions.go
+++ b/internal/packages/internal/packagetypes/permissions.go
@@ -1,0 +1,71 @@
+package packagetypes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	apiVersionRegEx = regexp.MustCompile(`(?m)^apiVersion:(.*)$`)
+	kindRegEx       = regexp.MustCompile(`(?m)^kind:(.*)$`)
+	isExternalRegEx = regexp.MustCompile(`(?m)package-operator\.run/external:.*"True"$`)
+)
+
+func Permissions(
+	ctx context.Context,
+	files Files,
+) (PackagePermissions, error) {
+	perms := PackagePermissions{}
+
+	managedGK := map[schema.GroupKind]struct{}{}
+	externalGK := map[schema.GroupKind]struct{}{}
+
+	// GKs from un-templated files.
+	for _, file := range files {
+		for _, yamlDocument := range bytes.Split(bytes.Trim(file, "---\n"), []byte("---\n")) {
+			gk, isExternal, err := permissionsFromTemplateFile(ctx, yamlDocument)
+			if err != nil {
+				return perms, err
+			}
+			if isExternal {
+				externalGK[gk] = struct{}{}
+			} else {
+				managedGK[gk] = struct{}{}
+			}
+		}
+	}
+
+	perms.Managed = mapKeysToList(managedGK)
+	perms.External = mapKeysToList(externalGK)
+	return perms, nil
+}
+
+func permissionsFromTemplateFile(
+	_ context.Context, file []byte,
+) (gk schema.GroupKind, isExternal bool, err error) {
+	apiVersion := strings.TrimSpace(strings.TrimPrefix(apiVersionRegEx.FindString(string(file)), "apiVersion:"))
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return gk, false, fmt.Errorf("parsing apiVersion: %w", err)
+	}
+
+	gk.Group = gv.Group
+	gk.Kind = strings.TrimSpace(strings.TrimPrefix(kindRegEx.FindString(string(file)), "kind:"))
+	isExternal = isExternalRegEx.Match(file)
+	return
+}
+
+func mapKeysToList[K comparable, V any](in map[K]V) []K {
+	out := make([]K, len(in))
+	var i int
+	for k := range in {
+		out[i] = k
+		i++
+	}
+	return out
+}

--- a/internal/packages/internal/packagetypes/permissions_test.go
+++ b/internal/packages/internal/packagetypes/permissions_test.go
@@ -1,0 +1,52 @@
+package packagetypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestPermissions(t *testing.T) {
+	t.Parallel()
+
+	files := Files{
+		"xxx.yaml.gotmpl": []byte(`
+apiVersion: my-group/v1alpha1
+kind: MyThing
+---
+apiVersion: my-group/v1alpha1
+kind: MyOtherThing
+metadata:
+  annotations:
+    package-operator.run/external: "True"
+---
+apiVersion: v1
+kind: Secret
+---
+apiVersion: v1
+kind: ConfigMap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    package-operator.run/external: "True"
+`),
+	}
+
+	ctx := context.Background()
+	perms, err := Permissions(ctx, files)
+	require.NoError(t, err)
+	if assert.Len(t, perms.Managed, 3) {
+		assert.Contains(t, perms.Managed, schema.GroupKind{Kind: "ConfigMap"})
+		assert.Contains(t, perms.Managed, schema.GroupKind{Kind: "Secret"})
+		assert.Contains(t, perms.Managed, schema.GroupKind{Group: "my-group", Kind: "MyThing"})
+	}
+	if assert.Len(t, perms.External, 2) {
+		assert.Contains(t, perms.External, schema.GroupKind{Kind: "Service"})
+		assert.Contains(t, perms.External, schema.GroupKind{Group: "my-group", Kind: "MyOtherThing"})
+	}
+}

--- a/internal/packages/internal/packagetypes/types.go
+++ b/internal/packages/internal/packagetypes/types.go
@@ -52,7 +52,15 @@ type PackageRenderContext struct {
 // RawPackage right after import.
 // No validation has been performed yet.
 type RawPackage struct {
-	Files Files
+	Files       Files
+	Permissions PackagePermissions
+}
+
+type PackagePermissions struct {
+	// ObjectTypes managed by this package.
+	Managed []schema.GroupKind `json:"managed"`
+	// ObjectTypes external to the package, that are included for evaluating status.
+	External []schema.GroupKind `json:"external"`
 }
 
 // Returns a deep copy of the RawPackage map.


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Added managed and external object kinds as annotations on the image. This is to provide a list of objects the package will need permissions for the ongoing privilege escalation protection work. 

With this PR, image built with the package CLI will included these annotation:
```
$ podman inspect myimage
[
     {
      ...
          "Annotations": {
               "external": "",
               "managed": "CustomResourceDefinition.apiextensions.k8s.io,Namespace,PackageManifest.manifests.package-operator.run,ServiceAccount,Role.rbac.authorization.k8s.io,RoleBinding.rbac.authorization.k8s.io,ClusterRole.rbac.authorization.k8s.io,ClusterRoleBinding.rbac.authorization.k8s.io,Deployment.apps"
          },
      ...      
```


### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
