### PR TITLE
Base package object order on fs order

### DIFF
--- a/internal/packages/internal/packagerender/objects.go
+++ b/internal/packages/internal/packagerender/objects.go
@@ -57,7 +57,13 @@ func RenderObjects(
 		paths[i] = path
 		i++
 	}
-	sort.Sort(pathsAscending(paths))
+	// sorts a list of file paths ascending.
+	// e.g. a, a/b, a/b/c, b, b/x, bat.
+	sort.Slice(paths, func(i, j int) bool {
+		p1 := strings.ReplaceAll(paths[i], "/", "\x00")
+		p2 := strings.ReplaceAll(paths[j], "/", "\x00")
+		return p1 < p2
+	})
 
 	var objects []unstructured.Unstructured
 	for _, path := range paths {
@@ -65,24 +71,6 @@ func RenderObjects(
 		objects = append(objects, objs...)
 	}
 	return objects, nil
-}
-
-// sorts a list of file paths ascending.
-// e.g. a, a/b, a/b/c, b, b/x, bat.
-type pathsAscending []string
-
-func (s pathsAscending) Len() int {
-	return len(s)
-}
-
-func (s pathsAscending) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s pathsAscending) Less(i, j int) bool {
-	s1 := strings.ReplaceAll(s[i], "/", "\x00")
-	s2 := strings.ReplaceAll(s[j], "/", "\x00")
-	return s1 < s2
 }
 
 var splitYAMLDocumentsRegEx = regexp.MustCompile(`(?m)^---$`)

--- a/internal/packages/internal/packagerender/objectsettemplate.go
+++ b/internal/packages/internal/packagerender/objectsettemplate.go
@@ -111,11 +111,6 @@ func (c phaseCollector) Collect() []corev1alpha1.ObjectSetTemplatePhase {
 			continue
 		}
 
-		// sort objects by name to ensure we are getting deterministic output.
-		sort.Slice(entry.Phase.Objects, func(i, j int) bool {
-			return entry.Phase.Objects[i].Object.GetName() < entry.Phase.Objects[j].Object.GetName()
-		})
-
 		entries = append(entries, entry)
 	}
 

--- a/internal/packages/internal/packagerender/objectsettemplate_test.go
+++ b/internal/packages/internal/packagerender/objectsettemplate_test.go
@@ -2,11 +2,14 @@ package packagerender
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/internal/packages/internal/packageimport"
 	"package-operator.run/internal/packages/internal/packagestructure"
 	"package-operator.run/internal/packages/internal/packagetypes"
@@ -31,4 +34,25 @@ func TestTemplateSpecFromPackage(t *testing.T) {
 
 	spec := RenderObjectSetTemplateSpec(pkgInstance)
 	require.NotNil(t, spec)
+
+	require.Len(t, spec.Phases, 1)
+
+	// assert objects are in the right order
+	assert.Equal(t, []string{
+		"/v1, Kind=ConfigMap /zzz",
+		"apps/v1, Kind=StatefulSet /some-stateful-set-1",
+		"/v1, Kind=ConfigMap /t4",
+		"/v1, Kind=ConfigMap /abc",
+	}, objectsToKindNameString(spec.Phases[0].Objects))
+}
+
+func objectsToKindNameString(objects []v1alpha1.ObjectSetObject) []string {
+	out := make([]string, len(objects))
+	for i, obj := range objects {
+		out[i] = fmt.Sprintf("%s %s/%s",
+			obj.Object.GroupVersionKind(),
+			obj.Object.GetNamespace(),
+			obj.Object.GetName())
+	}
+	return out
 }

--- a/internal/packages/internal/packagerender/testdata/base/before.yaml
+++ b/internal/packages/internal/packagerender/testdata/base/before.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zzz
+  annotations:
+    package-operator.run/phase: main-stuff

--- a/internal/packages/internal/packagerender/testdata/base/some-statefulset.yaml
+++ b/internal/packages/internal/packagerender/testdata/base/some-statefulset.yaml
@@ -5,3 +5,17 @@ metadata:
   annotations:
     package-operator.run/phase: main-stuff
 spec: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: t4
+  annotations:
+    package-operator.run/phase: main-stuff
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: abc
+  annotations:
+    package-operator.run/phase: main-stuff


### PR DESCRIPTION
This commit changes the ordering of objects within a phase when rendering a Package. Object order is now based on the order within the filesystem.

Files are now traversed in lexical order.
e.g. a.yaml, b.yaml, c/test.yaml, cb.yaml, ...

Objects will retain the order that they are specified in each file encountered.

### Change Type
Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
