### PR TITLE
Retry image pull on empty image

### DIFF
--- a/internal/packages/internal/packageimport/oci.go
+++ b/internal/packages/internal/packageimport/oci.go
@@ -58,6 +58,10 @@ func FromOCI(ctx context.Context, image containerregistrypkgv1.Image) (
 		files[path] = data
 	}
 
+	if len(files) == 0 {
+		return nil, packagetypes.ErrEmptyPackage
+	}
+
 	return &packagetypes.RawPackage{
 		Files: files,
 	}, nil

--- a/internal/packages/internal/packagetypes/violation.go
+++ b/internal/packages/internal/packagetypes/violation.go
@@ -55,6 +55,7 @@ type ViolationReason string
 
 // Predefined reasons for package violations.
 const (
+	ViolationReasonEmptyPackage                  ViolationReason = "Package image contains no files. Might be corrupted."
 	ViolationReasonPackageManifestNotFound       ViolationReason = "PackageManifest not found"
 	ViolationReasonUnknownGVK                    ViolationReason = "unknown GVK"
 	ViolationReasonPackageManifestInvalid        ViolationReason = "PackageManifest invalid"
@@ -76,6 +77,10 @@ const (
 	ViolationReasonInvalidFileInComponentsDir    ViolationReason = "The components directory may only contain folders and dot files"
 	ViolationReasonKubeconform                   ViolationReason = "Kubeconform rejected schema"
 )
+
+var ErrEmptyPackage = ViolationError{
+	Reason: ViolationReasonEmptyPackage,
+}
 
 // ErrManifestNotFound indicates that a package manifest was not found at any expected location.
 var ErrManifestNotFound = ViolationError{


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
It seems like Quay sometimes unexpectedly returns empty images.

Currently, if an empty image is pulled from the registry, the parsing phase completes without errors but then the operator marks the packages as `Invalid` because it can't find the manifest.

This state does not automatically try to re-pull the image, so the package gets stuck there even if the real image in the registry is valid.

With this PR, if an empty image is parsed, an error is immediately returned so that the operator marks the package as `NotReady`.

In this case the logic contains a retry mechanism (with backoff).

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
