### PR TITLE
fix api resource exists preflight checks

### DIFF
--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -86,10 +86,10 @@ func NewMultiClusterObjectSetPhaseController(
 		ownerhandling.NewAnnotation(scheme),
 		log, scheme, dynamicCache, uncachedClient,
 		class, client, targetWriter,
-		preflight.List{
-			preflight.NewAPIExistence(targetRESTMapper),
+		preflight.NewAPIExistence(
+			targetRESTMapper,
 			preflight.NewDryRun(targetWriter),
-		},
+		),
 	)
 }
 
@@ -108,10 +108,10 @@ func NewMultiClusterClusterObjectSetPhaseController(
 		ownerhandling.NewAnnotation(scheme),
 		log, scheme, dynamicCache, uncachedClient,
 		class, client, targetWriter,
-		preflight.List{
-			preflight.NewAPIExistence(targetRESTMapper),
-			preflight.NewDryRun(targetWriter),
-		},
+		preflight.NewAPIExistence(
+			targetRESTMapper,
+			preflight.List{preflight.NewDryRun(targetWriter)},
+		),
 	)
 }
 
@@ -129,11 +129,13 @@ func NewSameClusterObjectSetPhaseController(
 		ownerhandling.NewNative(scheme),
 		log, scheme, dynamicCache, uncachedClient,
 		class, client, client,
-		preflight.List{
-			preflight.NewAPIExistence(restMapper),
-			preflight.NewNamespaceEscalation(restMapper),
-			preflight.NewDryRun(client),
-		},
+		preflight.NewAPIExistence(
+			restMapper,
+			preflight.List{
+				preflight.NewNamespaceEscalation(restMapper),
+				preflight.NewDryRun(client),
+			},
+		),
 	)
 }
 
@@ -151,10 +153,10 @@ func NewSameClusterClusterObjectSetPhaseController(
 		ownerhandling.NewNative(scheme),
 		log, scheme, dynamicCache, uncachedClient,
 		class, client, client,
-		preflight.List{
-			preflight.NewAPIExistence(restMapper),
+		preflight.NewAPIExistence(
+			restMapper,
 			preflight.NewDryRun(client),
-		},
+		),
 	)
 }
 

--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -118,11 +118,12 @@ func newGenericObjectSetController(
 			dynamicCache,
 			uncachedClient,
 			ownerhandling.NewNative(scheme),
-			preflight.List{
-				preflight.NewAPIExistence(restMapper),
-				preflight.NewNamespaceEscalation(restMapper),
-				preflight.NewDryRun(client),
-			},
+			preflight.NewAPIExistence(restMapper,
+				preflight.List{
+					preflight.NewNamespaceEscalation(restMapper),
+					preflight.NewDryRun(client),
+				},
+			),
 		),
 		newObjectSetRemotePhaseReconciler(
 			client, uncachedClient, scheme, newObjectSetPhase),

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -89,11 +89,15 @@ func newGenericObjectTemplateController(
 		client:            client,
 		uncachedClient:    uncachedClient,
 		dynamicCache:      dynamicCache,
-		templateReconciler: newTemplateReconciler(scheme, client, uncachedClient, dynamicCache, preflight.List{
-			preflight.NewAPIExistence(restMapper),
-			preflight.NewEmptyNamespaceNoDefault(restMapper),
-			preflight.NewNamespaceEscalation(restMapper),
-		}),
+		templateReconciler: newTemplateReconciler(scheme, client, uncachedClient, dynamicCache,
+			preflight.NewAPIExistence(
+				restMapper,
+				preflight.List{
+					preflight.NewEmptyNamespaceNoDefault(restMapper),
+					preflight.NewNamespaceEscalation(restMapper),
+				},
+			),
+		),
 	}
 	controller.reconciler = []reconciler{controller.templateReconciler}
 	return controller

--- a/internal/preflight/apis_exist.go
+++ b/internal/preflight/apis_exist.go
@@ -5,34 +5,42 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Prevents the use of APIs not registered into the kube-apiserver.
 type APIExistence struct {
-	restMapper meta.RESTMapper
+	restMapper restMapper
+	sub        preflightChecker
+}
+
+type preflightChecker interface {
+	Check(ctx context.Context, owner, obj client.Object) (violations []Violation, err error)
+}
+
+type restMapper interface {
+	RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error)
 }
 
 var _ checker = (*APIExistence)(nil)
 
-func NewAPIExistence(restMapper meta.RESTMapper) *APIExistence {
-	return &APIExistence{
-		restMapper: restMapper,
-	}
+func NewAPIExistence(restMapper restMapper, sub preflightChecker) *APIExistence {
+	return &APIExistence{restMapper, sub}
 }
 
-func (p *APIExistence) Check(ctx context.Context, _, obj client.Object) (violations []Violation, err error) {
-	defer addPositionToViolations(ctx, obj, &violations)
-
+func (p *APIExistence) Check(ctx context.Context, owner, obj client.Object) ([]Violation, error) {
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	_, err = p.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if meta.IsNoMatchError(err) {
-		violations = append(violations, Violation{
-			Error: fmt.Sprintf("%s not registered on the api server.", gvk),
-		})
+	_, err := p.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	switch {
+	case err == nil:
+		return p.sub.Check(ctx, owner, obj)
+	case meta.IsNoMatchError(err):
+		violations := []Violation{{Error: fmt.Sprintf("%s not registered on the api server.", gvk)}}
+		addPositionToViolations(ctx, obj, &violations)
+
+		return violations, nil
+	default:
+		return nil, err
 	}
-	if err != nil {
-		return
-	}
-	return
 }

--- a/internal/preflight/apis_exist_test.go
+++ b/internal/preflight/apis_exist_test.go
@@ -1,0 +1,91 @@
+package preflight_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"package-operator.run/internal/preflight"
+)
+
+type sub struct{ mock.Mock }
+
+func (s *sub) Check(ctx context.Context, owner client.Object, obj client.Object) (violations []preflight.Violation, err error) {
+	ret := s.Called(ctx, owner, obj)
+
+	return ret.Get(0).([]preflight.Violation), ret.Error(1)
+}
+
+type mapper struct{ mock.Mock }
+
+func (m *mapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	ret := m.Called(gk, versions)
+
+	return ret.Get(0).(*meta.RESTMapping), ret.Error(1)
+}
+
+func TestAPIExistenceExists(t *testing.T) {
+	t.Parallel()
+
+	m := &mapper{}
+	s := &sub{}
+	ctx := context.Background()
+	owner := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "blorb"}}
+	obj := &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "3"}}
+
+	checkVios := []preflight.Violation{{Position: "12321"}}
+	checkErr := fmt.Errorf("smth") //nolint: goerr113
+
+	m.On("RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"}).Once().Return(&meta.RESTMapping{}, nil)
+	s.On("Check", ctx, owner, obj).Once().Return(checkVios, checkErr)
+
+	violations, err := preflight.NewAPIExistence(m, s).Check(ctx, owner, obj)
+
+	require.ErrorIs(t, err, checkErr)
+	require.Equal(t, checkVios, violations)
+}
+
+func TestAPIExistenceNotExists(t *testing.T) {
+	t.Parallel()
+
+	m := &mapper{}
+	s := &sub{}
+	ctx := context.Background()
+	owner := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "blorb"}}
+	obj := &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "3"}}
+
+	checkVios := []preflight.Violation{{Position: "kind /", Error: "/3, Kind=kind not registered on the api server."}}
+
+	m.On("RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"}).Once().Return(&meta.RESTMapping{}, &meta.NoResourceMatchError{})
+	violations, err := preflight.NewAPIExistence(m, s).Check(ctx, owner, obj)
+
+	require.NoError(t, err)
+	require.Equal(t, checkVios, violations)
+}
+
+func TestAPIExistenceErr(t *testing.T) {
+	t.Parallel()
+
+	m := &mapper{}
+	s := &sub{}
+	ctx := context.Background()
+	owner := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "blorb"}}
+	obj := &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "3"}}
+
+	checkErr := fmt.Errorf("smth") //nolint: goerr113
+
+	m.On("RESTMapping", schema.GroupKind{Group: "", Kind: "kind"}, []string{"3"}).Once().Return(&meta.RESTMapping{}, checkErr)
+
+	violations, err := preflight.NewAPIExistence(m, s).Check(ctx, owner, obj)
+
+	require.ErrorIs(t, err, checkErr)
+	require.Empty(t, violations)
+}


### PR DESCRIPTION
When creating an ObjectSet including an object that was not registered into the kube-apiserver, the ObjectSet is stuck "Pending" and only when checking PKO logs you see an error:

2023-12-19T10:02:43Z ERROR Reconciler error {"controller": "clusterobjectset", "controllerGroup": "package-operator.run", "controllerKind": "ClusterObjectSet", "ClusterObjectSet":
{"name":"test-6c5fdd6896"}

, "namespace": "", "name": "test-6c5fdd6896", "reconcileID": "486aec14-39d9-4a98-be91-8d056fef2383", "error": "failed to get API group resources: unable to retrieve the complete list of server APIs: operators.coreos.com/v1alpha1: the server could not find the requested resource"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227
 
