### PR TITLE
[cmd/build] add CI:RegistryLoginAndReleaseOnlyImages

### DIFF
--- a/cmd/build/ci.go
+++ b/cmd/build/ci.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 
 	"pkg.package-operator.run/cardboard/run"
 )
@@ -44,38 +43,38 @@ func (ci *CI) RegistryLogin(_ context.Context, args []string) error {
 	return shr.Run("crane", append([]string{"auth", "login"}, args...)...)
 }
 
-// Release builds binaries and releases the CLI, PKO manager, PKO webhooks and test-stub images to the given registry.
+// Release builds binaries (if not exluded with the 'images-only" arg) and releases the
+// CLI, PKO manager, RP manager, PKO webhooks and test-stub images to the given registry.
 func (ci *CI) Release(ctx context.Context, args []string) error {
 	registry := imageRegistry()
 
-	if len(args) > 2 {
-		return errors.New("target registry as a single arg or no args for official") //nolint:goerr113
-	} else if len(args) == 1 {
-		registry = args[1]
-	}
-	if registry == "" {
-		return errors.New("registry may not be empty") //nolint:goerr113
-	}
-
 	self := run.Meth1(ci, ci.Release, args)
 
-	if err := mgr.ParallelDeps(ctx, self,
-		// bootstrap job manifests
-		run.Meth(generate, generate.selfBootstrapJob),
+	deps := []run.Dependency{}
 
-		// binaries
-		run.Fn3(compile, "kubectl-package", "linux", "amd64"),
-		run.Fn3(compile, "kubectl-package", "linux", "arm64"),
-		run.Fn3(compile, "kubectl-package", "darwin", "amd64"),
-		run.Fn3(compile, "kubectl-package", "darwin", "arm64"),
+	imagesOnly := len(args) > 0 && args[0] == "images-only"
+	if !imagesOnly {
+		deps = append(deps,
+			// bootstrap job manifests
+			run.Meth(generate, generate.selfBootstrapJob),
+			// binaries
+			run.Fn3(compile, "kubectl-package", "linux", "amd64"),
+			run.Fn3(compile, "kubectl-package", "linux", "arm64"),
+			run.Fn3(compile, "kubectl-package", "darwin", "amd64"),
+			run.Fn3(compile, "kubectl-package", "darwin", "arm64"),
+		)
+	}
 
+	deps = append(deps,
 		// binary images
 		run.Fn3(pushImage, "cli", registry, "amd64"),
 		run.Fn3(pushImage, "package-operator-manager", registry, "amd64"),
 		run.Fn3(pushImage, "package-operator-webhook", registry, "amd64"),
 		run.Fn3(pushImage, "remote-phase-manager", registry, "amd64"),
 		run.Fn3(pushImage, "test-stub", registry, "amd64"),
-	); err != nil {
+	)
+
+	if err := mgr.ParallelDeps(ctx, self, deps...); err != nil {
 		return err
 	}
 
@@ -94,5 +93,14 @@ func (ci *CI) Release(ctx context.Context, args []string) error {
 	// the lockfile of the package-operator package image can be regenerated.
 	return mgr.SerialDeps(ctx, self,
 		run.Fn2(pushPackage, "package-operator", registry),
+	)
+}
+
+// Combined RegistryLogin and Release with images-only arg. (This is our downstream CI target.)
+func (ci *CI) RegistryLoginAndReleaseOnlyImages(ctx context.Context, args []string) error {
+	self := run.Meth1(ci, ci.RegistryLoginAndReleaseOnlyImages, args)
+	return mgr.SerialDeps(ctx, self,
+		run.Meth1(ci, ci.RegistryLogin, args),
+		run.Meth1(ci, ci.Release, []string{"images-only"}),
 	)
 }


### PR DESCRIPTION
because we don't have to cross-compile binaries on downstream CI and we need login + release to be a single command there

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
