### PR TITLE
increase timeout for package integration tests

### DIFF
--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
+
+	"pkg.package-operator.run/cardboard/kubeutils/wait"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -30,13 +33,15 @@ func requireDeployPackage(ctx context.Context, t *testing.T, pkg, objectDeployme
 	require.NoError(t, Client.Create(ctx, pkg))
 	cleanupOnSuccess(ctx, t, pkg)
 
+	timeoutOpt := wait.WithTimeout(40 * time.Second)
+
 	require.NoError(t,
-		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageUnpacked, metav1.ConditionTrue))
+		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageUnpacked, metav1.ConditionTrue, timeoutOpt))
 	// Condition Mapping from Deployment
 	require.NoError(t,
-		Waiter.WaitForCondition(ctx, pkg, "my-prefix/Progressing", metav1.ConditionTrue))
+		Waiter.WaitForCondition(ctx, pkg, "my-prefix/Progressing", metav1.ConditionTrue, timeoutOpt))
 	require.NoError(t,
-		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageAvailable, metav1.ConditionTrue))
+		Waiter.WaitForCondition(ctx, pkg, corev1alpha1.PackageAvailable, metav1.ConditionTrue, timeoutOpt))
 
 	require.NoError(t, Client.Get(ctx, client.ObjectKey{
 		Name: pkg.GetName(), Namespace: pkg.GetNamespace(),


### PR DESCRIPTION
We suspect GH actions runners are slower now and thus increase the timeouts a little so that our int tests stop failing.

Cherry-picked from @pbabic-redhat's PR branch for #1013 :heart: 


<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
