### PR TITLE
[PKO-13] Automatic Big Package Support - add BinpackNextFitChunker

### DIFF
--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -6,25 +6,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
-	"pkg.package-operator.run/cardboard/kubeutils/wait"
-
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-
-	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
-
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"pkg.package-operator.run/cardboard/kubeutils/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
 )
 
 func requireDeployPackage(ctx context.Context, t *testing.T, pkg, objectDeployment client.Object) {
@@ -159,8 +157,15 @@ func TestPackage_simpleWithSlices(t *testing.T) {
 			err := Client.List(ctx, sliceList)
 			require.NoError(t, err)
 
-			// Just a Deployment
-			assertLenWithJSON(t, sliceList.Items, 2)
+			filteredSlices := []corev1alpha1.ClusterObjectSlice{}
+			for _, item := range sliceList.Items {
+				if !strings.HasPrefix(item.Name, "success-slices-") {
+					continue
+				}
+				filteredSlices = append(filteredSlices, item)
+			}
+
+			assertLenWithJSON(t, filteredSlices, 2)
 		}
 	}
 

--- a/internal/packages/internal/packagedeploy/chunking.go
+++ b/internal/packages/internal/packagedeploy/chunking.go
@@ -2,6 +2,8 @@ package packagedeploy
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/internal/adapters"
@@ -11,8 +13,12 @@ type (
 	// NoOpChunker implements objectChunker, but does not actually chunk.
 	NoOpChunker struct{}
 
-	// NoOpChunker implements objectChunker, by putting every object into it's own ObjectSlice.
+	// EachObjectChunker implements objectChunker, by putting every object into it's own ObjectSlice.
 	EachObjectChunker struct{}
+
+	// BinpackNextFitChunker implements objectChunker by putting up to `binpackNextFitStrategyChunkLimit`
+	// of object bytes into their own ObjectSlices.
+	BinpackNextFitChunker struct{}
 )
 
 type (
@@ -31,11 +37,22 @@ const (
 
 	// Chunks objects by putting every single object into it's own slice.
 	chunkingStrategyEachObject chunkingStrategy = "EachObject"
+
+	// Chunks objects by putting up to `binpackNextFitStrategyChunkLimit` of object bytes into their own ObjectSlices.
+	chunkingStrategyBinpackNextFit chunkingStrategy = "BinpackNextFit"
+
+	// etcd - the default Kubernetes database - has an object size limit of
+	// 1 MiB for etcd <=v3.2: https://etcd.io/docs/v3.2/dev-guide/limit/
+	// and
+	// 1.5 MiB for etcd >v3.2: https://etcd.io/docs/v3.3/dev-guide/limit/
+	// .
+	binpackNextFitStrategyChunkLimit int = 1024 * 1024 // 1 MiB
 )
 
 var (
 	_ objectChunker = (*NoOpChunker)(nil)
 	_ objectChunker = (*EachObjectChunker)(nil)
+	_ objectChunker = (*BinpackNextFitChunker)(nil)
 )
 
 // Returns the chunkingStrategy implementation for the given Package.
@@ -44,6 +61,8 @@ func determineChunkingStrategyForPackage(pkg adapters.GenericPackageAccessor) ob
 	switch chunkingStrategy(strategy) {
 	case chunkingStrategyEachObject:
 		return &EachObjectChunker{}
+	case chunkingStrategyBinpackNextFit:
+		return &BinpackNextFitChunker{}
 	default:
 		return &NoOpChunker{}
 	}
@@ -63,4 +82,45 @@ func (c *EachObjectChunker) Chunk(
 		out[i] = []corev1alpha1.ObjectSetObject{obj}
 	}
 	return out, nil
+}
+
+// Chunk produces either 0 chunks if all objects are too small to overflow the first chunk, or at least two chunks.
+func (c *BinpackNextFitChunker) Chunk(
+	_ context.Context, phase *corev1alpha1.ObjectSetTemplatePhase,
+) ([][]corev1alpha1.ObjectSetObject, error) {
+	chunks := make([][]corev1alpha1.ObjectSetObject, 0, 1)
+	currentChuckSize := 0
+	currentChunk := make([]corev1alpha1.ObjectSetObject, 0)
+
+	for _, obj := range phase.Objects {
+		b, err := json.Marshal(obj.Object)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling object to json for chunk estimation: %w", err)
+		}
+
+		size := len(b)
+
+		// Close open chunk and allocate new chunk if the open chunk already contains objects and would overflow.
+		if currentChuckSize > 0 && currentChuckSize+size > binpackNextFitStrategyChunkLimit {
+			currentChuckSize = 0
+			chunks = append(chunks, currentChunk)
+			currentChunk = make([]corev1alpha1.ObjectSetObject, 0)
+		}
+
+		// Add object to open chunk.
+		currentChunk = append(currentChunk, obj)
+		currentChuckSize += size
+	}
+
+	// Signal chunking bypass because no chunks have been made.
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	// flush open chunk
+	if len(currentChunk) > 0 {
+		chunks = append(chunks, currentChunk)
+	}
+
+	return chunks, nil
 }

--- a/internal/packages/internal/packagedeploy/chunking.go
+++ b/internal/packages/internal/packagedeploy/chunking.go
@@ -35,6 +35,9 @@ const (
 	// Allows to force a chunking strategy when set on a Package object.
 	chunkingStrategyAnnotation = "packages.package-operator.run/chunking-strategy"
 
+	// Chunks no objects at all.
+	chunkingStrategyNoOp chunkingStrategy = "NoOp"
+
 	// Chunks objects by putting every single object into it's own slice.
 	chunkingStrategyEachObject chunkingStrategy = "EachObject"
 
@@ -63,8 +66,10 @@ func determineChunkingStrategyForPackage(pkg adapters.GenericPackageAccessor) ob
 		return &EachObjectChunker{}
 	case chunkingStrategyBinpackNextFit:
 		return &BinpackNextFitChunker{}
-	default:
+	case chunkingStrategyNoOp:
 		return &NoOpChunker{}
+	default:
+		return &BinpackNextFitChunker{}
 	}
 }
 

--- a/internal/packages/internal/packagedeploy/chunking_test.go
+++ b/internal/packages/internal/packagedeploy/chunking_test.go
@@ -87,7 +87,7 @@ func TestEachObjectChunker(t *testing.T) {
 	assert.Len(t, chunks, 3)
 }
 
-func TestBinpackNextFitChunkerChunker(t *testing.T) {
+func TestBinpackNextFitChunker(t *testing.T) {
 	t.Parallel()
 
 	tcases := []struct {


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR adds a chunker that put's at most 1 Megabyte (1 MiB) of objects into a single ObjectSlice and makes PKO behave as described in [1]:

> When using the 'Package' API, Package Operator will automatically split packages that reach a certain limit by using the 'ObjectSlice' API.

The chunker uses next fit binpacking aka:
- keep 1 bucket open
- put objects into the open bucket
- close the bucket and create a new bucket if the next object is too big

### Change Type

<!-- Uncomment one of the following -->
Breaking Change
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] Clarify: will this chunker be used by default?

### Additional Information

[1] https://package-operator.run/docs/concepts/big-packages/