### PR TITLE
[ci/testing] do not fail the CI for failed codecov uploads when a fork is tested

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,7 +43,7 @@ jobs:
       with:
         files: .cache/unit/cover.txt,.cache/integration/cover.txt
         token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.repository_owner == 'package-operator' }}
         verbose: true
 
     - name: Archive unit test results


### PR DESCRIPTION
no more

![image](https://github.com/package-operator/package-operator/assets/5539202/8036d449-7164-4c2f-9523-e3d7e1c01793)

maybe?
please?

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
