### PR TITLE
PKO-82: Implement regression test and bugfix for invalid remote-phase package upgrade

### DIFF
--- a/internal/controllers/hostedclusters/hostedcluster_controller.go
+++ b/internal/controllers/hostedclusters/hostedcluster_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -103,11 +104,11 @@ func (c *HostedClusterController) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("getting Package: %w", err)
 	}
 
-	if existingPkg.Spec.Image != desiredPkg.Spec.Image {
-		// update Job
-		existingPkg.Spec.Image = desiredPkg.Spec.Image
+	// Update package if spec is different.
+	if !reflect.DeepEqual(existingPkg.Spec, desiredPkg.Spec) {
+		existingPkg.Spec = desiredPkg.Spec
 		if err := c.client.Update(ctx, existingPkg); err != nil {
-			return ctrl.Result{}, fmt.Errorf("deleting outdated Package: %w", err)
+			return ctrl.Result{}, fmt.Errorf("updating outdated Package: %w", err)
 		}
 	}
 


### PR DESCRIPTION
In a previous release, the remote-phase component was moved from the top-level component of its own package to the `remote-phase` component of the package-operator package.

Upgrading all existing remote-phase Packages controlled by PKO includes the (up until now missing pieces):
- diffing existing-package vs desired-package `.spec` and not only `.spec.image`
- updating/overriding `.spec` (and thus also, the crucial field: `.spec.component`) instead of only updating `.spec.image`

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
