### PR TITLE
[cmd/build] include debug symbols in binaries

### DIFF
--- a/cmd/build/binary.go
+++ b/cmd/build/binary.go
@@ -40,7 +40,7 @@ func compile(ctx context.Context, cmd string, goos, goarch string) error {
 	dst := filepath.Join("bin", fmt.Sprintf("%s_%s_%s", cmd, goos, goarch))
 
 	ldflags := []string{
-		"-buildid=",
+		"-w", "-buildid=",
 		"--extldflags", "'-zrelro -znow -O1'",
 		"-X", fmt.Sprintf("'package-operator.run/internal/version.version=%s'", appVersion),
 	}

--- a/cmd/build/binary.go
+++ b/cmd/build/binary.go
@@ -40,7 +40,7 @@ func compile(ctx context.Context, cmd string, goos, goarch string) error {
 	dst := filepath.Join("bin", fmt.Sprintf("%s_%s_%s", cmd, goos, goarch))
 
 	ldflags := []string{
-		"-w", "-s", "-buildid=",
+		"-buildid=",
 		"--extldflags", "'-zrelro -znow -O1'",
 		"-X", fmt.Sprintf("'package-operator.run/internal/version.version=%s'", appVersion),
 	}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

As part of @sclarkso 's work on [PKO-39](https://issues.redhat.com/browse/PKO-39) we discovered, that [check-payload](https://github.com/openshift/check-payload) does not like our go binaries and their validation fails.

Apparently check-payload looks for the existence of a bunch of symbol names [1], which needs the symbol table to be available and not stripped during compilation.

[1] [return types.NewValidationError(types.ErrGoMissingSymbols](https://github.com/openshift/check-payload/blob/5a2d845f8debd082ad27998a34bbe069e5a557d5/internal/validations/validations.go#L84) 

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
