### PR TITLE
[cmd/build] explore adding optional fips validation as preparation/inspiration for PKO-40

### DIFF
--- a/cmd/build/binary.go
+++ b/cmd/build/binary.go
@@ -54,3 +54,11 @@ func compile(ctx context.Context, cmd string, goos, goarch string) error {
 
 	return nil
 }
+
+// Validate fips readyness of binary by demonstrating that
+// the compiled go binary contains bindings to a fips validated crypto library.
+func validateFIPS(_ context.Context, _ string, _, _ string) error {
+	// something like
+	// run go tool nm on binary and look for correct symbols/patterns in output
+	return nil
+}

--- a/cmd/build/cluster.go
+++ b/cmd/build/cluster.go
@@ -270,10 +270,10 @@ func (c *Cluster) loadImages(ctx context.Context, registryPort int32) error {
 	registry := localRegistry(hostPort)
 
 	if err := mgr.ParallelDeps(ctx, self,
-		run.Fn3(pushImage, "package-operator-manager", registry, runtime.GOARCH),
-		run.Fn3(pushImage, "package-operator-webhook", registry, runtime.GOARCH),
-		run.Fn3(pushImage, "remote-phase-manager", registry, runtime.GOARCH),
-		run.Fn3(pushImage, "test-stub", registry, runtime.GOARCH),
+		run.Fn4(pushImage, "package-operator-manager", registry, runtime.GOARCH, false),
+		run.Fn4(pushImage, "package-operator-webhook", registry, runtime.GOARCH, false),
+		run.Fn4(pushImage, "remote-phase-manager", registry, runtime.GOARCH, false),
+		run.Fn4(pushImage, "test-stub", registry, runtime.GOARCH, false),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is intented to be an inspirational playground to explore the possibility of adding an optional "validate fips-readiness of built binary"-step for [PKO-40](https://issues.redhat.com/browse/PKO-40).

The downstream CI target now has the ability to instruct `build/pushImage` to validate the built go binary before actually building the image.

There's a stub function called `validateFIPS` in binary.go which needs to be implemented. This PR explores how the validation could be woven into `cmd/build` aka `cmd/build` and the actual validation is not implemented yet.

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
