### PR TITLE
make object template controller retry duration on missing sources configurable

### DIFF
--- a/cmd/build/generate.go
+++ b/cmd/build/generate.go
@@ -119,7 +119,11 @@ func (g Generate) selfBootstrapJobLocal(context.Context) error {
 	}
 
 	registyOverrides := imageRegistryHost() + "=dev-registry.dev-registry.svc.cluster.local:5001"
-	pkoConfig := fmt.Sprintf(`{"registryHostOverrides":"%s"}`, registyOverrides)
+	pkoConfig := fmt.Sprintf(`{
+		"registryHostOverrides": "%s",
+		"objectTemplateResourceRetryInterval": "2s",
+		"objectTemplateOptionalResourceRetryInterval": "4s"
+	}`, registyOverrides)
 
 	replacements := map[string]string{
 		`##registry-overrides##`: registyOverrides,

--- a/cmd/package-operator-manager/components/objecttemplate.go
+++ b/cmd/package-operator-manager/components/objecttemplate.go
@@ -22,13 +22,17 @@ type (
 func ProvideObjectTemplateController(
 	mgr ctrl.Manager, log logr.Logger,
 	uncachedClient UncachedClient,
-	dc *dynamiccache.Cache,
+	dc *dynamiccache.Cache, options Options,
 ) ObjectTemplateController {
 	return ObjectTemplateController{
 		objecttemplate.NewObjectTemplateController(
 			mgr.GetClient(), uncachedClient,
 			log.WithName("controllers").WithName("ObjectTemplate"),
 			dc, mgr.GetScheme(), mgr.GetRESTMapper(),
+			objecttemplate.ControllerConfig{
+				OptionalResourceRetryInterval: options.ObjectTemplateOptionalResourceRetryInterval,
+				ResourceRetryInterval:         options.ObjectTemplateResourceRetryInterval,
+			},
 		),
 	}
 }
@@ -37,12 +41,17 @@ func ProvideClusterObjectTemplateController(
 	mgr ctrl.Manager, log logr.Logger,
 	uncachedClient UncachedClient,
 	dc *dynamiccache.Cache,
+	options Options,
 ) ClusterObjectTemplateController {
 	return ClusterObjectTemplateController{
 		objecttemplate.NewClusterObjectTemplateController(
 			mgr.GetClient(), uncachedClient,
 			log.WithName("controllers").WithName("ClusterObjectTemplate"),
 			dc, mgr.GetScheme(), mgr.GetRESTMapper(),
+			objecttemplate.ControllerConfig{
+				OptionalResourceRetryInterval: options.ObjectTemplateOptionalResourceRetryInterval,
+				ResourceRetryInterval:         options.ObjectTemplateResourceRetryInterval,
+			},
 		),
 	}
 }

--- a/cmd/package-operator-manager/components/options.go
+++ b/cmd/package-operator-manager/components/options.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -35,6 +36,10 @@ const (
 		"like remote-phase-manager."
 	subCmpntTolerationsFlagDescription = "Pod tolerations settings used in PKO deployed subcomponents, " +
 		"like remote-phase-manager."
+	objectTemplateOptionalResourceRetryIntervalFlagDescription = "The interval at which the controller will retry " +
+		"getting optional source resource for an ObjectTemplate."
+	objectTemplateResourceRetryIntervalFlagDescription = "The interval at which the controller will retry " +
+		"getting source resource for an ObjectTemplate."
 )
 
 type Options struct {
@@ -56,6 +61,10 @@ type Options struct {
 	// Sub component Settings
 	SubComponentAffinity    *corev1.Affinity
 	SubComponentTolerations []corev1.Toleration
+
+	// Controller configuration
+	ObjectTemplateOptionalResourceRetryInterval time.Duration
+	ObjectTemplateResourceRetryInterval         time.Duration
 }
 
 func ProvideOptions() (opts Options, err error) {
@@ -97,6 +106,15 @@ func ProvideOptions() (opts Options, err error) {
 		&opts.RegistryHostOverrides, "registry-host-overrides",
 		os.Getenv("PKO_REGISTRY_HOST_OVERRIDES"),
 		registryHostOverrides)
+
+	flag.DurationVar(
+		&opts.ObjectTemplateResourceRetryInterval,
+		"object-template-resource-retry-interval",
+		time.Second*30, objectTemplateResourceRetryIntervalFlagDescription)
+	flag.DurationVar(
+		&opts.ObjectTemplateOptionalResourceRetryInterval,
+		"object-template-optional-resource-retry-interval",
+		time.Second*60, objectTemplateOptionalResourceRetryIntervalFlagDescription)
 
 	var (
 		subComponentAffinityJSON    string

--- a/cmd/package-operator-manager/components/options_test.go
+++ b/cmd/package-operator-manager/components/options_test.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,5 +66,7 @@ func TestProvideOptions(t *testing.T) {
 				},
 			},
 		},
+		ObjectTemplateOptionalResourceRetryInterval: time.Second * 60,
+		ObjectTemplateResourceRetryInterval:         time.Second * 30,
 	}, opts)
 }

--- a/config/packages/package-operator/manifest.yaml.tpl
+++ b/config/packages/package-operator/manifest.yaml.tpl
@@ -36,6 +36,10 @@ spec:
           format: int32
         registryHostOverrides:
           type: string
+        objectTemplateResourceRetryInterval:
+          type: string
+        objectTemplateOptionalResourceRetryInterval:
+          type: string
         namespace:
           description: Namespace to install package operator into.
           type: string

--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -33,6 +33,12 @@ spec:
       containers:
       - args:
         - --enable-leader-election
+        {{- if hasKey .config "objectTemplateResourceRetryInterval" }}
+        - --object-template-resource-retry-interval={{ .config.objectTemplateResourceRetryInterval }}
+        {{- end}}
+        {{- if hasKey .config "objectTemplateOptionalResourceRetryInterval" }}
+        - --object-template-optional-resource-retry-interval={{ .config.objectTemplateOptionalResourceRetryInterval }}
+        {{- end}}
         ports:
         - name: metrics
           containerPort: 8080

--- a/integration/package-operator/objecttemplate_test.go
+++ b/integration/package-operator/objecttemplate_test.go
@@ -446,8 +446,7 @@ data:
 				upatedCM := obj.(*corev1.ConfigMap)
 				return upatedCM.Data["test"] == secretValue, nil
 			},
-			// For optional source the default retryAfter duration in the controller is 60s.
-			wait.WithTimeout(100*time.Second),
+			wait.WithTimeout(6*time.Second),
 		),
 	)
 }

--- a/integration/package-operator/objecttemplate_test.go
+++ b/integration/package-operator/objecttemplate_test.go
@@ -446,7 +446,8 @@ data:
 				upatedCM := obj.(*corev1.ConfigMap)
 				return upatedCM.Data["test"] == secretValue, nil
 			},
-			wait.WithTimeout(60*time.Second),
+			// For optional source the default retryAfter duration in the controller is 60s.
+			wait.WithTimeout(100*time.Second),
 		),
 	)
 }

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -53,9 +53,14 @@ type GenericObjectTemplateController struct {
 	reconciler         []reconciler
 }
 
+// ControllerConfig holds the configuration for the ObjectTemplate controller.
 type ControllerConfig struct {
+	// OptionalResourceRetryInterval is the interval at which the controller will retry
+	// to fetch optional resources.
 	OptionalResourceRetryInterval time.Duration
-	ResourceRetryInterval         time.Duration
+	// ResourceRetryInterval is the interval at which the controller will retry to fetch
+	// resources(non optional).
+	ResourceRetryInterval time.Duration
 }
 
 func NewObjectTemplateController(

--- a/internal/controllers/objecttemplate/objecttemplate_controller_test.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller_test.go
@@ -3,6 +3,7 @@ package objecttemplate
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +36,11 @@ func TestObjectTemplateController_Reconcile(t *testing.T) {
 	log := testr.New(t)
 	dc := &dynamiccachemocks.DynamicCacheMock{}
 	rm := &restmappermock.RestMapperMock{}
-	controller := NewObjectTemplateController(c, uncachedClient, log, dc, testScheme, rm)
+	cfg := ControllerConfig{
+		OptionalResourceRetryInterval: time.Second * 30,
+		ResourceRetryInterval:         time.Second * 30,
+	}
+	controller := NewObjectTemplateController(c, uncachedClient, log, dc, testScheme, rm, cfg)
 	controller.reconciler = nil // we are testing reconcilers on their own
 
 	objectKey := client.ObjectKey{Name: "test", Namespace: "testns"}
@@ -67,7 +72,11 @@ func TestObjectTemplateController_Reconcile_deletion(t *testing.T) {
 	log := testr.New(t)
 	dc := &dynamiccachemocks.DynamicCacheMock{}
 	rm := &restmappermock.RestMapperMock{}
-	controller := NewObjectTemplateController(c, uncachedClient, log, dc, testScheme, rm)
+	cfg := ControllerConfig{
+		OptionalResourceRetryInterval: time.Second * 30,
+		ResourceRetryInterval:         time.Second * 30,
+	}
+	controller := NewObjectTemplateController(c, uncachedClient, log, dc, testScheme, rm, cfg)
 	controller.reconciler = nil // we are testing reconcilers on their own
 
 	objectKey := client.ObjectKey{Name: "test", Namespace: "testns"}

--- a/internal/controllers/objecttemplate/template_reconciler.go
+++ b/internal/controllers/objecttemplate/template_reconciler.go
@@ -34,13 +34,13 @@ var defaultMissingResourceRetryInterval = 30 * time.Second
 
 type templateReconciler struct {
 	*environment.Sink
-	scheme                               *runtime.Scheme
-	client                               client.Writer
-	uncachedClient                       client.Reader
-	dynamicCache                         dynamicCache
-	preflightChecker                     preflightChecker
-	missingOptionalResourceRetryInterval time.Duration
-	missingResourceRetryInterval         time.Duration
+	scheme                        *runtime.Scheme
+	client                        client.Writer
+	uncachedClient                client.Reader
+	dynamicCache                  dynamicCache
+	preflightChecker              preflightChecker
+	optionalResourceRetryInterval time.Duration
+	resourceRetryInterval         time.Duration
 }
 
 func newTemplateReconciler(
@@ -49,19 +49,19 @@ func newTemplateReconciler(
 	uncachedClient client.Reader,
 	dynamicCache dynamicCache,
 	preflightChecker preflightChecker,
-	missingOptionalResourceRetryInterval time.Duration,
-	missingResourceRetryInterval time.Duration,
+	optionalResourceRetryInterval time.Duration,
+	resourceRetryInterval time.Duration,
 ) *templateReconciler {
 	return &templateReconciler{
 		Sink: environment.NewSink(client),
 
-		scheme:                               scheme,
-		client:                               client,
-		uncachedClient:                       uncachedClient,
-		dynamicCache:                         dynamicCache,
-		preflightChecker:                     preflightChecker,
-		missingOptionalResourceRetryInterval: missingOptionalResourceRetryInterval,
-		missingResourceRetryInterval:         missingResourceRetryInterval,
+		scheme:                        scheme,
+		client:                        client,
+		uncachedClient:                uncachedClient,
+		dynamicCache:                  dynamicCache,
+		preflightChecker:              preflightChecker,
+		optionalResourceRetryInterval: optionalResourceRetryInterval,
+		resourceRetryInterval:         resourceRetryInterval,
 	}
 }
 
@@ -76,13 +76,13 @@ func (r *templateReconciler) Reconcile(
 	retryLater, err := r.getValuesFromSources(ctx, objectTemplate, sourcesConfig)
 	if err != nil {
 		if isMissingResourceError(err) {
-			res.RequeueAfter = r.missingResourceRetryInterval
+			res.RequeueAfter = r.resourceRetryInterval
 		}
 		return res, fmt.Errorf("retrieving values from sources: %w", err)
 	}
 	// For optional resources.
 	if retryLater {
-		res.RequeueAfter = r.missingOptionalResourceRetryInterval
+		res.RequeueAfter = r.optionalResourceRetryInterval
 	}
 
 	obj := &unstructured.Unstructured{

--- a/internal/controllers/objecttemplate/template_reconciler.go
+++ b/internal/controllers/objecttemplate/template_reconciler.go
@@ -34,11 +34,13 @@ var defaultMissingResourceRetryInterval = 30 * time.Second
 
 type templateReconciler struct {
 	*environment.Sink
-	scheme           *runtime.Scheme
-	client           client.Writer
-	uncachedClient   client.Reader
-	dynamicCache     dynamicCache
-	preflightChecker preflightChecker
+	scheme                               *runtime.Scheme
+	client                               client.Writer
+	uncachedClient                       client.Reader
+	dynamicCache                         dynamicCache
+	preflightChecker                     preflightChecker
+	missingOptionalResourceRetryInterval time.Duration
+	missingResourceRetryInterval         time.Duration
 }
 
 func newTemplateReconciler(
@@ -47,15 +49,19 @@ func newTemplateReconciler(
 	uncachedClient client.Reader,
 	dynamicCache dynamicCache,
 	preflightChecker preflightChecker,
+	missingOptionalResourceRetryInterval time.Duration,
+	missingResourceRetryInterval time.Duration,
 ) *templateReconciler {
 	return &templateReconciler{
 		Sink: environment.NewSink(client),
 
-		scheme:           scheme,
-		client:           client,
-		uncachedClient:   uncachedClient,
-		dynamicCache:     dynamicCache,
-		preflightChecker: preflightChecker,
+		scheme:                               scheme,
+		client:                               client,
+		uncachedClient:                       uncachedClient,
+		dynamicCache:                         dynamicCache,
+		preflightChecker:                     preflightChecker,
+		missingOptionalResourceRetryInterval: missingOptionalResourceRetryInterval,
+		missingResourceRetryInterval:         missingResourceRetryInterval,
 	}
 }
 
@@ -69,10 +75,14 @@ func (r *templateReconciler) Reconcile(
 	sourcesConfig := map[string]any{}
 	retryLater, err := r.getValuesFromSources(ctx, objectTemplate, sourcesConfig)
 	if err != nil {
+		if isMissingResourceError(err) {
+			res.RequeueAfter = r.missingResourceRetryInterval
+		}
 		return res, fmt.Errorf("retrieving values from sources: %w", err)
 	}
+	// For optional resources.
 	if retryLater {
-		res.RequeueAfter = defaultMissingResourceRetryInterval
+		res.RequeueAfter = r.missingOptionalResourceRetryInterval
 	}
 
 	obj := &unstructured.Unstructured{
@@ -441,4 +451,12 @@ func RelaxedJSONPathExpression(pathExpression string) (string, error) {
 		fieldSpec = submatches[2]
 	}
 	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+func isMissingResourceError(err error) bool {
+	var sourceError *SourceError
+	if errors.As(err, &sourceError) {
+		return apimachineryerrors.IsNotFound(sourceError.Err)
+	}
+	return false
 }

--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	missingResourceRetryInterval         = 30 * time.Second
-	missingOptionalResourceRetryInterval = 60 * time.Second
+	resourceRetryInterval         = 3 * time.Second
+	optionalResourceRetryInterval = 6 * time.Second
 )
 
 func Test_templateReconciler_getSourceObject(t *testing.T) {
@@ -566,11 +566,11 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 
 func TestRequeueDurationOnMissingSource(t *testing.T) {
 	t.Parallel()
-	t.Run("missing optional source returns configured missingResourceRetryInterval", func(t *testing.T) {
+	t.Run("missing optional source returns configured optionalResourceRetryInterval", func(t *testing.T) {
 		t.Parallel()
 		r, client, uncachedClient, dc := newControllerAndMocks(t)
-		r.missingOptionalResourceRetryInterval = missingOptionalResourceRetryInterval
-		r.missingResourceRetryInterval = missingResourceRetryInterval
+		r.optionalResourceRetryInterval = optionalResourceRetryInterval
+		r.resourceRetryInterval = resourceRetryInterval
 
 		sources := []corev1alpha1.ObjectTemplateSource{
 			{
@@ -615,15 +615,15 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 		}
 		res, err := r.Reconcile(context.Background(), objectTemplate)
 		require.False(t, res.IsZero())
-		assert.Equal(t, missingOptionalResourceRetryInterval, res.RequeueAfter)
+		assert.Equal(t, optionalResourceRetryInterval, res.RequeueAfter)
 		require.NoError(t, err)
 	})
 
-	t.Run("missing source returns configured missingResourceRetryInterval", func(t *testing.T) {
+	t.Run("missing source returns configured resourceRetryInterval", func(t *testing.T) {
 		t.Parallel()
 		r, client, uncachedClient, dc := newControllerAndMocks(t)
-		r.missingOptionalResourceRetryInterval = missingOptionalResourceRetryInterval
-		r.missingResourceRetryInterval = missingResourceRetryInterval
+		r.optionalResourceRetryInterval = optionalResourceRetryInterval
+		r.resourceRetryInterval = resourceRetryInterval
 
 		sources := []corev1alpha1.ObjectTemplateSource{
 			{
@@ -643,7 +643,7 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 			On("Watch", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
 
-		// Make both dynamic cache and uncache client return not found error.
+		// Make both dynamic cache and uncached client return not found error.
 		dc.
 			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
@@ -668,7 +668,7 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 		}
 		res, err := r.Reconcile(context.Background(), objectTemplate)
 		require.False(t, res.IsZero())
-		assert.Equal(t, missingResourceRetryInterval, res.RequeueAfter)
+		assert.Equal(t, resourceRetryInterval, res.RequeueAfter)
 		require.NoError(t, err)
 	})
 }

--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -24,6 +25,11 @@ import (
 	"package-operator.run/internal/preflight"
 	"package-operator.run/internal/testutil"
 	"package-operator.run/internal/testutil/dynamiccachemocks"
+)
+
+const (
+	missingResourceRetryInterval         = 30 * time.Second
+	missingOptionalResourceRetryInterval = 60 * time.Second
 )
 
 func Test_templateReconciler_getSourceObject(t *testing.T) {
@@ -556,4 +562,113 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequeueDurationOnMissingSource(t *testing.T) {
+	t.Parallel()
+	t.Run("missing optional source returns configured missingResourceRetryInterval", func(t *testing.T) {
+		t.Parallel()
+		r, client, uncachedClient, dc := newControllerAndMocks(t)
+		r.missingOptionalResourceRetryInterval = missingOptionalResourceRetryInterval
+		r.missingResourceRetryInterval = missingResourceRetryInterval
+
+		sources := []corev1alpha1.ObjectTemplateSource{
+			{
+				Kind:      "ConfigMap",
+				Name:      "test",
+				Namespace: "default",
+				Optional:  true,
+			},
+		}
+		client.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		client.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		client.On("Create", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		dc.
+			On("Watch", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+
+		// Make both dynamic cache and uncache client return not found error.
+		dc.
+			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+		uncachedClient.
+			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+
+		template, err := os.ReadFile("testdata/package_template_to_json.yaml")
+		require.NoError(t, err)
+		objectTemplate := &GenericObjectTemplate{
+			ObjectTemplate: corev1alpha1.ObjectTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{
+						controllers.CachedFinalizer,
+					},
+				},
+				Spec: corev1alpha1.ObjectTemplateSpec{
+					Template: string(template),
+					Sources:  sources,
+				},
+			},
+		}
+		res, err := r.Reconcile(context.Background(), objectTemplate)
+		require.False(t, res.IsZero())
+		assert.Equal(t, missingOptionalResourceRetryInterval, res.RequeueAfter)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing source returns configured missingResourceRetryInterval", func(t *testing.T) {
+		t.Parallel()
+		r, client, uncachedClient, dc := newControllerAndMocks(t)
+		r.missingOptionalResourceRetryInterval = missingOptionalResourceRetryInterval
+		r.missingResourceRetryInterval = missingResourceRetryInterval
+
+		sources := []corev1alpha1.ObjectTemplateSource{
+			{
+				Kind:      "ConfigMap",
+				Name:      "test",
+				Namespace: "default",
+				Optional:  false,
+			},
+		}
+		client.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		client.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		client.On("Create", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		dc.
+			On("Watch", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
+
+		// Make both dynamic cache and uncache client return not found error.
+		dc.
+			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+		uncachedClient.
+			On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(apimachineryerrors.NewNotFound(schema.GroupResource{}, ""))
+
+		template, err := os.ReadFile("testdata/package_template_to_json.yaml")
+		require.NoError(t, err)
+		objectTemplate := &GenericObjectTemplate{
+			ObjectTemplate: corev1alpha1.ObjectTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{
+						controllers.CachedFinalizer,
+					},
+				},
+				Spec: corev1alpha1.ObjectTemplateSpec{
+					Template: string(template),
+					Sources:  sources,
+				},
+			},
+		}
+		res, err := r.Reconcile(context.Background(), objectTemplate)
+		require.False(t, res.IsZero())
+		assert.Equal(t, missingResourceRetryInterval, res.RequeueAfter)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/PKO-49

Currently the object template controller retries with equal hardcoded duration on missing source errors. This can potentially add a considerable amount of API requests to the kube-apiserver as we try to GET the objects using the uncached client. 
This PR makes this retry duration configurable and separates the retry duration for sources which are "optional" and which are not.

### Change Type
Bug Fix 

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
