### PR TITLE
Introduce Kickstart command

### DIFF
--- a/cmd/kubectl-package/deps/command.go
+++ b/cmd/kubectl-package/deps/command.go
@@ -9,6 +9,7 @@ import (
 
 	"package-operator.run/cmd/kubectl-package/buildcmd"
 	clustertreecmd "package-operator.run/cmd/kubectl-package/clustertreecmd"
+	"package-operator.run/cmd/kubectl-package/kickstartcmd"
 	"package-operator.run/cmd/kubectl-package/rolloutcmd"
 	"package-operator.run/cmd/kubectl-package/rootcmd"
 	"package-operator.run/cmd/kubectl-package/treecmd"
@@ -137,6 +138,12 @@ func ProvideRolloutCmd(params rolloutcmd.Params) RootSubCommandResult {
 	}
 }
 
+func ProvideKickstartCmd(ks kickstartcmd.Kickstarter) RootSubCommandResult {
+	return RootSubCommandResult{
+		SubCommand: kickstartcmd.NewCmd(ks),
+	}
+}
+
 type RolloutSubCommandResult struct {
 	dig.Out
 
@@ -151,4 +158,8 @@ func ProvideRolloutHistoryCmd(clientFactory internalcmd.ClientFactory) RolloutSu
 
 func ProvideClientFactory(kcliFactory internalcmd.KubeClientFactory) internalcmd.ClientFactory {
 	return internalcmd.NewDefaultClientFactory(kcliFactory)
+}
+
+func ProvideKickstarter() kickstartcmd.Kickstarter {
+	return internalcmd.NewKickstarter(os.Stdin)
 }

--- a/cmd/kubectl-package/deps/deps.go
+++ b/cmd/kubectl-package/deps/deps.go
@@ -40,5 +40,7 @@ func constructors() []any {
 		ProvideRolloutCmd,
 		ProvideClientFactory,
 		ProvideRolloutHistoryCmd,
+		ProvideKickstartCmd,
+		ProvideKickstarter,
 	}
 }

--- a/cmd/kubectl-package/kickstartcmd/kickstart.go
+++ b/cmd/kubectl-package/kickstartcmd/kickstart.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type Kickstarter interface {
@@ -27,7 +28,7 @@ func NewCmd(kickstarter Kickstarter) *cobra.Command {
 		Short: cmdShort,
 		Long:  cmdLong,
 	}
-	opts.AddFlags(cmd)
+	opts.AddFlags(cmd.Flags())
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		msg, err := kickstarter.Kickstart(cmd.Context(), args[0], opts.Inputs)
@@ -46,11 +47,9 @@ type options struct {
 	Inputs []string
 }
 
-func (o *options) AddFlags(cmd *cobra.Command) {
-	flags := cmd.Flags()
-
+func (o *options) AddFlags(flags *pflag.FlagSet) {
 	const (
-		inputUse = "(Required) Files or urls to load objects from. " +
+		inputUse = "Files or urls to load objects from. " +
 			`Supports glob and "-" to read from stdin. Can be supplied multiple times.`
 	)
 
@@ -61,8 +60,4 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		nil,
 		inputUse,
 	)
-
-	if err := cmd.MarkFlagRequired("filename"); err != nil {
-		panic(`Programmer error: Unknown flag "filename".`)
-	}
 }

--- a/cmd/kubectl-package/kickstartcmd/kickstart.go
+++ b/cmd/kubectl-package/kickstartcmd/kickstart.go
@@ -1,0 +1,61 @@
+package kickstartcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type Kickstarter interface {
+	KickStart(ctx context.Context, pkgName string, inputs []string) (msg string, err error)
+}
+
+func NewCmd(kickstarter Kickstarter) *cobra.Command {
+	const (
+		cmdUse   = "kickstart pkg_name"
+		cmdShort = "Starts a new package with the given name."
+		cmdLong  = "Starts a new package with the given name containing objects referenced via -f."
+	)
+
+	var opts options
+
+	cmd := &cobra.Command{
+		Args:  cobra.ExactArgs(1),
+		Use:   cmdUse,
+		Short: cmdShort,
+		Long:  cmdLong,
+	}
+	opts.AddFlags(cmd.Flags())
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		msg, err := kickstarter.KickStart(cmd.Context(), args[0], opts.Inputs)
+		if err != nil {
+			return fmt.Errorf("kickstarting package: %w", err)
+		}
+		_, err = fmt.Fprint(cmd.OutOrStdout(), msg)
+		return err
+	}
+
+	return cmd
+}
+
+type options struct {
+	// Inputs (files/http/etc.)
+	Inputs []string
+}
+
+func (o *options) AddFlags(flags *pflag.FlagSet) {
+	const (
+		inputUse = "Files or urls to load objects from."
+	)
+
+	flags.StringSliceVarP(
+		&o.Inputs,
+		"filename",
+		"f",
+		nil,
+		inputUse,
+	)
+}

--- a/internal/cmd/kickstart.go
+++ b/internal/cmd/kickstart.go
@@ -1,0 +1,5 @@
+package cmd
+
+import "package-operator.run/internal/cmd/kickstart"
+
+var NewKickstarter = kickstart.NewKickstarter

--- a/internal/cmd/kickstart/kickstart.go
+++ b/internal/cmd/kickstart/kickstart.go
@@ -1,0 +1,417 @@
+package kickstart
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"pkg.package-operator.run/cardboard/kubeutils/kubemanifests"
+	"sigs.k8s.io/yaml"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+)
+
+type Kickstarter struct {
+	stdin io.Reader
+}
+
+func NewKickstarter(stdin io.Reader) *Kickstarter {
+	return &Kickstarter{stdin: stdin}
+}
+
+func (k *Kickstarter) KickStart(
+	ctx context.Context,
+	pkgName string,
+	inputs []string,
+) (msg string, err error) {
+	if err := os.Mkdir(pkgName, os.ModePerm); err != nil {
+		return "", fmt.Errorf("create directory: %w", err)
+	}
+
+	usedPhases := map[string]struct{}{}
+	usedGKs := map[schema.GroupKind]struct{}{}
+	var objCount int
+	for _, input := range inputs {
+		objects, err := k.getInput(input)
+		if err != nil {
+			return "", fmt.Errorf("get input: %w", err)
+		}
+
+		for _, obj := range objects {
+			phase, gk, err := k.processObject(pkgName, obj)
+			if err != nil {
+				return "", fmt.Errorf("processing object: %w", err)
+			}
+			usedPhases[phase] = struct{}{}
+			usedGKs[gk] = struct{}{}
+		}
+		objCount = objCount + len(objects)
+	}
+
+	// Write Manifest
+	var phases []manifestsv1alpha1.PackageManifestPhase
+	for _, phase := range orderedPhases {
+		if _, ok := usedPhases[string(phase)]; ok {
+			phases = append(phases, manifestsv1alpha1.PackageManifestPhase{Name: string(phase)})
+		}
+	}
+	var probes []corev1alpha1.ObjectSetProbe
+	for gk := range usedGKs {
+		probe, ok := getProbe(gk)
+		if !ok {
+			continue
+		}
+		probes = append(probes, probe)
+	}
+	manifest := &manifestsv1alpha1.PackageManifest{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManifest",
+			APIVersion: "manifests.package-operator.run/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pkgName,
+		},
+		Spec: manifestsv1alpha1.PackageManifestSpec{
+			Phases: phases,
+			Scopes: []manifestsv1alpha1.PackageManifestScope{
+				// TODO: new option?
+				manifestsv1alpha1.PackageManifestScopeCluster,
+				manifestsv1alpha1.PackageManifestScopeNamespaced,
+			},
+			AvailabilityProbes: probes,
+		},
+	}
+	b, err := yaml.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("marshalling PackageManifest YAML: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgName, "manifest.yaml"), b, os.ModePerm); err != nil {
+		return "", fmt.Errorf("writing PackageManifest: %w", err)
+	}
+
+	return fmt.Sprintf("Kickstarted the %q package with %d objects.", pkgName, objCount), nil
+}
+
+func (k *Kickstarter) processObject(
+	pkgName string, obj unstructured.Unstructured,
+) (phase string, gk schema.GroupKind, err error) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	gk = obj.GroupVersionKind().GroupKind()
+	phase = guessPresetPhase(gk)
+	annotations[manifestsv1alpha1.PackagePhaseAnnotation] = phase
+	obj.SetAnnotations(annotations)
+
+	path := filepath.Join(pkgName, phase,
+		fmt.Sprintf("%s.%s.yaml", obj.GetName(), strings.ToLower(obj.GetKind())))
+	b, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return phase, gk, fmt.Errorf("marshalling YAML: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return phase, gk, fmt.Errorf("creating directory: %w", err)
+	}
+	return phase, gk, os.WriteFile(path, b, os.ModePerm)
+}
+
+func (k *Kickstarter) getInput(input string) (
+	[]unstructured.Unstructured, error,
+) {
+	var reader io.Reader
+	switch {
+	case input == "-":
+		// from stdin
+		reader = k.stdin
+
+	case strings.Index(input, "http://") == 0 ||
+		strings.Index(input, "https://") == 0:
+		// from HTTP(S)
+		resp, err := http.Get(input)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP get: %w", err)
+		}
+		defer resp.Body.Close()
+		reader = resp.Body
+
+	default:
+		// Files or Folders
+		matches, err := expandIfFilePattern(input)
+		if err != nil {
+			return nil, fmt.Errorf("expand pattern: %w", err)
+		}
+
+		var objects []unstructured.Unstructured
+		for _, match := range matches {
+			i, err := os.Stat(match)
+			if err != nil {
+				return nil, fmt.Errorf("accessing: %w", err)
+			}
+			var (
+				matchObjs []unstructured.Unstructured
+			)
+			if i.IsDir() {
+				matchObjs, err = kubemanifests.LoadKubernetesObjectsFromFolder(match)
+			} else {
+				matchObjs, err = kubemanifests.LoadKubernetesObjectsFromFile(match)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("loading kubernetes objects: %w", err)
+			}
+			objects = append(objects, matchObjs...)
+		}
+		return objects, nil
+	}
+
+	if reader == nil {
+		return nil, nil
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading: %w", err)
+	}
+	return kubemanifests.LoadKubernetesObjectsFromBytes(content)
+}
+
+// expandIfFilePattern returns all the filenames that match the input pattern
+// or the filename if it is a specific filename and not a pattern.
+// If the input is a pattern and it yields no result it will result in an error.
+func expandIfFilePattern(pattern string) ([]string, error) {
+	if _, err := os.Stat(pattern); os.IsNotExist(err) {
+		matches, err := filepath.Glob(pattern)
+		if err == nil && len(matches) == 0 {
+			return nil, fmt.Errorf(os.ErrNotExist.Error(), pattern)
+		}
+		if err == filepath.ErrBadPattern {
+			return nil, fmt.Errorf("pattern %q is not valid: %v", pattern, err)
+		}
+		return matches, err
+	}
+	return []string{pattern}, nil
+}
+
+// Determines a phase using the objects Group Kind from a list or presets.
+func guessPresetPhase(gk schema.GroupKind) string {
+	phase, ok := gkPhaseMap[gk]
+	if !ok {
+		return string(presetPhaseOther)
+	}
+	return string(phase)
+}
+
+type presetPhase string
+
+const (
+	presetPhaseNamespaces presetPhase = "namespaces"
+	presetPhasePolicies   presetPhase = "policies"
+	presetPhaseRBAC       presetPhase = "rbac"
+	presetPhaseCRDs       presetPhase = "crds"
+	presetPhaseStorage    presetPhase = "storage"
+	presetPhaseDeploy     presetPhase = "deploy"
+	presetPhasePublish    presetPhase = "publish"
+	// anything else that is not explicitly sorted into a phase.
+	presetPhaseOther presetPhase = "other"
+)
+
+var orderedPhases = []presetPhase{
+	presetPhaseNamespaces,
+	presetPhasePolicies,
+	presetPhaseRBAC,
+	presetPhaseCRDs,
+	presetPhaseStorage,
+	presetPhaseDeploy,
+	presetPhasePublish,
+	presetPhaseOther,
+}
+
+var gkPhaseMap = map[schema.GroupKind]presetPhase{}
+var phaseGKMap = map[presetPhase][]schema.GroupKind{
+	presetPhaseNamespaces: {
+		{Kind: "Namespace"},
+	},
+
+	presetPhasePolicies: {
+		{Kind: "ResourceQuota"},
+		{Kind: "LimitRange"},
+		{Kind: "PriorityClass", Group: "scheduling.k8s.io"},
+		{Kind: "NetworkPolicy", Group: "networking.k8s.io"},
+		{Kind: "HorizontalPodAutoscaler", Group: "autoscaling"},
+		{Kind: "PodDisruptionBudget", Group: "policy"},
+	},
+
+	presetPhaseRBAC: {
+		{Kind: "ServiceAccount", Group: ""},
+		{Kind: "Role", Group: "rbac.authorization.k8s.io"},
+		{Kind: "RoleRolebinding", Group: "rbac.authorization.k8s.io"},
+		{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"},
+		{Kind: "ClusterRoleRolebinding", Group: "rbac.authorization.k8s.io"},
+	},
+
+	presetPhaseCRDs: {
+		{Kind: "CustomResourceDefinition", Group: "apiextensions.k8s.io"},
+	},
+
+	presetPhaseStorage: {
+		{Kind: "PersistentVolume"},
+		{Kind: "PersistentVolumeClaim"},
+		{Kind: "StorageClass", Group: "storage.k8s.io"},
+	},
+
+	presetPhaseDeploy: {
+		{Kind: "Deployment", Group: "apps"},
+		{Kind: "DaemonSet", Group: "apps"},
+		{Kind: "StatefulSet", Group: "apps"},
+		{Kind: "ReplicaSet"},
+		{Kind: "Pod"}, // probing complicated, may be either Completed or Available.
+		{Kind: "Job", Group: "batch"},
+		{Kind: "CronJob", Group: "batch"},
+		{Kind: "Service"},
+		{Kind: "Secret"},
+		{Kind: "ConfigMap"},
+	},
+
+	presetPhasePublish: {
+		{Kind: "Ingress", Group: "networking.k8s.io"},
+		{Kind: "APIService", Group: "apiregistration.k8s.io"},
+		{Kind: "Route", Group: "route.openshift.io"},
+		{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+		{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+	},
+}
+
+// Determines probes required for the given Group Kind.
+func getProbe(gk schema.GroupKind) (corev1alpha1.ObjectSetProbe, bool) {
+	probes, ok := gkProbes[gk]
+	if !ok {
+		return corev1alpha1.ObjectSetProbe{}, false
+	}
+	return corev1alpha1.ObjectSetProbe{
+		Selector: corev1alpha1.ProbeSelector{
+			Kind: &corev1alpha1.PackageProbeKindSpec{
+				Group: gk.Group,
+				Kind:  gk.Kind,
+			},
+		},
+		Probes: probes,
+	}, true
+}
+
+var gkProbes = map[schema.GroupKind][]corev1alpha1.Probe{
+	{
+		Kind: "Deployment", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind: "StatefulSet", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind: "DaemonSet", Group: "apps",
+	}: {
+		{
+			FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+				FieldA: ".status.desiredNumberScheduled",
+				FieldB: ".status.numberAvailable",
+			},
+		},
+	},
+	{
+		Kind: "ReplicaSet", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind:  "CustomResourceDefinition",
+		Group: "apiextensions.k8s.io",
+	}: {
+		{
+			Condition: &corev1alpha1.ProbeConditionSpec{
+				Type:   "Established",
+				Status: string(metav1.ConditionTrue),
+			},
+		},
+	},
+	{
+		Kind:  "Job",
+		Group: "batch",
+	}: {
+		{
+			Condition: &corev1alpha1.ProbeConditionSpec{
+				Type:   "Complete",
+				Status: string(metav1.ConditionTrue),
+			},
+		},
+	},
+	{
+		Kind:  "Route",
+		Group: "route.openshift.io",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "not all ingress points are reporting ready",
+				Rule:    `self.status.ingress.all(i, i.conditions.all(c, c.type == "Ready" && c.status == "True"))`,
+			},
+		},
+	},
+	{
+		Kind:  "PersistentVolumeClaim",
+		Group: "",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "is not yet Bound",
+				Rule:    `self.status.phase == "Bound"`,
+			},
+		},
+	},
+	{
+		Kind:  "ClusterServiceVersion",
+		Group: "operators.coreos.com",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "CSV not succeeded",
+				Rule:    `self.status.phase == "Succeeded"`,
+			},
+		},
+	},
+}
+
+// Checks if the Available Condition is True.
+var availableProbe = corev1alpha1.Probe{
+	Condition: &corev1alpha1.ProbeConditionSpec{
+		Type:   "Available",
+		Status: string(metav1.ConditionTrue),
+	},
+}
+
+// Checks if all replicas have been updated.
+// Works for StatefulSets, Deployments and ReplicaSets.
+var replicasUpdatedProbe = corev1alpha1.Probe{
+	FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+		FieldA: ".status.updatedReplicas",
+		FieldB: ".status.replicas",
+	},
+}
+
+func init() {
+	for phase, gks := range phaseGKMap {
+		for _, gk := range gks {
+			gkPhaseMap[gk] = phase
+		}
+	}
+}

--- a/internal/cmd/kickstart/kickstart_test.go
+++ b/internal/cmd/kickstart/kickstart_test.go
@@ -24,7 +24,7 @@ func TestKickstart(t *testing.T) {
 
 	ctx := context.Background()
 	k := NewKickstarter(nil)
-	msg, err := k.KickStart(ctx, "my-pkg", []string{"testdata/all-the-objects.yaml"})
+	msg, err := k.Kickstart(ctx, "my-pkg", []string{"testdata/all-the-objects.yaml"})
 	require.NoError(t, err)
 	assert.Equal(t, kickstartMessage, msg)
 }

--- a/internal/cmd/kickstart/kickstart_test.go
+++ b/internal/cmd/kickstart/kickstart_test.go
@@ -9,12 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var kickstartMessage = `Kickstarted the "my-pkg" package with 3 objects.
+[WARN] Some kinds don't have availability probes defined:
+- Banana.fruits
+`
+
 func TestKickstart(t *testing.T) {
-	defer os.RemoveAll("my-pkg")
+	t.Parallel()
+	defer func() {
+		if err := os.RemoveAll("my-pkg"); err != nil {
+			panic(err)
+		}
+	}()
 
 	ctx := context.Background()
 	k := NewKickstarter(nil)
 	msg, err := k.KickStart(ctx, "my-pkg", []string{"testdata/all-the-objects.yaml"})
 	require.NoError(t, err)
-	assert.Equal(t, `Kickstarted the "my-pkg" package with 2 objects.`, msg)
+	assert.Equal(t, kickstartMessage, msg)
 }

--- a/internal/cmd/kickstart/kickstart_test.go
+++ b/internal/cmd/kickstart/kickstart_test.go
@@ -1,0 +1,20 @@
+package kickstart
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKickstart(t *testing.T) {
+	defer os.RemoveAll("my-pkg")
+
+	ctx := context.Background()
+	k := NewKickstarter(nil)
+	msg, err := k.KickStart(ctx, "my-pkg", []string{"testdata/all-the-objects.yaml"})
+	require.NoError(t, err)
+	assert.Equal(t, `Kickstarted the "my-pkg" package with 2 objects.`, msg)
+}

--- a/internal/cmd/kickstart/phases.go
+++ b/internal/cmd/kickstart/phases.go
@@ -1,0 +1,148 @@
+package kickstart
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type presetPhase string
+
+const (
+	presetPhaseNamespaces presetPhase = "namespaces"
+	presetPhasePolicies   presetPhase = "policies"
+	presetPhaseRBAC       presetPhase = "rbac"
+	presetPhaseCRDs       presetPhase = "crds"
+	presetPhaseStorage    presetPhase = "storage"
+	presetPhaseDeploy     presetPhase = "deploy"
+	presetPhasePublish    presetPhase = "publish"
+	// anything else that is not explicitly sorted into a phase.
+	presetPhaseOther presetPhase = "other"
+)
+
+var orderedPhases = []presetPhase{
+	presetPhaseNamespaces,
+	presetPhasePolicies,
+	presetPhaseRBAC,
+	presetPhaseCRDs,
+	presetPhaseStorage,
+	presetPhaseDeploy,
+	presetPhasePublish,
+	presetPhaseOther,
+}
+
+var (
+	gkPhaseMap = map[schema.GroupKind]presetPhase{}
+	phaseGKMap = map[presetPhase][]schema.GroupKind{
+		presetPhaseNamespaces: {
+			{Kind: "Namespace"},
+		},
+
+		presetPhasePolicies: {
+			{Kind: "ResourceQuota"},
+			{Kind: "LimitRange"},
+			{Kind: "PriorityClass", Group: "scheduling.k8s.io"},
+			{Kind: "NetworkPolicy", Group: "networking.k8s.io"},
+			{Kind: "HorizontalPodAutoscaler", Group: "autoscaling"},
+			{Kind: "PodDisruptionBudget", Group: "policy"},
+		},
+
+		presetPhaseRBAC: {
+			{Kind: "ServiceAccount"},
+			{Kind: "Role", Group: "rbac.authorization.k8s.io"},
+			{Kind: "RoleRolebinding", Group: "rbac.authorization.k8s.io"},
+			{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"},
+			{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"},
+		},
+
+		presetPhaseCRDs: {
+			{Kind: "CustomResourceDefinition", Group: "apiextensions.k8s.io"},
+		},
+
+		presetPhaseStorage: {
+			{Kind: "PersistentVolume"},
+			{Kind: "PersistentVolumeClaim"},
+			{Kind: "StorageClass", Group: "storage.k8s.io"},
+		},
+
+		presetPhaseDeploy: {
+			{Kind: "Deployment", Group: "apps"},
+			{Kind: "DaemonSet", Group: "apps"},
+			{Kind: "StatefulSet", Group: "apps"},
+			{Kind: "ReplicaSet"},
+			{Kind: "Pod"}, // probing complicated, may be either Completed or Available.
+			{Kind: "Job", Group: "batch"},
+			{Kind: "CronJob", Group: "batch"},
+			{Kind: "Service"},
+			{Kind: "Secret"},
+			{Kind: "ConfigMap"},
+		},
+
+		presetPhasePublish: {
+			{Kind: "Ingress", Group: "networking.k8s.io"},
+			{Kind: "APIService", Group: "apiregistration.k8s.io"},
+			{Kind: "Route", Group: "route.openshift.io"},
+			{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+			{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"},
+		},
+	}
+)
+
+// Known Objects that do not need probes defined.
+var noProbeGK = map[schema.GroupKind]struct{}{
+	{Kind: "Namespace"}:             {},
+	{Kind: "ServiceAccount"}:        {},
+	{Kind: "Endpoints"}:             {},
+	{Kind: "EndpointSlice"}:         {},
+	{Kind: "IngressClass"}:          {},
+	{Kind: "Service"}:               {},
+	{Kind: "Secret"}:                {},
+	{Kind: "ConfigMap"}:             {},
+	{Kind: "PersistentVolume"}:      {},
+	{Kind: "PersistentVolumeClaim"}: {},
+	{Kind: "ResourceQuota"}:         {},
+	{Kind: "LimitRange"}:            {},
+
+	{Kind: "Role", Group: "rbac.authorization.k8s.io"}:               {},
+	{Kind: "RoleRolebinding", Group: "rbac.authorization.k8s.io"}:    {},
+	{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"}:        {},
+	{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"}: {},
+
+	{Kind: "PriorityClass", Group: "scheduling.k8s.io"}:     {},
+	{Kind: "Ingress", Group: "networking.k8s.io"}:           {},
+	{Kind: "NetworkPolicy", Group: "networking.k8s.io"}:     {},
+	{Kind: "HorizontalPodAutoscaler", Group: "autoscaling"}: {},
+	{Kind: "PodDisruptionBudget", Group: "policy"}:          {},
+	{Kind: "CronJob", Group: "batch"}:                       {},
+	{Kind: "APIService", Group: "apiregistration.k8s.io"}:   {},
+
+	{Kind: "StorageClass", Group: "storage.k8s.io"}:       {},
+	{Kind: "CSIDriver", Group: "storage.k8s.io"}:          {},
+	{Kind: "CSINode", Group: "storage.k8s.io"}:            {},
+	{Kind: "CSIStorageCapacity", Group: "storage.k8s.io"}: {},
+
+	{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}:   {},
+	{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}: {},
+	{Kind: "ValidatingAdmissionPolicy", Group: "admissionregistration.k8s.io"}:      {},
+}
+
+// Determines a phase using the objects Group Kind from a list or presets.
+func guessPresetPhase(gk schema.GroupKind) string {
+	phase, ok := gkPhaseMap[gk]
+	if !ok {
+		return string(presetPhaseOther)
+	}
+	return string(phase)
+}
+
+func reportGKsWithoutProbes(gksWithoutProbes map[schema.GroupKind]struct{}) (report string, ok bool) {
+	report = "[WARN] Some kinds don't have availability probes defined:\n"
+	for gk := range gksWithoutProbes {
+		if _, ok := noProbeGK[gk]; ok {
+			continue
+		}
+		report += fmt.Sprintf("- %s\n", gk.String())
+		ok = true
+	}
+	return report, ok
+}

--- a/internal/cmd/kickstart/probing.go
+++ b/internal/cmd/kickstart/probing.go
@@ -1,0 +1,128 @@
+package kickstart
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+// Determines probes required for the given Group Kind.
+func getProbe(gk schema.GroupKind) (corev1alpha1.ObjectSetProbe, bool) {
+	probes, ok := gkProbes[gk]
+	if !ok {
+		return corev1alpha1.ObjectSetProbe{}, false
+	}
+	return corev1alpha1.ObjectSetProbe{
+		Selector: corev1alpha1.ProbeSelector{
+			Kind: &corev1alpha1.PackageProbeKindSpec{
+				Group: gk.Group,
+				Kind:  gk.Kind,
+			},
+		},
+		Probes: probes,
+	}, true
+}
+
+var gkProbes = map[schema.GroupKind][]corev1alpha1.Probe{
+	{
+		Kind: "Deployment", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind: "StatefulSet", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind: "DaemonSet", Group: "apps",
+	}: {
+		{
+			FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+				FieldA: ".status.desiredNumberScheduled",
+				FieldB: ".status.numberAvailable",
+			},
+		},
+	},
+	{
+		Kind: "ReplicaSet", Group: "apps",
+	}: {
+		availableProbe,
+		replicasUpdatedProbe,
+	},
+	{
+		Kind:  "CustomResourceDefinition",
+		Group: "apiextensions.k8s.io",
+	}: {
+		{
+			Condition: &corev1alpha1.ProbeConditionSpec{
+				Type:   "Established",
+				Status: string(metav1.ConditionTrue),
+			},
+		},
+	},
+	{
+		Kind:  "Job",
+		Group: "batch",
+	}: {
+		{
+			Condition: &corev1alpha1.ProbeConditionSpec{
+				Type:   "Complete",
+				Status: string(metav1.ConditionTrue),
+			},
+		},
+	},
+	{
+		Kind:  "Route",
+		Group: "route.openshift.io",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "not all ingress points are reporting ready",
+				Rule:    `self.status.ingress.all(i, i.conditions.all(c, c.type == "Ready" && c.status == "True"))`,
+			},
+		},
+	},
+	{
+		Kind:  "PersistentVolumeClaim",
+		Group: "",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "is not yet Bound",
+				Rule:    `self.status.phase == "Bound"`,
+			},
+		},
+	},
+	{
+		Kind:  "ClusterServiceVersion",
+		Group: "operators.coreos.com",
+	}: {
+		{
+			CEL: &corev1alpha1.ProbeCELSpec{
+				Message: "CSV not succeeded",
+				Rule:    `self.status.phase == "Succeeded"`,
+			},
+		},
+	},
+}
+
+// Checks if the Available Condition is True.
+var availableProbe = corev1alpha1.Probe{
+	Condition: &corev1alpha1.ProbeConditionSpec{
+		Type:   "Available",
+		Status: string(metav1.ConditionTrue),
+	},
+}
+
+// Checks if all replicas have been updated.
+// Works for StatefulSets, Deployments and ReplicaSets.
+var replicasUpdatedProbe = corev1alpha1.Probe{
+	FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+		FieldA: ".status.updatedReplicas",
+		FieldB: ".status.replicas",
+	},
+}

--- a/internal/cmd/kickstart/testdata/all-the-objects.yaml
+++ b/internal/cmd/kickstart/testdata/all-the-objects.yaml
@@ -29,3 +29,10 @@ metadata:
     pod-security.kubernetes.io/audit-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: fruits/v1
+kind: Banana
+metadata:
+  name: cavendish
+spec:
+  sweet: True

--- a/internal/cmd/kickstart/testdata/all-the-objects.yaml
+++ b/internal/cmd/kickstart/testdata/all-the-objects.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: my-app
+  labels:
+    app: my-app
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+    spec:
+      containers:
+        - name: my-container
+          image: quay.io/example
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-app
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/internal/packages/export_kickstart.go
+++ b/internal/packages/export_kickstart.go
@@ -1,0 +1,10 @@
+package packages
+
+import "package-operator.run/internal/packages/internal/packagekickstart"
+
+type KickstartResult = packagekickstart.KickstartResult
+
+var (
+	Kickstart          = packagekickstart.Kickstart
+	KickstartFromBytes = packagekickstart.KickstartFromBytes
+)

--- a/internal/packages/internal/packagekickstart/errors.go
+++ b/internal/packages/internal/packagekickstart/errors.go
@@ -1,0 +1,56 @@
+package packagekickstart
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+type ObjectIsMissingMetadataError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsMissingMetadataError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object is missing metadata: '%s'", b)
+}
+
+type ObjectIsMissingNameError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsMissingNameError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object is missing name: '%s'", b)
+}
+
+type ObjectIsDuplicateError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectIsDuplicateError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("duplicate object: '%s'", b)
+}
+
+type ObjectHasInvalidAPIVersionError struct {
+	obj unstructured.Unstructured
+}
+
+func (e *ObjectHasInvalidAPIVersionError) Error() string {
+	b, err := yaml.Marshal(e.obj.Object)
+	if err != nil {
+		b = []byte("Failed to marshal object.")
+	}
+	return fmt.Sprintf("object has invalid apiVersion: '%s'", b)
+}

--- a/internal/packages/internal/packagekickstart/kickstart.go
+++ b/internal/packages/internal/packagekickstart/kickstart.go
@@ -1,0 +1,124 @@
+package packagekickstart
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"pkg.package-operator.run/cardboard/kubeutils/kubemanifests"
+	"sigs.k8s.io/yaml"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
+	"package-operator.run/internal/packages/internal/packagetypes"
+)
+
+type KickstartResult struct {
+	ObjectCount             int
+	GroupKindsWithoutProbes []schema.GroupKind
+}
+
+func Kickstart(_ context.Context, pkgName string, objects []unstructured.Unstructured) (
+	*packagetypes.RawPackage, KickstartResult, error,
+) {
+	res := KickstartResult{}
+	rawPkg := &packagetypes.RawPackage{
+		Files: packagetypes.Files{},
+	}
+
+	// Process objects
+	usedPhases := map[string]struct{}{}
+	usedGKs := map[schema.GroupKind]struct{}{}
+	var objCount int
+	for _, obj := range objects {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		gk := obj.GroupVersionKind().GroupKind()
+		phase := guessPresetPhase(gk)
+		annotations[manifestsv1alpha1.PackagePhaseAnnotation] = phase
+		obj.SetAnnotations(annotations)
+
+		path := filepath.Join(phase,
+			fmt.Sprintf("%s.%s.yaml", strings.ReplaceAll(
+				obj.GetName(), string(filepath.Separator), "-"),
+				strings.ToLower(obj.GetKind())))
+		b, err := yaml.Marshal(obj.Object)
+		if err != nil {
+			return nil, res, fmt.Errorf("marshalling YAML: %w", err)
+		}
+		rawPkg.Files[path] = b
+
+		usedPhases[phase] = struct{}{}
+		usedGKs[gk] = struct{}{}
+		objCount++
+	}
+
+	// Generate Manifest
+	var phases []manifestsv1alpha1.PackageManifestPhase
+	for _, phase := range orderedPhases {
+		if _, ok := usedPhases[string(phase)]; ok {
+			phases = append(phases, manifestsv1alpha1.PackageManifestPhase{Name: string(phase)})
+		}
+	}
+
+	probes := []corev1alpha1.ObjectSetProbe{}
+	gksWithoutProbes := map[schema.GroupKind]struct{}{}
+	for gk := range usedGKs {
+		if _, needsNoProbe := noProbeGK[gk]; needsNoProbe {
+			continue
+		}
+		probe, ok := getProbe(gk)
+		if !ok {
+			gksWithoutProbes[gk] = struct{}{}
+			continue
+		}
+		probes = append(probes, probe)
+	}
+	manifest := &manifestsv1alpha1.PackageManifest{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManifest",
+			APIVersion: "manifests.package-operator.run/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pkgName,
+		},
+		Spec: manifestsv1alpha1.PackageManifestSpec{
+			Phases: phases,
+			Scopes: []manifestsv1alpha1.PackageManifestScope{
+				manifestsv1alpha1.PackageManifestScopeCluster,
+				manifestsv1alpha1.PackageManifestScopeNamespaced,
+			},
+			AvailabilityProbes: probes,
+		},
+	}
+	b, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, res, fmt.Errorf("marshalling PackageManifest YAML: %w", err)
+	}
+	rawPkg.Files[packagetypes.PackageManifestFilename+".yaml"] = b
+
+	// Result stats
+	for gk := range gksWithoutProbes {
+		res.GroupKindsWithoutProbes = append(res.GroupKindsWithoutProbes, gk)
+	}
+	res.ObjectCount = objCount
+
+	return rawPkg, res, nil
+}
+
+func KickstartFromBytes(ctx context.Context, pkgName string, c []byte) (
+	*packagetypes.RawPackage, KickstartResult, error,
+) {
+	objects, err := kubemanifests.LoadKubernetesObjectsFromBytes(c)
+	if err != nil {
+		return nil, KickstartResult{},
+			fmt.Errorf("loading Kubernetes manifests: %w", err)
+	}
+	return Kickstart(ctx, pkgName, objects)
+}

--- a/internal/packages/internal/packagekickstart/kickstart_test.go
+++ b/internal/packages/internal/packagekickstart/kickstart_test.go
@@ -1,0 +1,64 @@
+package packagekickstart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var manifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: my-app
+  labels:
+    app: my-app
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+    spec:
+      containers:
+        - name: my-container
+          image: quay.io/example
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-app
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: fruits/v1
+kind: Banana
+metadata:
+  name: cavendish
+spec:
+  sweet: True
+`
+
+func TestKickstartFromBytes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rawPkg, res, err := KickstartFromBytes(ctx, "my-pkg", []byte(manifest))
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.ObjectCount)
+	if assert.Len(t, res.GroupKindsWithoutProbes, 1) {
+		assert.Equal(t, schema.GroupKind{
+			Group: "fruits",
+			Kind:  "Banana",
+		}, res.GroupKindsWithoutProbes[0])
+	}
+	assert.Len(t, rawPkg.Files, 4)
+}

--- a/internal/packages/internal/packagekickstart/meta.go
+++ b/internal/packages/internal/packagekickstart/meta.go
@@ -24,7 +24,7 @@ func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
 	if !ok {
 		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
 	}
-	// Validate that .metdata is a map.
+	// Validate that .metadata is a map.
 	metamap, ok := metadata.(map[string]interface{})
 	if !ok {
 		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
@@ -36,14 +36,7 @@ func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
 		return namespacedName{}, &ObjectIsMissingNameError{obj}
 	}
 
-	namespace := obj.GetNamespace()
-	// Default empty namespace - this also happens for cluster-scoped GKs
-	// since there is no reliable way to look up the scope of a GK.
-	if namespace == "" {
-		namespace = "default"
-	}
-
-	escapedNamespace := escapeFilepathSeparator(namespace)
+	escapedNamespace := escapeFilepathSeparator(obj.GetNamespace())
 	escapedName := escapeFilepathSeparator(name)
 	return namespacedName{
 		namespace: escapedNamespace,

--- a/internal/packages/internal/packagekickstart/meta.go
+++ b/internal/packages/internal/packagekickstart/meta.go
@@ -1,0 +1,87 @@
+package packagekickstart
+
+import (
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type namespacedName struct {
+	namespace, name string
+}
+
+// Parses namespace and name from the given unstructured object.
+// The function:
+// - validatesthe existence of `.metadata` and that it is a map.
+// - defaults an empty `.metadata.namespace` to the string "default".
+// - validates that `.metadata.name` is not empty.
+// - escapes potential filepath separators in the results by passing them through `escapeFilepathSeparator()`
+// - returns namespace and name.
+func parseObjectMeta(obj unstructured.Unstructured) (namespacedName, error) {
+	metadata, ok := obj.Object["metadata"]
+	// Validate that .metadata exists.
+	if !ok {
+		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
+	}
+	// Validate that .metdata is a map.
+	metamap, ok := metadata.(map[string]interface{})
+	if !ok {
+		return namespacedName{}, &ObjectIsMissingMetadataError{obj}
+	}
+
+	// Validate that .metadata.name exists, is a string and is not empty.
+	name, ok := metamap["name"].(string)
+	if !ok || name == "" {
+		return namespacedName{}, &ObjectIsMissingNameError{obj}
+	}
+
+	namespace := obj.GetNamespace()
+	// Default empty namespace - this also happens for cluster-scoped GKs
+	// since there is no reliable way to look up the scope of a GK.
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	escapedNamespace := escapeFilepathSeparator(namespace)
+	escapedName := escapeFilepathSeparator(name)
+	return namespacedName{
+		namespace: escapedNamespace,
+		name:      escapedName,
+	}, nil
+}
+
+// Replace filepath separators (`/` or `\`) with dashes (`-`), to prevent
+// the kickstart from creating files outside of the package directory for
+// malformed object namespaces or names in the input.
+func escapeFilepathSeparator(input string) string {
+	return strings.ReplaceAll(input, string(filepath.Separator), "-")
+}
+
+type groupKind struct {
+	group, kind string
+}
+
+// Parses group and kind from the given unstructured object.
+// This function:
+//   - validates that the apiVersion in the object contains a version.
+//   - does NOT validate that the object contains a kind because this already fails the unmarshalling phase.
+//     (There is be a regression test for that case!)
+//   - defaults an empty apiGroup to the string "core".
+func parseTypeMeta(obj unstructured.Unstructured) (groupKind, error) {
+	gvk := obj.GroupVersionKind()
+	if gvk.Version == "" {
+		return groupKind{}, &ObjectHasInvalidAPIVersionError{obj}
+	}
+
+	group := obj.GroupVersionKind().Group
+	// Expand core api group.
+	if group == "" {
+		group = "core"
+	}
+
+	return groupKind{
+		group: group,
+		kind:  obj.GetKind(),
+	}, nil
+}

--- a/internal/packages/internal/packagekickstart/phases.go
+++ b/internal/packages/internal/packagekickstart/phases.go
@@ -1,8 +1,6 @@
-package kickstart
+package packagekickstart
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -32,6 +30,7 @@ var orderedPhases = []presetPhase{
 }
 
 var (
+	// This will be populated from `phaseGKMap` in an init func!
 	gkPhaseMap = map[schema.GroupKind]presetPhase{}
 	phaseGKMap = map[presetPhase][]schema.GroupKind{
 		presetPhaseNamespaces: {
@@ -88,61 +87,12 @@ var (
 	}
 )
 
-// Known Objects that do not need probes defined.
-var noProbeGK = map[schema.GroupKind]struct{}{
-	{Kind: "Namespace"}:             {},
-	{Kind: "ServiceAccount"}:        {},
-	{Kind: "Endpoints"}:             {},
-	{Kind: "EndpointSlice"}:         {},
-	{Kind: "IngressClass"}:          {},
-	{Kind: "Service"}:               {},
-	{Kind: "Secret"}:                {},
-	{Kind: "ConfigMap"}:             {},
-	{Kind: "PersistentVolume"}:      {},
-	{Kind: "PersistentVolumeClaim"}: {},
-	{Kind: "ResourceQuota"}:         {},
-	{Kind: "LimitRange"}:            {},
-
-	{Kind: "Role", Group: "rbac.authorization.k8s.io"}:               {},
-	{Kind: "RoleRolebinding", Group: "rbac.authorization.k8s.io"}:    {},
-	{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"}:        {},
-	{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"}: {},
-
-	{Kind: "PriorityClass", Group: "scheduling.k8s.io"}:     {},
-	{Kind: "Ingress", Group: "networking.k8s.io"}:           {},
-	{Kind: "NetworkPolicy", Group: "networking.k8s.io"}:     {},
-	{Kind: "HorizontalPodAutoscaler", Group: "autoscaling"}: {},
-	{Kind: "PodDisruptionBudget", Group: "policy"}:          {},
-	{Kind: "CronJob", Group: "batch"}:                       {},
-	{Kind: "APIService", Group: "apiregistration.k8s.io"}:   {},
-
-	{Kind: "StorageClass", Group: "storage.k8s.io"}:       {},
-	{Kind: "CSIDriver", Group: "storage.k8s.io"}:          {},
-	{Kind: "CSINode", Group: "storage.k8s.io"}:            {},
-	{Kind: "CSIStorageCapacity", Group: "storage.k8s.io"}: {},
-
-	{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}:   {},
-	{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}: {},
-	{Kind: "ValidatingAdmissionPolicy", Group: "admissionregistration.k8s.io"}:      {},
-}
-
-// Determines a phase using the objects Group Kind from a list or presets.
+// Determines a phase using the objects Group Kind from a list of presets.
+// Defaults to the value of `presetPhaseOther` if no preset was found.
 func guessPresetPhase(gk schema.GroupKind) string {
 	phase, ok := gkPhaseMap[gk]
 	if !ok {
 		return string(presetPhaseOther)
 	}
 	return string(phase)
-}
-
-func reportGKsWithoutProbes(gksWithoutProbes map[schema.GroupKind]struct{}) (report string, ok bool) {
-	report = "[WARN] Some kinds don't have availability probes defined:\n"
-	for gk := range gksWithoutProbes {
-		if _, ok := noProbeGK[gk]; ok {
-			continue
-		}
-		report += fmt.Sprintf("- %s\n", gk.String())
-		ok = true
-	}
-	return report, ok
 }

--- a/internal/packages/internal/packagekickstart/probing.go
+++ b/internal/packages/internal/packagekickstart/probing.go
@@ -1,4 +1,4 @@
-package kickstart
+package packagekickstart
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,6 +8,7 @@ import (
 )
 
 // Determines probes required for the given Group Kind.
+// Returns a probe if one was found and an ok-style bool to let the caller know if a probe was found.
 func getProbe(gk schema.GroupKind) (corev1alpha1.ObjectSetProbe, bool) {
 	probes, ok := gkProbes[gk]
 	if !ok {
@@ -125,4 +126,50 @@ var replicasUpdatedProbe = corev1alpha1.Probe{
 		FieldA: ".status.updatedReplicas",
 		FieldB: ".status.replicas",
 	},
+}
+
+// Known Objects that do not need probes defined.
+var noProbeGK = map[schema.GroupKind]struct{}{
+	{Kind: "Namespace"}:             {},
+	{Kind: "ServiceAccount"}:        {},
+	{Kind: "Endpoints"}:             {},
+	{Kind: "EndpointSlice"}:         {},
+	{Kind: "IngressClass"}:          {},
+	{Kind: "Service"}:               {},
+	{Kind: "Secret"}:                {},
+	{Kind: "ConfigMap"}:             {},
+	{Kind: "PersistentVolume"}:      {},
+	{Kind: "PersistentVolumeClaim"}: {},
+	{Kind: "ResourceQuota"}:         {},
+	{Kind: "LimitRange"}:            {},
+
+	{Kind: "Role", Group: "rbac.authorization.k8s.io"}:               {},
+	{Kind: "RoleRolebinding", Group: "rbac.authorization.k8s.io"}:    {},
+	{Kind: "ClusterRole", Group: "rbac.authorization.k8s.io"}:        {},
+	{Kind: "ClusterRoleBinding", Group: "rbac.authorization.k8s.io"}: {},
+
+	{Kind: "PriorityClass", Group: "scheduling.k8s.io"}:     {},
+	{Kind: "Ingress", Group: "networking.k8s.io"}:           {},
+	{Kind: "NetworkPolicy", Group: "networking.k8s.io"}:     {},
+	{Kind: "HorizontalPodAutoscaler", Group: "autoscaling"}: {},
+	{Kind: "PodDisruptionBudget", Group: "policy"}:          {},
+	{Kind: "CronJob", Group: "batch"}:                       {},
+	{Kind: "APIService", Group: "apiregistration.k8s.io"}:   {},
+
+	{Kind: "StorageClass", Group: "storage.k8s.io"}:       {},
+	{Kind: "CSIDriver", Group: "storage.k8s.io"}:          {},
+	{Kind: "CSINode", Group: "storage.k8s.io"}:            {},
+	{Kind: "CSIStorageCapacity", Group: "storage.k8s.io"}: {},
+
+	{Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}:   {},
+	{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io"}: {},
+	{Kind: "ValidatingAdmissionPolicy", Group: "admissionregistration.k8s.io"}:      {},
+}
+
+func init() {
+	for phase, gks := range phaseGKMap {
+		for _, gk := range gks {
+			gkPhaseMap[gk] = phase
+		}
+	}
 }

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/duplicate-object.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/duplicate-object.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  namespace: ns
+  labels:
+    foo: bar
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a
+  namespace: ns
+  labels:
+    foo: baz

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/metadata-is-string.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/metadata-is-string.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: foo

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-apiversion.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-apiversion.yaml
@@ -1,0 +1,4 @@
+kind: Secret
+metadata:
+  namespace: foo
+  name: bar

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-kind.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-kind.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+metadata:
+  namespace: foo
+  name: bar

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-metadata.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-metadata.yaml
@@ -1,0 +1,2 @@
+apiVersion: v1
+kind: ConfigMap

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-name.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-name.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: {}

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-namespace.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/missing-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo

--- a/internal/packages/internal/packagekickstart/testdata/errorreporting/same-name-different-namespace.yaml
+++ b/internal/packages/internal/packagekickstart/testdata/errorreporting/same-name-different-namespace.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: a
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: b
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aaah
+  namespace: c


### PR DESCRIPTION
### Summary
Introduces the kubectl package kickstart command to quickly start a new package from static kubernetes manifests.

Example:
```
$ kubectl package kickstart olm \                                                   
-f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/crds.yaml \
-f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/olm.yaml
Kickstarted the "olm" package with 22 objects.
[WARN] Some kinds don't have availability probes defined:
- OperatorGroup.operators.coreos.com
- CatalogSource.operators.coreos.com
- OLMConfig.operators.coreos.com

$ kubectl package tree olm       
olm
Package namespace/name
└── Phase namespaces
│   ├── /v1, Kind=Namespace /olm
│   ├── /v1, Kind=Namespace /operators
└── Phase rbac
│   ├── rbac.authorization.k8s.io/v1, Kind=ClusterRole /aggregate-olm-edit
│   ├── rbac.authorization.k8s.io/v1, Kind=ClusterRole /aggregate-olm-view
│   ├── rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding /olm-operator-binding-olm
│   ├── /v1, Kind=ServiceAccount olm/olm-operator-serviceaccount
│   ├── rbac.authorization.k8s.io/v1, Kind=ClusterRole /system:controller:operator-lifecycle-manager
└── Phase crds
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /catalogsources.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /clusterserviceversions.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /installplans.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /olmconfigs.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /operatorconditions.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /operatorgroups.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /operators.operators.coreos.com
│   ├── apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /subscriptions.operators.coreos.com
└── Phase deploy
│   ├── apps/v1, Kind=Deployment olm/catalog-operator
│   ├── apps/v1, Kind=Deployment olm/olm-operator
└── Phase other
    └── operators.coreos.com/v1, Kind=OLMConfig /cluster
    └── operators.coreos.com/v1, Kind=OperatorGroup operators/global-operators
    └── operators.coreos.com/v1, Kind=OperatorGroup olm/olm-operators
    └── operators.coreos.com/v1alpha1, Kind=CatalogSource olm/operatorhubio-catalog
    └── operators.coreos.com/v1alpha1, Kind=ClusterServiceVersion olm/packageserver
```

### Change Type
New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
