### PR TITLE
DRAFT: Security Enhanced Packages

### DIFF
--- a/apis/core/v1alpha1/commonpackage_types.go
+++ b/apis/core/v1alpha1/commonpackage_types.go
@@ -29,6 +29,8 @@ const (
 	PackageProgressing = "Progressing"
 	// Unpacked tracks the completion or failure of the image unpack operation.
 	PackageUnpacked = "Unpacked"
+	// Unpacked tracks the ObjectDeployments Blocked condition.
+	PackageBlocked = "Blocked"
 	// Invalid condition tracks unrecoverable validation and loading issues of the Package.
 	// A package might be invalid because of multiple reasons:
 	// - Does not support the right scope -> Namespaced vs. Cluster
@@ -48,6 +50,7 @@ const (
 	PackagePhaseAvailable   PackageStatusPhase = "Available"
 	PackagePhaseProgressing PackageStatusPhase = "Progressing"
 	PackagePhaseUnpacking   PackageStatusPhase = "Unpacking"
+	PackagePhaseBlocked     PackageStatusPhase = "Blocked"
 	PackagePhaseNotReady    PackageStatusPhase = "NotReady"
 	PackagePhaseInvalid     PackageStatusPhase = "Invalid"
 )

--- a/apis/core/v1alpha1/objectdeployment_types.go
+++ b/apis/core/v1alpha1/objectdeployment_types.go
@@ -43,6 +43,8 @@ type ObjectDeploymentStatus struct {
 const (
 	ObjectDeploymentAvailable   = "Available"
 	ObjectDeploymentProgressing = "Progressing"
+	// Reported when preflight errors or permission issues have the rollout stuck.
+	ObjectDeploymentBlocked = "Blocked"
 )
 
 // ObjectDeploymentPhase specifies a phase that a deployment is in.
@@ -54,6 +56,7 @@ const (
 	ObjectDeploymentPhasePending     ObjectDeploymentPhase = "Pending"
 	ObjectDeploymentPhaseAvailable   ObjectDeploymentPhase = "Available"
 	ObjectDeploymentPhaseNotReady    ObjectDeploymentPhase = "NotReady"
+	ObjectDeploymentPhaseBlocked     ObjectDeploymentPhase = "Blocked"
 	ObjectDeploymentPhaseProgressing ObjectDeploymentPhase = "Progressing"
 )
 

--- a/cmd/package-operator-manager/bootstrap/init.go
+++ b/cmd/package-operator-manager/bootstrap/init.go
@@ -268,10 +268,16 @@ var crdGK = schema.GroupKind{
 	Kind:  "CustomResourceDefinition",
 }
 
+// GroupKind for CRDs.
+var cbindGK = schema.GroupKind{
+	Group: "rbac.authorization.k8s.io",
+	Kind:  "ClusterRoleBinding",
+}
+
 func crdsFromObjects(objs []unstructured.Unstructured) (crds []unstructured.Unstructured) {
 	for _, obj := range objs {
 		gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
-		if gk != crdGK {
+		if gk != crdGK && gk != cbindGK {
 			continue
 		}
 

--- a/cmd/package-operator-manager/components/objectset.go
+++ b/cmd/package-operator-manager/components/objectset.go
@@ -28,6 +28,7 @@ func ProvideObjectSetController(
 			log.WithName("controllers").WithName("ObjectSet"),
 			mgr.GetScheme(), dc, uncachedClient, recorder,
 			mgr.GetRESTMapper(),
+			*mgr.GetConfig(),
 		),
 	}
 }
@@ -44,6 +45,7 @@ func ProvideClusterObjectSetController(
 			log.WithName("controllers").WithName("ObjectSet"),
 			mgr.GetScheme(), dc, uncachedClient, recorder,
 			mgr.GetRESTMapper(),
+			*mgr.GetConfig(),
 		),
 	}
 }

--- a/cmd/package-operator-manager/components/objectsetphase.go
+++ b/cmd/package-operator-manager/components/objectsetphase.go
@@ -28,6 +28,7 @@ func ProvideObjectSetPhaseController(
 			mgr.GetScheme(), dc, uncachedClient,
 			defaultObjectSetPhaseClass, mgr.GetClient(),
 			mgr.GetRESTMapper(),
+			*mgr.GetConfig(),
 		),
 	}
 }
@@ -43,6 +44,7 @@ func ProvideClusterObjectSetPhaseController(
 			mgr.GetScheme(), dc, uncachedClient,
 			defaultObjectSetPhaseClass, mgr.GetClient(),
 			mgr.GetRESTMapper(),
+			*mgr.GetConfig(),
 		),
 	}
 }

--- a/cmd/remote-phase-manager/main.go
+++ b/cmd/remote-phase-manager/main.go
@@ -166,13 +166,6 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 	if err != nil {
 		return fmt.Errorf("creating target cluster rest mapper: %w", err)
 	}
-	targetClient, err := client.New(targetCfg, client.Options{
-		Scheme: scheme,
-		Mapper: targetMapper,
-	})
-	if err != nil {
-		return fmt.Errorf("creating target cluster client: %w", err)
-	}
 
 	// Create metrics recorder
 	recorder := metrics.NewRecorder()
@@ -203,7 +196,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 		ctrl.Log.WithName("controllers").WithName("ObjectSetPhase"),
 		mgr.GetScheme(), dc, uncachedTargetClient,
 		opts.class, managementClusterClient,
-		targetClient, targetMapper,
+		targetMapper, *targetCfg,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller for ObjectSetPhase: %w", err)
 	}
@@ -214,7 +207,7 @@ func run(log logr.Logger, scheme *runtime.Scheme, opts opts) error {
 			ctrl.Log.WithName("controllers").WithName("ClusterObjectSetPhase"),
 			mgr.GetScheme(), dc, uncachedTargetClient,
 			opts.class, managementClusterClient,
-			targetClient, targetMapper,
+			targetMapper, *targetCfg,
 		).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller for ClusterObjectSetPhase: %w", err)
 		}

--- a/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,5 +12,27 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
-- kind: User
-  name: pko:clusterpackage:package-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator-packages
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: pko:clusterpackages
+- kind: Group
+  name: pko:clusterobjectdeployments
+- kind: Group
+  name: pko:clusterobjectsets
+- kind: Group
+  name: pko:packages
+- kind: Group
+  name: pko:objectdeployments
+- kind: Group
+  name: pko:objectsets

--- a/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/affinity-tolerations-resources/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,3 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
+- kind: User
+  name: pko:clusterpackage:package-operator

--- a/config/packages/package-operator/.test-fixtures/no-config/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/no-config/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,5 +12,27 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
-- kind: User
-  name: pko:clusterpackage:package-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator-packages
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: pko:clusterpackages
+- kind: Group
+  name: pko:clusterobjectdeployments
+- kind: Group
+  name: pko:clusterobjectsets
+- kind: Group
+  name: pko:packages
+- kind: Group
+  name: pko:objectdeployments
+- kind: Group
+  name: pko:objectsets

--- a/config/packages/package-operator/.test-fixtures/no-config/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/no-config/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,3 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
+- kind: User
+  name: pko:clusterpackage:package-operator

--- a/config/packages/package-operator/.test-fixtures/openshift-with-proxy/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/openshift-with-proxy/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,5 +12,27 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
-- kind: User
-  name: pko:clusterpackage:package-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator-packages
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: pko:clusterpackages
+- kind: Group
+  name: pko:clusterobjectdeployments
+- kind: Group
+  name: pko:clusterobjectsets
+- kind: Group
+  name: pko:packages
+- kind: Group
+  name: pko:objectdeployments
+- kind: Group
+  name: pko:objectsets

--- a/config/packages/package-operator/.test-fixtures/openshift-with-proxy/rbac/package-operator.ClusterRoleBinding.yaml
+++ b/config/packages/package-operator/.test-fixtures/openshift-with-proxy/rbac/package-operator.ClusterRoleBinding.yaml
@@ -12,3 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: package-operator-system
+- kind: User
+  name: pko:clusterpackage:package-operator

--- a/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml.gotmpl
+++ b/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml.gotmpl
@@ -12,3 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: {{ .config.namespace }}
+- kind: User
+  name: pko:clusterpackage:package-operator

--- a/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml.gotmpl
+++ b/config/packages/package-operator/rbac/package-operator.ClusterRoleBinding.yaml.gotmpl
@@ -12,5 +12,27 @@ subjects:
 - kind: ServiceAccount
   name: package-operator
   namespace: {{ .config.namespace }}
-- kind: User
-  name: pko:clusterpackage:package-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator-packages
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: pko:clusterpackages
+- kind: Group
+  name: pko:clusterobjectdeployments
+- kind: Group
+  name: pko:clusterobjectsets
+- kind: Group
+  name: pko:packages
+- kind: Group
+  name: pko:objectdeployments
+- kind: Group
+  name: pko:objectsets

--- a/config/self-bootstrap-job.yaml.tpl
+++ b/config/self-bootstrap-job.yaml.tpl
@@ -28,6 +28,32 @@ subjects:
   name: package-operator
   namespace: package-operator-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  labels:
+    package-operator.run/cache: "True"
+  name: package-operator-packages
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: pko:clusterpackages
+- kind: Group
+  name: pko:clusterobjectdeployments
+- kind: Group
+  name: pko:clusterobjectsets
+- kind: Group
+  name: pko:packages
+- kind: Group
+  name: pko:objectdeployments
+- kind: Group
+  name: pko:objectsets
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/internal/adapters/objectdeployment.go
+++ b/internal/adapters/objectdeployment.go
@@ -215,6 +215,11 @@ func (a *ClusterObjectDeployment) GetStatusRevision() int64 {
 }
 
 func objectDeploymentPhase(conditions []metav1.Condition) corev1alpha1.ObjectDeploymentPhase {
+	blockedCond := meta.FindStatusCondition(conditions, corev1alpha1.ObjectDeploymentBlocked)
+	if blockedCond != nil {
+		return corev1alpha1.ObjectDeploymentPhaseBlocked
+	}
+
 	availableCond := meta.FindStatusCondition(conditions, corev1alpha1.ObjectDeploymentAvailable)
 
 	if availableCond != nil {

--- a/internal/adapters/package.go
+++ b/internal/adapters/package.go
@@ -182,9 +182,25 @@ func updatePackagePhase(pkg GenericPackageAccessor) {
 		return
 	}
 
+	if meta.IsStatusConditionTrue(
+		*pkg.GetConditions(),
+		corev1alpha1.PackageBlocked,
+	) {
+		pkg.setStatusPhase(corev1alpha1.PackagePhaseBlocked)
+		return
+	}
+
 	unpackCond := meta.FindStatusCondition(*pkg.GetConditions(), corev1alpha1.PackageUnpacked)
 	if unpackCond == nil {
 		pkg.setStatusPhase(corev1alpha1.PackagePhaseUnpacking)
+		return
+	}
+
+	if meta.IsStatusConditionFalse(
+		*pkg.GetConditions(),
+		corev1alpha1.PackageAvailable,
+	) {
+		pkg.setStatusPhase(corev1alpha1.PackagePhaseNotReady)
 		return
 	}
 

--- a/internal/controllers/impersonation.go
+++ b/internal/controllers/impersonation.go
@@ -13,6 +13,8 @@ import (
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
 
+// AutoImpersonatingWriterWrapper wraps calls from the client.Writer interface
+// into new clients using impersonation depending on the root owner.
 type AutoImpersonatingWriterWrapper struct {
 	restConfig rest.Config
 	scheme     *runtime.Scheme
@@ -32,6 +34,7 @@ func NewAutoImpersonatingWriter(
 	}
 }
 
+// Interface function so clients can require an impersonation aware client.
 func (w *AutoImpersonatingWriterWrapper) Impersonate() {}
 
 func (w *AutoImpersonatingWriterWrapper) Create(

--- a/internal/controllers/impersonation.go
+++ b/internal/controllers/impersonation.go
@@ -1,0 +1,221 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+type AutoImpersonatingWriterWrapper struct {
+	restConfig rest.Config
+	scheme     *runtime.Scheme
+	// I want a cached client pls!
+	reader client.Reader
+}
+
+func NewAutoImpersonatingWriter(
+	restConfig rest.Config,
+	scheme *runtime.Scheme,
+	reader client.Reader,
+) *AutoImpersonatingWriterWrapper {
+	return &AutoImpersonatingWriterWrapper{
+		restConfig: restConfig,
+		scheme:     scheme,
+		reader:     reader,
+	}
+}
+
+func (w *AutoImpersonatingWriterWrapper) Impersonate() {}
+
+func (w *AutoImpersonatingWriterWrapper) Create(
+	ctx context.Context, obj client.Object, opts ...client.CreateOption,
+) error {
+	c, err := w.clientUsingPKOImpersonationSettings(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return c.Create(ctx, obj, opts...)
+}
+
+func (w *AutoImpersonatingWriterWrapper) Delete(
+	ctx context.Context, obj client.Object, opts ...client.DeleteOption,
+) error {
+	c, err := w.clientUsingPKOImpersonationSettings(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return c.Delete(ctx, obj, opts...)
+}
+
+func (w *AutoImpersonatingWriterWrapper) Update(
+	ctx context.Context, obj client.Object, opts ...client.UpdateOption,
+) error {
+	c, err := w.clientUsingPKOImpersonationSettings(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return c.Update(ctx, obj, opts...)
+}
+
+func (w *AutoImpersonatingWriterWrapper) Patch(
+	ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption,
+) error {
+	c, err := w.clientUsingPKOImpersonationSettings(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return c.Patch(ctx, obj, patch, opts...)
+}
+
+func (w *AutoImpersonatingWriterWrapper) DeleteAllOf(
+	ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption,
+) error {
+	c, err := w.clientUsingPKOImpersonationSettings(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return c.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (w *AutoImpersonatingWriterWrapper) clientUsingPKOImpersonationSettings(
+	ctx context.Context, obj client.Object,
+) (client.Writer, error) {
+	c := w.restConfig // shallow colpy of rest.Config
+	ic, err := w.impersonationConfigForObject(ctx, obj)
+	if err != nil {
+		return nil, err
+	}
+	c.Impersonate = ic
+	return client.New(&c, client.Options{})
+}
+
+func (w AutoImpersonatingWriterWrapper) impersonationConfigForObject(
+	ctx context.Context,
+	obj client.Object,
+) (rest.ImpersonationConfig, error) {
+	toImpersonate, err := w.getOwner(ctx, obj)
+	if err != nil {
+		return rest.ImpersonationConfig{}, fmt.Errorf("get owner for: %w", err)
+	}
+
+	user, groups := impersonationUserAndGroupsForObject(toImpersonate)
+	return rest.ImpersonationConfig{
+		UserName: user,
+		Groups:   groups,
+	}, nil
+}
+
+type objectIdentity struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+func (w AutoImpersonatingWriterWrapper) getOwner(ctx context.Context, obj client.Object) (objectIdentity, error) {
+	for _, ownerRef := range obj.GetOwnerReferences() {
+		gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+		if err != nil {
+			return objectIdentity{}, err
+		}
+		if ownerRef.Controller != nil &&
+			*ownerRef.Controller &&
+			gv.Group == corev1alpha1.GroupVersion.Group {
+			// The controller is a Package Operator Object.
+			// -> check it's owners.
+			robj, err := w.scheme.New(schema.FromAPIVersionAndKind(ownerRef.APIVersion, ownerRef.Kind))
+			if err != nil {
+				return objectIdentity{}, err
+			}
+			potentialOwner := robj.(client.Object)
+
+			var ns string
+			if !strings.HasPrefix(ownerRef.Kind, "Cluster") {
+				ns = obj.GetNamespace() // same namespace as self.
+			}
+			if err := w.reader.Get(ctx, client.ObjectKey{
+				Name:      ownerRef.Name,
+				Namespace: ns,
+			}, potentialOwner); err != nil {
+				return objectIdentity{}, err
+			}
+			// recurse into this function
+			return w.getOwner(ctx, potentialOwner)
+		}
+	}
+	return objectIdentity{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
+	}, nil
+}
+
+const impersonationPrefix = "pko"
+
+func impersonationUserAndGroupsForObject(oi objectIdentity) (user string, groups []string) {
+	var (
+		resourceSingular string
+		resourcePlural   string
+		isClusterScope   bool
+	)
+	switch oi.Kind {
+	case "ObjectSet":
+		resourceSingular = "objectset"
+		resourcePlural = "objectsets"
+	case "ObjectDeployment":
+		resourceSingular = "objectdeployment"
+		resourcePlural = "objectdeployments"
+	case "Package":
+		resourceSingular = "package"
+		resourcePlural = "packages"
+	case "ClusterObjectSet":
+		resourceSingular = "clusterobjectset"
+		resourcePlural = "clusterobjectsets"
+		isClusterScope = true
+	case "ClusterObjectDeployment":
+		resourceSingular = "clusterobjectdeployment"
+		resourcePlural = "clusterobjectdeployments"
+		isClusterScope = true
+	case "ClusterPackage":
+		resourceSingular = "clusterpackage"
+		resourcePlural = "clusterpackages"
+		isClusterScope = true
+	default:
+		panic(fmt.Sprintf("%q unsupported kind for impersonation", oi.Kind))
+	}
+
+	if isClusterScope {
+		// Example:
+		// User: pko:clusterpackage:banana
+		// Groups:
+		// - pko:clusterpackages
+		return strings.Join([]string{
+				impersonationPrefix, resourceSingular, oi.Name,
+			}, ":"), []string{
+				strings.Join([]string{
+					impersonationPrefix, resourcePlural,
+				}, ":"),
+			}
+	}
+	// Example:
+	// User: pko:package:fruits:banana
+	// Groups:
+	// - pko:packages:fruits
+	// - pko:packages
+	return strings.Join([]string{
+			impersonationPrefix, resourceSingular, oi.Namespace, oi.Name,
+		}, ":"), []string{
+			strings.Join([]string{
+				impersonationPrefix, resourcePlural, oi.Namespace,
+			}, ":"),
+			strings.Join([]string{
+				impersonationPrefix, resourcePlural,
+			}, ":"),
+		}
+}

--- a/internal/controllers/impersonation.go
+++ b/internal/controllers/impersonation.go
@@ -187,7 +187,7 @@ func impersonationUserAndGroupsForObject(oi objectIdentity) (user string, groups
 		resourcePlural = "clusterpackages"
 		isClusterScope = true
 	default:
-		panic(fmt.Sprintf("%q unsupported kind for impersonation", oi.Kind))
+		return "", nil
 	}
 
 	if isClusterScope {

--- a/internal/controllers/impersonation_test.go
+++ b/internal/controllers/impersonation_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/internal/testutil"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func Test_impersonationConfigForObject_namespaced(t *testing.T) {

--- a/internal/controllers/impersonation_test.go
+++ b/internal/controllers/impersonation_test.go
@@ -1,0 +1,149 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/internal/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func Test_impersonationConfigForObject_namespaced(t *testing.T) {
+	t.Parallel()
+	pkg := &corev1alpha1.Package{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Package",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "banana",
+			Namespace: "fruits",
+		},
+	}
+	odepl := &corev1alpha1.ObjectDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "banana",
+			Namespace: "fruits",
+		},
+	}
+	require.NoError(t,
+		controllerutil.SetControllerReference(pkg, odepl, testScheme))
+
+	oset := &corev1alpha1.ObjectSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "banana-xxx",
+			Namespace: "fruits",
+		},
+	}
+	require.NoError(t,
+		controllerutil.SetControllerReference(odepl, oset, testScheme))
+
+	c := testutil.NewClient()
+	c.On(
+		"Get", mock.Anything, mock.Anything,
+		mock.AnythingOfType("*v1alpha1.ObjectDeployment"),
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		o := args.Get(2).(*corev1alpha1.ObjectDeployment)
+		*o = *odepl
+	}).Return(nil)
+	c.On(
+		"Get", mock.Anything, mock.Anything,
+		mock.AnythingOfType("*v1alpha1.Package"),
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		o := args.Get(2).(*corev1alpha1.Package)
+		*o = *pkg
+	}).Return(nil)
+
+	ctx := context.Background()
+	w := &AutoImpersonatingWriterWrapper{
+		scheme: testScheme,
+		reader: c,
+	}
+	i, err := w.impersonationConfigForObject(ctx, oset)
+	require.NoError(t, err)
+	assert.Equal(t, rest.ImpersonationConfig{
+		UserName: "pko:package:fruits:banana",
+		Groups: []string{
+			"pko:packages:fruits",
+			"pko:packages",
+		},
+	}, i)
+}
+
+func Test_impersonationConfigForObject_cluster(t *testing.T) {
+	t.Parallel()
+	pkg := &corev1alpha1.ClusterPackage{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterPackage",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "banana",
+		},
+	}
+	odepl := &corev1alpha1.ClusterObjectDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterObjectDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "banana",
+		},
+	}
+	require.NoError(t,
+		controllerutil.SetControllerReference(pkg, odepl, testScheme))
+
+	oset := &corev1alpha1.ClusterObjectSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterObjectSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "banana-xxx",
+		},
+	}
+	require.NoError(t,
+		controllerutil.SetControllerReference(odepl, oset, testScheme))
+
+	c := testutil.NewClient()
+	c.On(
+		"Get", mock.Anything, mock.Anything,
+		mock.AnythingOfType("*v1alpha1.ClusterObjectDeployment"),
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		o := args.Get(2).(*corev1alpha1.ClusterObjectDeployment)
+		*o = *odepl
+	}).Return(nil)
+	c.On(
+		"Get", mock.Anything, mock.Anything,
+		mock.AnythingOfType("*v1alpha1.ClusterPackage"),
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		o := args.Get(2).(*corev1alpha1.ClusterPackage)
+		*o = *pkg
+	}).Return(nil)
+
+	ctx := context.Background()
+	w := &AutoImpersonatingWriterWrapper{
+		scheme: testScheme,
+		reader: c,
+	}
+	i, err := w.impersonationConfigForObject(ctx, oset)
+	require.NoError(t, err)
+	assert.Equal(t, rest.ImpersonationConfig{
+		UserName: "pko:clusterpackage:banana",
+		Groups: []string{
+			"pko:clusterpackages",
+		},
+	}, i)
+}

--- a/internal/controllers/objectsetphases/objectsetphase_controller_test.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -296,8 +297,8 @@ func TestInitializers(t *testing.T) {
 
 		ctrl := NewMultiClusterObjectSetPhaseController(
 			log, scheme,
-			dc, client, class, client, client,
-			mapper,
+			dc, client, class, client,
+			mapper, rest.Config{},
 		)
 
 		require.NotNil(t, ctrl)
@@ -308,8 +309,8 @@ func TestInitializers(t *testing.T) {
 
 		ctrl := NewMultiClusterClusterObjectSetPhaseController(
 			log, scheme,
-			dc, client, class, client, client,
-			mapper,
+			dc, client, class, client,
+			mapper, rest.Config{},
 		)
 
 		require.NotNil(t, ctrl)
@@ -321,7 +322,7 @@ func TestInitializers(t *testing.T) {
 		ctrl := NewSameClusterObjectSetPhaseController(
 			log, scheme,
 			dc, client, class, client,
-			mapper,
+			mapper, rest.Config{},
 		)
 
 		require.NotNil(t, ctrl)
@@ -333,7 +334,7 @@ func TestInitializers(t *testing.T) {
 		ctrl := NewSameClusterClusterObjectSetPhaseController(
 			log, scheme,
 			dc, client, class, client,
-			mapper,
+			mapper, rest.Config{},
 		)
 
 		require.NotNil(t, ctrl)

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -95,7 +95,6 @@ func newGenericObjectTemplateController(
 			preflight.NewAPIExistence(
 				restMapper,
 				preflight.List{
-					preflight.NewNoOwnerReferences(restMapper),
 					preflight.NewEmptyNamespaceNoDefault(restMapper),
 					preflight.NewNamespaceEscalation(restMapper),
 				},

--- a/internal/controllers/packages/object_deployment_status_reconciler.go
+++ b/internal/controllers/packages/object_deployment_status_reconciler.go
@@ -43,6 +43,14 @@ func (r *objectDeploymentStatusReconciler) Reconcile(
 		meta.SetStatusCondition(packageObj.GetConditions(), *packageProgressingCond)
 	}
 
+	objDepBlockedCond := meta.FindStatusCondition(*objDep.GetConditions(), corev1alpha1.ObjectDeploymentBlocked)
+	if objDepBlockedCond != nil && objDepBlockedCond.ObservedGeneration == objDep.GetGeneration() {
+		packageBlockedCond := objDepBlockedCond.DeepCopy()
+		packageBlockedCond.ObservedGeneration = packageObj.ClientObject().GetGeneration()
+
+		meta.SetStatusCondition(packageObj.GetConditions(), *packageBlockedCond)
+	}
+
 	controllers.DeleteMappedConditions(ctx, packageObj.GetConditions())
 	controllers.MapConditions(
 		ctx,

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -1551,16 +1551,22 @@ func TestPhaseReconciler_observeExternalObject(t *testing.T) {
 func TestPhaseReconciler_ReconcilePhase_preflightError(t *testing.T) {
 	t.Parallel()
 
+	ownerStrategyMock := &ownerStrategyMock{}
 	pcm := &preflightCheckerMock{}
 	pr := &PhaseReconciler{
 		scheme:           testScheme,
 		preflightChecker: pcm,
+		ownerStrategy:    ownerStrategyMock,
 	}
 
 	ownerObj := &unstructured.Unstructured{}
 	owner := &phaseObjectOwnerMock{}
 	owner.On("ClientObject").Return(ownerObj)
 	owner.On("GetRevision").Return(int64(12))
+
+	ownerStrategyMock.
+		On("SetControllerReference", mock.Anything, mock.Anything).
+		Return(nil)
 
 	pcm.
 		On("Check", mock.Anything, mock.Anything, mock.Anything).

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -45,6 +45,7 @@ func TestPhaseReconciler_TeardownPhase_failing_preflight(t *testing.T) {
 		dynamicCache:     dynamicCache,
 		ownerStrategy:    ownerStrategy,
 		preflightChecker: preflightChecker,
+		ownerRefChecker:  preflight.List{},
 	}
 	owner := &phaseObjectOwnerMock{}
 	ownerObj := &unstructured.Unstructured{}
@@ -93,6 +94,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
+			ownerRefChecker:  preflight.List{},
 		}
 		owner := &phaseObjectOwnerMock{}
 		ownerObj := &unstructured.Unstructured{}
@@ -142,6 +144,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
+			ownerRefChecker:  preflight.List{},
 		}
 		owner := &phaseObjectOwnerMock{}
 		ownerObj := &unstructured.Unstructured{}
@@ -211,6 +214,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			uncachedClient:   uncachedClient,
 			ownerStrategy:    ownerStrategy,
 			preflightChecker: preflightChecker,
+			ownerRefChecker:  preflight.List{},
 		}
 
 		owner := &phaseObjectOwnerMock{}
@@ -277,6 +281,7 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) { //nolint:maintidx
 			ownerStrategy:    ownerStrategy,
 			writer:           testClient,
 			preflightChecker: preflightChecker,
+			ownerRefChecker:  preflight.List{},
 		}
 
 		owner := &phaseObjectOwnerMock{}
@@ -554,7 +559,8 @@ func TestPhaseReconciler_desiredObject(t *testing.T) {
 
 	os := &ownerStrategyMock{}
 	r := &PhaseReconciler{
-		ownerStrategy: os,
+		ownerStrategy:   os,
+		ownerRefChecker: preflight.List{},
 	}
 
 	os.On("SetControllerReference",
@@ -601,7 +607,8 @@ func TestPhaseReconciler_desiredObject_defaultsNamespace(t *testing.T) {
 
 	os := &ownerStrategyMock{}
 	r := &PhaseReconciler{
-		ownerStrategy: os,
+		ownerStrategy:   os,
+		ownerRefChecker: preflight.List{},
 	}
 
 	os.On("SetControllerReference",
@@ -1557,6 +1564,7 @@ func TestPhaseReconciler_ReconcilePhase_preflightError(t *testing.T) {
 		scheme:           testScheme,
 		preflightChecker: pcm,
 		ownerStrategy:    ownerStrategyMock,
+		ownerRefChecker:  preflight.List{},
 	}
 
 	ownerObj := &unstructured.Unstructured{}

--- a/internal/preflight/dryrun.go
+++ b/internal/preflight/dryrun.go
@@ -21,13 +21,27 @@ type autoImpersonatingWriter interface {
 }
 
 type DryRun struct {
-	client autoImpersonatingWriter
+	writer autoImpersonatingWriter
 }
 
-func NewDryRun(client autoImpersonatingWriter) *DryRun { return &DryRun{client: client} }
+func NewDryRun(writer autoImpersonatingWriter) *DryRun {
+	return &DryRun{
+		writer: writer,
+	}
+}
 
 func (p *DryRun) Check(ctx context.Context, _, obj client.Object) (violations []Violation, err error) {
 	defer addPositionToViolations(ctx, obj, &violations)
+	obj = obj.DeepCopyObject().(client.Object)
+
+	// Pretend any new owner is not marked as Controller to get around
+	// preflight issues when adoption objects from other Controllers.
+	ownerRefs := make([]metav1.OwnerReference, len(obj.GetOwnerReferences()))
+	for i, ownerRef := range obj.GetOwnerReferences() {
+		ownerRef.Controller = nil
+		ownerRefs[i] = ownerRef
+	}
+	obj.SetOwnerReferences(ownerRefs)
 
 	objectPatch, mErr := json.Marshal(obj)
 	if mErr != nil {
@@ -36,11 +50,7 @@ func (p *DryRun) Check(ctx context.Context, _, obj client.Object) (violations []
 
 	patch := client.RawPatch(types.ApplyPatchType, objectPatch)
 	dst := obj.DeepCopyObject().(*unstructured.Unstructured)
-	err = p.client.Patch(ctx, dst, patch, client.FieldOwner("package-operator"), client.ForceOwnership, client.DryRunAll)
-
-	if apimachineryerrors.IsNotFound(err) {
-		err = p.client.Create(ctx, obj.DeepCopyObject().(client.Object), client.DryRunAll)
-	}
+	err = p.writer.Patch(ctx, dst, patch, client.FieldOwner("package-operator"), client.ForceOwnership, client.DryRunAll)
 
 	var apiErr apimachineryerrors.APIStatus
 

--- a/internal/preflight/dryrun_test.go
+++ b/internal/preflight/dryrun_test.go
@@ -22,7 +22,7 @@ var errTest = errors.New("explosion")
 func TestDryRun(t *testing.T) {
 	t.Parallel()
 
-	c := testutil.NewClient()
+	c := newImpersonatingClient()
 
 	var objCalled *unstructured.Unstructured
 	c.
@@ -65,7 +65,7 @@ func TestDryRunViolations(t *testing.T) {
 		reason := reasons[i]
 		t.Run(string(reason), func(t *testing.T) {
 			t.Parallel()
-			c := testutil.NewClient()
+			c := newImpersonatingClient()
 
 			c.
 				On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -87,7 +87,7 @@ func TestDryRunViolations(t *testing.T) {
 func TestDryRun_alreadyExists(t *testing.T) {
 	t.Parallel()
 
-	c := testutil.NewClient()
+	c := newImpersonatingClient()
 
 	var objCalled *unstructured.Unstructured
 	c.
@@ -114,7 +114,7 @@ func TestDryRun_alreadyExists(t *testing.T) {
 func TestDryRun_notFround(t *testing.T) {
 	t.Parallel()
 
-	c := testutil.NewClient()
+	c := newImpersonatingClient()
 
 	c.
 		On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -137,7 +137,7 @@ func TestDryRun_notFround(t *testing.T) {
 func TestDryRun_emptyreason(t *testing.T) {
 	t.Parallel()
 
-	c := testutil.NewClient()
+	c := newImpersonatingClient()
 
 	e := &apimachineryerrors.StatusError{
 		ErrStatus: metav1.Status{Reason: "", Message: "cheese, also failed to create typed patch object, also more cheese"},
@@ -154,4 +154,16 @@ func TestDryRun_emptyreason(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, v, 1)
 	require.Contains(t, v[0].Error, e.ErrStatus.Message)
+}
+
+type impersonatingClient struct {
+	*testutil.CtrlClient
+}
+
+func (c *impersonatingClient) Impersonate() {}
+
+func newImpersonatingClient() *impersonatingClient {
+	return &impersonatingClient{
+		CtrlClient: testutil.NewClient(),
+	}
 }

--- a/internal/preflight/noownerreferences.go
+++ b/internal/preflight/noownerreferences.go
@@ -3,21 +3,16 @@ package preflight
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Prevents the use of APIs not registered into the kube-apiserver.
-type NoOwnerReferences struct {
-	restMapper meta.RESTMapper
-}
+type NoOwnerReferences struct{}
 
 var _ checker = (*NoOwnerReferences)(nil)
 
-func NewNoOwnerReferences(restMapper meta.RESTMapper) *NoOwnerReferences {
-	return &NoOwnerReferences{
-		restMapper: restMapper,
-	}
+func NewNoOwnerReferences() *NoOwnerReferences {
+	return &NoOwnerReferences{}
 }
 
 func (p *NoOwnerReferences) Check(ctx context.Context, _, obj client.Object) (violations []Violation, err error) {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,6 +15,15 @@ import (
 
 type Error struct {
 	Violations []Violation
+}
+
+func (e *Error) HasReason(r metav1.StatusReason) bool {
+	for _, v := range e.Violations {
+		if v.Reason == r {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Error) Error() string {
@@ -30,6 +40,8 @@ type Violation struct {
 	Position string
 	// Error describing the violation.
 	Error string
+	// API Status Reason for the Violation.
+	Reason metav1.StatusReason
 }
 
 func (v *Violation) String() string {


### PR DESCRIPTION
### Summary
Adds RBAC protection to packages.
(Cluster)Packages, (Cluster)ObjectSets and (Cluster)ObjectDeployments now require to have permissions bound to them to prevent users from elevating their own privileges.

Packages are granted permissions by referencing their users or group names in a RoleBinding subject. These names are generated like this: Users:
- `pko:package:<namespace>:<name>`
- `pko:clusterpackage:<name>`
- `pko:objectdeployment:<namespace>:<name>`
- `pko:clusterobjectdeployment:<name>`
- `pko:objectset:<namespace>:<name>`
- `pko:clusterobjectset:<name>`

Groups:
- `pko:packages:<namespace>`
- `pko:packages`
- `pko:clusterpackages`
- `pko:objectdeployments:<namespace>`
- `pko:objectdeployments`
- `pko:clusterobjectdeployments`
- `pko:objectsets:<namespace>`
- `pko:objectsets`
- `pko:clusterobjectsets`

Lower-level API objects will inherit the permissions from their parent within the package-operator.run API group. So ObjectDeployments or ObjectSets only need explicit permissions, if they are created without a parent Package.

### Change Type

New Feature

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
