### PR TITLE
[PKO-106] fix the endless reconcilation

### DIFF
--- a/internal/utils/hasSameController.go
+++ b/internal/utils/hasSameController.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func HasSameController(objA, objB metav1.Object) bool {
+	controllerA := metav1.GetControllerOf(objA)
+	controllerB := metav1.GetControllerOf(objB)
+	if controllerA == nil || controllerB == nil {
+		return false
+	}
+	return controllerA.UID == controllerB.UID
+}

--- a/internal/utils/hasSameController_test.go
+++ b/internal/utils/hasSameController_test.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestHasSameController(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+	// Helper function to create an object with a specified controller UID
+	createObjectWithController := func(uid types.UID) metav1.Object {
+		return &metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID:        uid,
+					Controller: boolPtr(true),
+				},
+			},
+		}
+	}
+
+	// Helper function to create an object without a controller
+	createObjectWithoutController := func() metav1.Object {
+		return &metav1.ObjectMeta{}
+	}
+
+	tests := []struct {
+		name   string
+		objA   metav1.Object
+		objB   metav1.Object
+		result bool
+	}{
+		{
+			name:   "Both objects have the same controller",
+			objA:   createObjectWithController("controller-1"),
+			objB:   createObjectWithController("controller-1"),
+			result: true,
+		},
+		{
+			name:   "Objects have different controllers",
+			objA:   createObjectWithController("controller-1"),
+			objB:   createObjectWithController("controller-2"),
+			result: false,
+		},
+		{
+			name:   "First object does not have a controller",
+			objA:   createObjectWithoutController(),
+			objB:   createObjectWithController("controller-1"),
+			result: false,
+		},
+		{
+			name:   "Second object does not have a controller",
+			objA:   createObjectWithController("controller-1"),
+			objB:   createObjectWithoutController(),
+			result: false,
+		},
+		{
+			name:   "Neither object has a controller",
+			objA:   createObjectWithoutController(),
+			objB:   createObjectWithoutController(),
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := HasSameController(tt.objA, tt.objB); got != tt.result {
+				t.Errorf("HasSameController() = %v, want %v", got, tt.result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->

https://issues.redhat.com/browse/PKO-106
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Currently the object template controller updates the object template object on every reconcile regardless of whether the desired state is equal to the current state of the object in the cluster. This creates unnecessary load on the api-server.[Ref: [https://github.com/package-operator/package-operator/blob/main/internal/controllers/objecttemplate/template_reconciler.go#L109]](https://issues.redhat.com/browse/PKO-106#L109%5D)

How this PR will help :

Currently in the code we are trying to make the update call until the spec gets changed . Requesting your review since the it seems to be a Unstructured Object so taking the "spec" value from the Map .
### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
