### PR TITLE
[cmd/build] ./do dev:run: use dynamic registry host in registry-host-overrides flag

### DIFF
--- a/cmd/build/dev.go
+++ b/cmd/build/dev.go
@@ -156,7 +156,7 @@ func (dev *Dev) Run(ctx context.Context, args []string) error {
 		"./cmd/package-operator-manager",
 		"-namespace", "package-operator-system",
 		"-enable-leader-election=true",
-		"-registry-host-overrides", "quay.io=localhost:5001",
+		"-registry-host-overrides", imageRegistryHost() + "=localhost:5001",
 		"--package-operator-package-image", imageRegistry() + "/package-operator-package:" + appVersion,
 	}
 


### PR DESCRIPTION
### Summary

This fix enables me to use `IMAGE_REGISTRY=ctr.erdii.net/pko-dev ./do dev:run`

to move the registry override for quay out of the way so that I can pull existing package images from quay into my development cluster.

I often use this manifest [1] to debug package-operator when developing.

[1]
```yaml
apiVersion: package-operator.run/v1alpha1
kind: Package
metadata:
  name: my-nginx
spec:
  image: quay.io/erdii-test/nginx-package:e9e4e0e
```

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
