### PR TITLE
[PKO-106] fix the endless reconcilation #1286

### DIFF
--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -396,7 +396,7 @@ func Test_templateReconcilerReconcile(t *testing.T) {
 
 			r, client, _, dc := newControllerAndMocks(t)
 
-			client.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			client.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil).Maybe()
 			client.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil).Maybe()


### PR DESCRIPTION
https://issues.redhat.com/browse/PKO-106

Summary
Currently the object template controller updates the object template object on every reconcile regardless of whether the desired state is equal to the current state of the object in the cluster. This creates unnecessary load on the api-server.[Ref: [https://github.com/package-operator/package-operator/blob/main/internal/controllers/objecttemplate/template_reconciler.go#L109]](https://issues.redhat.com/browse/PKO-106#L109%5D)

How this PR will help :

Currently in the code we are trying to make the update call until the spec gets changed . Requesting your review since the it seems to be a Unstructured Object so taking the "spec" value from the Map .

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
