### PR TITLE
[PKO-69] Add a go-template CEL Expression Evaluation Function

### DIFF
--- a/config/packages/test-stub-cel/.test-fixtures/cluster-scope/cel-template-cm.yaml
+++ b/config/packages/test-stub-cel/.test-fixtures/cluster-scope/cel-template-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cel-template-cm"
+  namespace: "test"
+  labels:
+    app: test-stub
+    instance: "test"
+  annotations:
+    test-environment: "{\"kubernetes\":{\"version\":\"v1.27.0\"},\"openShift\":{\"version\":\"v4.13.0\"},\"proxy\":{\"httpProxy\":\"xxx\",\"httpsProxy\":\"xxx\",\"noProxy\":\"xxxxx\"}}"
+    package-operator.run/phase: deploy
+data:
+  banana: "bread"

--- a/config/packages/test-stub-cel/.test-fixtures/namespace-scope/cel-template-cm.yaml
+++ b/config/packages/test-stub-cel/.test-fixtures/namespace-scope/cel-template-cm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cel-template-cm"
+  labels:
+    app: test-stub
+    instance: "test"
+  annotations:
+    test-environment: "{\"kubernetes\":{\"version\":\"v1.27.0\"}}"
+    package-operator.run/phase: deploy
+data:
+  banana: "bread"

--- a/config/packages/test-stub-cel/cel-template-cm.yaml.gotmpl
+++ b/config/packages/test-stub-cel/cel-template-cm.yaml.gotmpl
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cel-template-cm"
+{{- if eq .package.metadata.namespace ""}}
+  namespace: "{{.package.metadata.name}}"
+{{- end}}
+  labels:
+    app: test-stub
+    instance: "{{.package.metadata.name}}"
+  annotations:
+    test-environment: {{.environment | toJson | quote}}
+    package-operator.run/phase: deploy
+data:
+{{- if cel "true && false"}}
+  should-not: "be-here"
+{{- else}}
+  banana: "bread"
+{{- end}}

--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -274,6 +274,21 @@ func TestPackage_cel(t *testing.T) {
 			Namespace: ns,
 		}, cm)
 		require.EqualError(t, err, "configmaps \"ignored-cm\" not found")
+
+		// check that "cel-template-cm" was templated correctly
+		celTemplateCm := &v1.ConfigMap{}
+		err = Client.Get(ctx, client.ObjectKey{
+			Name:      "cel-template-cm",
+			Namespace: ns,
+		}, celTemplateCm)
+		require.NoError(t, err)
+
+		v, ok := celTemplateCm.Data["banana"]
+		require.True(t, ok)
+		assert.Equal(t, "bread", v)
+
+		_, ok = celTemplateCm.Data["should-not"]
+		assert.False(t, ok)
 	}
 
 	testNamespacedAndCluster(t, meta, spec, postCheck)

--- a/internal/packages/internal/packagerender/template_test.go
+++ b/internal/packages/internal/packagerender/template_test.go
@@ -32,7 +32,8 @@ func TestRenderTemplates(t *testing.T) {
 			"test.yml.gotmpl":  template,
 		}
 		pkg := &packagetypes.Package{
-			Files: fm,
+			Files:    fm,
+			Manifest: &manifests.PackageManifest{},
 		}
 
 		ctx := context.Background()
@@ -61,7 +62,8 @@ func TestRenderTemplates(t *testing.T) {
 			"test.yaml.gotmpl": template,
 		}
 		pkg := &packagetypes.Package{
-			Files: fm,
+			Files:    fm,
+			Manifest: &manifests.PackageManifest{},
 		}
 
 		ctx := context.Background()
@@ -85,11 +87,91 @@ func TestRenderTemplates(t *testing.T) {
 			"test.yaml.gotmpl": template,
 		}
 		pkg := &packagetypes.Package{
-			Files: fm,
+			Files:    fm,
+			Manifest: &manifests.PackageManifest{},
 		}
 
 		ctx := context.Background()
 		err := RenderTemplates(ctx, pkg, tmplCtx)
 		require.Error(t, err)
 	})
+}
+
+func TestRenderTemplates_CelFunction(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		tmplCtx    packagetypes.PackageRenderContext
+		conditions []manifests.PackageManifestNamedCondition
+		template   string
+		result     string
+		err        error
+	}{
+		{
+			name:     "if else with cel",
+			template: `{{if cel "true && false"}}then{{else}}else{{end}}`,
+			result:   "else",
+		},
+		{
+			name: "context construction error",
+			conditions: []manifests.PackageManifestNamedCondition{
+				{
+					Name:       "invalid",
+					Expression: "invalid",
+				},
+			},
+			template: `{{cel "cond.invalid"}}`,
+			err:      errConstructingCelContext,
+		},
+		{
+			name: "reusable condition",
+			conditions: []manifests.PackageManifestNamedCondition{
+				{
+					Name:       "test_condition",
+					Expression: "true && false",
+				},
+			},
+			template: `{{cel "cond.test_condition"}}`,
+			result:   "false",
+		},
+		{
+			name: "template context access",
+			tmplCtx: packagetypes.PackageRenderContext{
+				Config: map[string]any{
+					"banana": "bread",
+				},
+			},
+			template: `{{cel ".config.banana == \"bread\""}}`,
+			result:   "true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fm := packagetypes.Files{
+				"test.yaml.gotmpl": []byte(tc.template),
+			}
+			pkg := &packagetypes.Package{
+				Files: fm,
+				Manifest: &manifests.PackageManifest{
+					Spec: manifests.PackageManifestSpec{
+						Filters: manifests.PackageManifestFilter{
+							Conditions: tc.conditions,
+						},
+					},
+				},
+			}
+
+			ctx := context.Background()
+			err := RenderTemplates(ctx, pkg, tc.tmplCtx)
+
+			if tc.err == nil {
+				require.NoError(t, err)
+				assert.Equal(t, tc.result, string(fm["test.yaml"]))
+			} else {
+				assert.ErrorIs(t, err, tc.err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Summary
Adds a helper function to go-templates that evaluates CEL expressions. It has access to the full template context and
can utilize reusable CEL expressions.

### Change Type
New Feature

### Jira
[PKO-69](https://issues.redhat.com/browse/PKO-69)

### Testing
- Unit tests.
- Local testing:

Added `templated-cm.yaml.gotmpl` to a package:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: templated-cm
  annotations:
    package-operator.run/phase: deploy
data:
{{if cel "true && false"}}
  should-not: "be-here"
{{else}}
  banana: "bread"
{{end}}
```
After deploying the package:
```bash
$ kubectl get cm templated-cm -o yaml
apiVersion: v1
data:
  banana: bread
kind: ConfigMap
metadata:
  name: templated-cm
  namespace: default
...
```

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
