### PR TITLE
[PKO-60] Do not attempt to overwrite full object on teardown of object which we don't control anymore

### DIFF
--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
+
+	"k8s.io/utils/ptr"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -17,7 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"pkg.package-operator.run/cardboard/kubeutils/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"package-operator.run/internal/constants"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
@@ -293,4 +299,69 @@ func TestPackage_nonExistent(t *testing.T) {
 	err := Client.Get(ctx, client.ObjectKey{Name: "non-existent", Namespace: "default"}, existingPackage)
 	require.NoError(t, err)
 	require.Equal(t, "ImagePullBackOff", existingPackage.Status.Conditions[0].Reason)
+}
+
+func TestPackage_internalObject_teardown(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+	meta := metav1.ObjectMeta{
+		Name: "success",
+	}
+	spec := corev1alpha1.PackageSpec{
+		Image: SuccessTestPackageImage,
+		Config: &runtime.RawExtension{
+			Raw: []byte(fmt.Sprintf(`{"testStubImage": "%s"}`, TestStubImage)),
+		},
+	}
+	pkg := newPackage(meta, spec, true)
+	requireDeployPackage(ctx, t, pkg, &corev1alpha1.ObjectDeployment{})
+	// Test if environment information is injected successfully.
+	deploy := &appsv1.Deployment{}
+	err := Client.Get(ctx, client.ObjectKey{
+		Name:      "test-stub-success",
+		Namespace: "default",
+	}, deploy)
+	require.NoError(t, err)
+	cleanupOnSuccess(ctx, t, deploy)
+	var env manifestsv1alpha1.PackageEnvironment
+	te := deploy.Annotations["test-environment"]
+	err = json.Unmarshal([]byte(te), &env)
+	require.NoError(t, err)
+	assert.NotEmpty(t, env.Kubernetes.Version)
+	deploy.OwnerReferences[0].Controller = ptr.To(false)
+	err = Client.Update(ctx, deploy)
+	require.NoError(t, err)
+	objDeploy := &corev1alpha1.ObjectDeployment{}
+	err = Client.Get(ctx, client.ObjectKey{
+		Name:      "success",
+		Namespace: "default",
+	}, objDeploy)
+	require.NoError(t, err)
+	templateHash := objDeploy.Status.TemplateHash
+	objectSet := &corev1alpha1.ObjectSet{}
+	err = Client.Get(ctx, client.ObjectKey{
+		Name:      "success-" + templateHash,
+		Namespace: "default",
+	}, objectSet)
+	require.NoError(t, err)
+	require.NoError(t, Client.Delete(ctx, objectSet))
+	require.NoError(t,
+		Waiter.WaitForObject(
+			ctx, deploy, "internal ownerReference to be removed",
+			func(client.Object) (bool, error) {
+				deploy = &appsv1.Deployment{}
+				err = Client.Get(ctx, client.ObjectKey{
+					Name:      "test-stub-success",
+					Namespace: "default",
+				}, deploy)
+				internalOwner := false
+				for _, own := range deploy.GetOwnerReferences() {
+					if own.Name == "success" {
+						internalOwner = true
+					}
+				}
+				label := deploy.GetLabels()
+				_, exists := label[constants.DynamicCacheLabel]
+				return !internalOwner && !exists, err
+			}, wait.WithTimeout(40*time.Second),
+		))
 }

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -310,7 +310,15 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) {
 			Return(false)
 		ownerStrategy.
 			On("IsOwner", ownerObj, currentObj).
+			Return(true)
+
+		ownerStrategy.
+			On("RemoveOwner", ownerObj, currentObj).
 			Return(false)
+
+		testClient.
+			On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
 
 		ctx := context.Background()
 		done, err := r.TeardownPhase(ctx, owner, corev1alpha1.ObjectSetTemplatePhase{
@@ -328,6 +336,8 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) {
 		// It's super important that we don't check ownership on desiredObj on accident, because that will always return true.
 		ownerStrategy.AssertCalled(t, "IsController", ownerObj, currentObj)
 		ownerStrategy.AssertCalled(t, "IsOwner", ownerObj, currentObj)
+		ownerStrategy.AssertCalled(t, "RemoveOwner", ownerObj, currentObj)
+		testClient.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
Update the way to patch the object by removing `ownerReference` of the teardown external object
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
This resolves the https://issues.redhat.com/browse/PKO-60 
### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
Bug fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
```
=== RUN   TestPackage_externalObject_teardown
    wait.go:153: "level"=0 "msg"="waiting 40s on package-operator.run/v1alpha1, Kind=Package default/success to report condition \"Unpacked\"=\"True\"..."
    wait.go:153: "level"=0 "msg"="waiting 40s on package-operator.run/v1alpha1, Kind=Package default/success to report condition \"my-prefix/Progressing\"=\"True\"..."
    wait.go:153: "level"=0 "msg"="waiting 40s on package-operator.run/v1alpha1, Kind=Package default/success to report condition \"Available\"=\"True\"..."
    wait.go:153: "level"=0 "msg"="waiting 20s on package-operator.run/v1alpha1, Kind=ObjectSet default/external to report condition \"Available\"=\"True\"..."
    wait.go:153: "level"=0 "msg"="waiting 15s on apps/v1, Kind=Deployment default/test-stub-success external ownerReference to be removed..."
    wait.go:193: "level"=0 "msg"="waiting 20s for package-operator.run/v1alpha1, Kind=ObjectSet default/external to be gone..."
    wait.go:193: "level"=0 "msg"="waiting 20s for package-operator.run/v1alpha1, Kind=Package default/success to be gone..."
--- PASS: TestPackage_externalObject_teardown (17.28s)
PASS
```
