### PR TITLE
Implement support for passing structured api types directly to dynamicClient methods.

### DIFF
--- a/internal/dynamiccache/cache.go
+++ b/internal/dynamiccache/cache.go
@@ -137,7 +137,7 @@ func (c *Cache) OwnersForGKV(gvk schema.GroupVersionKind) []OwnerReference {
 func (c *Cache) Watch(
 	ctx context.Context, owner client.Object, obj runtime.Object,
 ) error {
-	obj, _, err := ensureUnstructured(obj)
+	uns, _, err := ensureUnstructured(obj)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (c *Cache) Watch(
 			"ownerNamespace", owner.GetNamespace())
 
 		// Create/Get Informer
-		informer, _, err := c.informerMap.Get(ctx, gvk, obj)
+		informer, _, err := c.informerMap.Get(ctx, gvk, uns)
 		if err != nil {
 			return fmt.Errorf("getting informer from InformerMap: %w", err)
 		}

--- a/internal/dynamiccache/cache.go
+++ b/internal/dynamiccache/cache.go
@@ -137,7 +137,7 @@ func (c *Cache) OwnersForGKV(gvk schema.GroupVersionKind) []OwnerReference {
 func (c *Cache) Watch(
 	ctx context.Context, owner client.Object, obj runtime.Object,
 ) error {
-	uns, _, err := ensureUnstructured(obj)
+	uns, _, err := ensureUnstructured(obj, c.scheme)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (c *Cache) Get(
 	key client.ObjectKey, out client.Object,
 	opts ...client.GetOption,
 ) error {
-	uns, wasConverted, err := ensureUnstructured(out)
+	uns, wasConverted, err := ensureUnstructured(out, c.scheme)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (c *Cache) list(
 	ctx context.Context,
 	out client.ObjectList, opts ...client.ListOption,
 ) error {
-	uns, wasConverted, err := ensureUnstructuredList(out)
+	uns, wasConverted, err := ensureUnstructuredList(out, c.scheme)
 	if err != nil {
 		return err
 	}

--- a/internal/dynamiccache/cache_test.go
+++ b/internal/dynamiccache/cache_test.go
@@ -100,7 +100,7 @@ func TestCache_Watch(t *testing.T) {
 		informerMap.AssertCalled(t, "Get", mock.Anything, schema.GroupVersionKind{
 			Kind:    "Secret",
 			Version: "v1",
-		}, obj, mock.Anything)
+		}, mock.IsType(&unstructured.Unstructured{}))
 		cacheSource.AssertCalled(t, "handleNewInformer", mock.Anything)
 	})
 
@@ -199,7 +199,7 @@ func TestCache_Reader(t *testing.T) {
 		err = c.Get(ctx, key, obj)
 		require.NoError(t, err)
 
-		reader.AssertCalled(t, "Get", mock.Anything, key, obj, mock.Anything)
+		reader.AssertCalled(t, "Get", mock.Anything, key, mock.IsType(&unstructured.Unstructured{}), mock.Anything)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestCache_Reader(t *testing.T) {
 		err = c.List(ctx, obj)
 		require.NoError(t, err)
 
-		reader.AssertCalled(t, "List", mock.Anything, obj, mock.Anything)
+		reader.AssertCalled(t, "List", mock.Anything, mock.IsType(&unstructured.UnstructuredList{}), mock.Anything)
 	})
 
 	// "reset" informerReferences to test error case,

--- a/internal/dynamiccache/convert.go
+++ b/internal/dynamiccache/convert.go
@@ -64,5 +64,17 @@ func toStructured(in *unstructured.Unstructured, out runtime.Object) error {
 }
 
 func toStructuredList(in *unstructured.UnstructuredList, out client.ObjectList) error {
+	// This function contains separate handling different storage locations of the list imems.
+	// The only other workaround I found, was marshaling the unstructured input into
+	// json/yaml and then remarshaling into `out`.
+
+	if len(in.Items) != 0 {
+		// The conversion input MUST be supplied via `in.UnstructuredContent()`,
+		// because the list items are in `in.Items` and not in `in.Object["items"]`.
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(in.UnstructuredContent(), out)
+	}
+
+	// The conversion input MUST be supplied via `in.Object`,
+	// because the list items are in `in.Object["items"]`.
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(in.Object, out)
 }

--- a/internal/dynamiccache/convert.go
+++ b/internal/dynamiccache/convert.go
@@ -1,0 +1,49 @@
+package dynamiccache
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Ensures that the given `obj` is an *unstructured.Unstructured,
+// by passing `obj` through `runtime.DefaultUnstructuredConverter` if needed.
+// The returned bool signals if the given object had to be converted or not.
+func ensureUnstructured(obj runtime.Object) (*unstructured.Unstructured, bool, error) {
+	if uns, ok := obj.(*unstructured.Unstructured); ok {
+		return uns, false, nil
+	}
+
+	uns, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, false, fmt.Errorf("converting to unstructured: %w", err)
+	}
+
+	return &unstructured.Unstructured{Object: uns}, true, nil
+}
+
+// Ensures that the given `list` is an *unstructured.UnstructuredList,
+// by passing `list` through `runtime.DefaultUnstructuredConverter` if needed.
+// The returned bool signals if the given list had to be converted or not.
+func ensureUnstructuredList(list client.ObjectList) (*unstructured.UnstructuredList, bool, error) {
+	if uns, ok := list.(*unstructured.UnstructuredList); ok {
+		return uns, false, nil
+	}
+
+	uns, err := runtime.DefaultUnstructuredConverter.ToUnstructured(list)
+	if err != nil {
+		return nil, false, fmt.Errorf("converting to unstructured: %w", err)
+	}
+
+	return &unstructured.UnstructuredList{Object: uns}, true, nil
+}
+
+func toStructured(in *unstructured.Unstructured, out runtime.Object) error {
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(in.Object, out)
+}
+
+func toStructuredList(in *unstructured.UnstructuredList, out client.ObjectList) error {
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(in.Object, out)
+}

--- a/internal/dynamiccache/convert.go
+++ b/internal/dynamiccache/convert.go
@@ -6,38 +6,57 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // Ensures that the given `obj` is an *unstructured.Unstructured,
 // by passing `obj` through `runtime.DefaultUnstructuredConverter` if needed.
 // The returned bool signals if the given object had to be converted or not.
-func ensureUnstructured(obj runtime.Object) (*unstructured.Unstructured, bool, error) {
+func ensureUnstructured(obj runtime.Object, scheme *runtime.Scheme) (*unstructured.Unstructured, bool, error) {
 	if uns, ok := obj.(*unstructured.Unstructured); ok {
 		return uns, false, nil
 	}
 
-	uns, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, false, fmt.Errorf("getting GVK for object: %w", err)
+	}
+
+	unsMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, false, fmt.Errorf("converting to unstructured: %w", err)
 	}
 
-	return &unstructured.Unstructured{Object: uns}, true, nil
+	uns := &unstructured.Unstructured{Object: unsMap}
+	uns.SetGroupVersionKind(gvk)
+
+	return uns, true, nil
 }
 
 // Ensures that the given `list` is an *unstructured.UnstructuredList,
 // by passing `list` through `runtime.DefaultUnstructuredConverter` if needed.
 // The returned bool signals if the given list had to be converted or not.
-func ensureUnstructuredList(list client.ObjectList) (*unstructured.UnstructuredList, bool, error) {
+func ensureUnstructuredList(list client.ObjectList, scheme *runtime.Scheme) (
+	*unstructured.UnstructuredList, bool, error,
+) {
 	if uns, ok := list.(*unstructured.UnstructuredList); ok {
 		return uns, false, nil
 	}
 
-	uns, err := runtime.DefaultUnstructuredConverter.ToUnstructured(list)
+	gvk, err := apiutil.GVKForObject(list, scheme)
+	if err != nil {
+		return nil, false, fmt.Errorf("getting GVK for object list: %w", err)
+	}
+
+	unsMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(list)
 	if err != nil {
 		return nil, false, fmt.Errorf("converting to unstructured: %w", err)
 	}
 
-	return &unstructured.UnstructuredList{Object: uns}, true, nil
+	uns := &unstructured.UnstructuredList{Object: unsMap}
+	uns.SetGroupVersionKind(gvk)
+
+	return uns, true, nil
 }
 
 func toStructured(in *unstructured.Unstructured, out runtime.Object) error {

--- a/internal/dynamiccache/convert_test.go
+++ b/internal/dynamiccache/convert_test.go
@@ -95,7 +95,7 @@ func TestToStructured(t *testing.T) {
 	assert.Equal(t, name, secret.Name)
 }
 
-func TestToStructuredList(t *testing.T) {
+func TestToStructuredList_DataInMap(t *testing.T) {
 	t.Parallel()
 
 	uns := &unstructured.UnstructuredList{Object: map[string]any{
@@ -113,5 +113,31 @@ func TestToStructuredList(t *testing.T) {
 	err := toStructuredList(uns, secretList)
 
 	require.NoError(t, err)
+	require.Len(t, secretList.Items, 1)
+	assert.Equal(t, name, secretList.Items[0].Name)
+}
+
+func TestToStructuredList_DataInItemsField(t *testing.T) {
+	t.Parallel()
+
+	uns := &unstructured.UnstructuredList{
+		Object: map[string]any{},
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]any{
+						"name": name,
+					},
+				},
+			},
+		},
+	}
+	secretList := &v1.SecretList{}
+	err := toStructuredList(uns, secretList)
+
+	require.NoError(t, err)
+	require.Len(t, secretList.Items, 1)
 	assert.Equal(t, name, secretList.Items[0].Name)
 }

--- a/internal/dynamiccache/convert_test.go
+++ b/internal/dynamiccache/convert_test.go
@@ -1,0 +1,107 @@
+package dynamiccache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestEnsureUnstructured(t *testing.T) {
+	t.Parallel()
+
+	name := "foo"
+	// Passing a secret object yields an unstructured with the same data.
+	uns, wasConverted, err := ensureUnstructured(&v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &unstructured.Unstructured{}, uns)
+	assert.True(t, wasConverted)
+	// Assert that name was carried over.
+	actualName := uns.Object["metadata"].(map[string]any)["name"].(string)
+	assert.Equal(t, name, actualName)
+
+	// Passing an unstructed object yiels the same unstructured.
+	in := &unstructured.Unstructured{}
+	uns, wasConverted, err = ensureUnstructured(in)
+	require.NoError(t, err)
+	assert.IsType(t, &unstructured.Unstructured{}, uns)
+	assert.False(t, wasConverted)
+	assert.Same(t, in, uns)
+}
+
+func TestEnsureUnstructuredList(t *testing.T) {
+	t.Parallel()
+
+	name := "foo"
+	// Passing a secret object list yields an unstructured with the same data.
+	uns, wasConverted, err := ensureUnstructuredList(&v1.SecretList{
+		Items: []v1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &unstructured.UnstructuredList{}, uns)
+	assert.True(t, wasConverted)
+	// Assert that name was carried over.
+	actualName := uns.Object["items"].([]any)[0].(map[string]any)["metadata"].(map[string]any)["name"].(string)
+	assert.Equal(t, name, actualName)
+
+	// Passing an unstructed object yiels the same unstructured.
+	in := &unstructured.UnstructuredList{}
+	uns, wasConverted, err = ensureUnstructuredList(in)
+	require.NoError(t, err)
+	assert.IsType(t, &unstructured.UnstructuredList{}, uns)
+	assert.False(t, wasConverted)
+	assert.Same(t, in, uns)
+}
+
+func TestToStructured(t *testing.T) {
+	t.Parallel()
+
+	name := "foo"
+	uns := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name": name,
+		},
+	}}
+	secret := &v1.Secret{}
+	err := toStructured(uns, secret)
+
+	require.NoError(t, err)
+	assert.Equal(t, name, secret.Name)
+}
+
+func TestToStructuredList(t *testing.T) {
+	t.Parallel()
+
+	name := "foo"
+	uns := &unstructured.UnstructuredList{Object: map[string]any{
+		"items": []any{
+			map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]any{
+					"name": name,
+				},
+			},
+		},
+	}}
+	secretList := &v1.SecretList{}
+	err := toStructuredList(uns, secretList)
+
+	require.NoError(t, err)
+	assert.Equal(t, name, secretList.Items[0].Name)
+}

--- a/internal/dynamiccache/convert_test.go
+++ b/internal/dynamiccache/convert_test.go
@@ -10,10 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const name = "foo"
+
 func TestEnsureUnstructured(t *testing.T) {
 	t.Parallel()
 
-	name := "foo"
 	// Passing a secret object yields an unstructured with the same data.
 	uns, wasConverted, err := ensureUnstructured(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -39,7 +40,6 @@ func TestEnsureUnstructured(t *testing.T) {
 func TestEnsureUnstructuredList(t *testing.T) {
 	t.Parallel()
 
-	name := "foo"
 	// Passing a secret object list yields an unstructured with the same data.
 	uns, wasConverted, err := ensureUnstructuredList(&v1.SecretList{
 		Items: []v1.Secret{
@@ -69,7 +69,6 @@ func TestEnsureUnstructuredList(t *testing.T) {
 func TestToStructured(t *testing.T) {
 	t.Parallel()
 
-	name := "foo"
 	uns := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Secret",
@@ -87,7 +86,6 @@ func TestToStructured(t *testing.T) {
 func TestToStructuredList(t *testing.T) {
 	t.Parallel()
 
-	name := "foo"
 	uns := &unstructured.UnstructuredList{Object: map[string]any{
 		"items": []any{
 			map[string]any{


### PR DESCRIPTION
Since the dynamic cache works with unstructured objects under the hood, it got confused when a program tried to pass a structured api type to `.Watch`, `.Get` or `.List`.

This change implements conversion from structured into unstructured types at incoming boundaries and (if needed) back from unstructured to structured types at outgoing boundaries.

It should explicitly not change any existing behavior of the dynamic cache APIs and thus package-operator as a whole.

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
