### PR TITLE
[PKO-160] Unset KUBECONFIG variable in unit test

### DIFF
--- a/cmd/package-operator-manager/components/components_test.go
+++ b/cmd/package-operator-manager/components/components_test.go
@@ -36,7 +36,7 @@ func TestUncachedClient(t *testing.T) {
 }
 
 func TestProvideRestConfig(t *testing.T) {
-	t.Parallel()
+	t.Setenv("KUBECONFIG", "")
 
 	_, err := ProvideRestConfig()
 	require.EqualError(t, err, "invalid configuration: no configuration has been provided"+


### PR DESCRIPTION
### Summary
Fixes a unit test. The bug is described in [PKO-160](https://issues.redhat.com/browse/PKO-160)

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
