### PR TITLE
ensure uniform logs for "processing dynamic cache event" across controllers

### DIFF
--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -325,6 +325,15 @@ func (c *GenericObjectSetPhaseController) SetupWithManager(
 		WatchesRawSource(
 			c.dynamicCache.Source(
 				c.ownerStrategy.EnqueueRequestForOwner(objectSetPhase, mgr.GetRESTMapper(), false),
+				predicate.NewPredicateFuncs(func(object client.Object) bool {
+					c.log.Info(
+						"processing dynamic cache event",
+						"gvk", object.GetObjectKind().GroupVersionKind(),
+						"object", client.ObjectKeyFromObject(object),
+						"owners", object.GetOwnerReferences(),
+					)
+					return true
+				}),
 			),
 		).Complete(c)
 }

--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -166,8 +166,10 @@ func (c *GenericObjectSetController) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.NewPredicateFuncs(func(object client.Object) bool {
 					c.log.Info(
 						"processing dynamic cache event",
+						"gvk", object.GetObjectKind().GroupVersionKind(),
 						"object", client.ObjectKeyFromObject(object),
-						"owners", object.GetOwnerReferences())
+						"owners", object.GetOwnerReferences(),
+					)
 					return true
 				}),
 			),

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -187,6 +187,15 @@ func (c *GenericObjectTemplateController) SetupWithManager(
 		WatchesRawSource(
 			c.dynamicCache.Source(
 				dynamiccache.NewEnqueueWatchingObjects(c.dynamicCache, objectTemplate, mgr.GetScheme()),
+				predicate.NewPredicateFuncs(func(object client.Object) bool {
+					c.log.Info(
+						"processing dynamic cache event",
+						"gvk", object.GetObjectKind().GroupVersionKind(),
+						"object", client.ObjectKeyFromObject(object),
+						"owners", object.GetOwnerReferences(),
+					)
+					return true
+				}),
 			),
 		).
 		Complete(c)


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This change ensures that all dynamiccache event sources log the same metadata about the object that triggered the event.

```go
c.log.Info(
	"processing dynamic cache event",
	"gvk", object.GetObjectKind().GroupVersionKind(),
	"object", client.ObjectKeyFromObject(object),
	"owners", object.GetOwnerReferences(),
)
```

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
