### PR TITLE
fix: store package image tarballs in .cache/packages/<name> instead of the source directory

### DIFF
--- a/config/packages/.gitignore
+++ b/config/packages/.gitignore
@@ -1,1 +1,0 @@
-container.oci.tar


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Before this change, the build system would output the image tarballs into 
`./config/packages/<packageName>/container.oci.tar` instead of `./cache/packages/<packageName>/container.oci.tar`.
We even needed a special `.gitignore` for them in `./config/packages/`.

This PR cleans up.


To test this, you can run any build command that builds the packages (for example `./do dev:create`) and validate that no `container.oci.tar`balls appear under `./config/packages/...` but in the cache folder instead.


### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
(Dev) Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
