### PR TITLE
ref: remove ctx as it's not being used

### DIFF
--- a/internal/controllers/mocks_test.go
+++ b/internal/controllers/mocks_test.go
@@ -70,10 +70,10 @@ type adoptionCheckerMock struct {
 }
 
 func (m *adoptionCheckerMock) Check(
-	ctx context.Context, owner PhaseObjectOwner, obj client.Object, previous []PreviousObjectSet,
+	owner PhaseObjectOwner, obj client.Object, previous []PreviousObjectSet,
 	collisionProtection corev1alpha1.CollisionProtection,
 ) (needsAdoption bool, err error) {
-	args := m.Called(ctx, owner, obj, previous, collisionProtection)
+	args := m.Called(owner, obj, previous, collisionProtection)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -57,7 +57,7 @@ type ownerStrategy interface {
 
 type adoptionChecker interface {
 	Check(
-		ctx context.Context, owner PhaseObjectOwner, obj client.Object,
+		owner PhaseObjectOwner, obj client.Object,
 		previous []PreviousObjectSet,
 		collisionProtection corev1alpha1.CollisionProtection,
 	) (needsAdoption bool, err error)
@@ -677,7 +677,7 @@ func (r *PhaseReconciler) reconcileObject(
 	updatedObj := currentObj.DeepCopy()
 
 	// Check if we can even work on this object or need to adopt it.
-	needsAdoption, err := r.adoptionChecker.Check(ctx, owner, currentObj, previous, collisionProtection)
+	needsAdoption, err := r.adoptionChecker.Check(owner, currentObj, previous, collisionProtection)
 	if err != nil {
 		return nil, err
 	}
@@ -789,8 +789,7 @@ type defaultAdoptionChecker struct {
 }
 
 // Check detects whether an ownership change is needed.
-func (c *defaultAdoptionChecker) Check(
-	_ context.Context, owner PhaseObjectOwner, obj client.Object,
+func (c *defaultAdoptionChecker) Check(owner PhaseObjectOwner, obj client.Object,
 	previous []PreviousObjectSet,
 	collisionProtection corev1alpha1.CollisionProtection,
 ) (needsAdoption bool, err error) {

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -880,9 +880,8 @@ func Test_defaultAdoptionChecker_Check(t *testing.T) {
 
 			test.mockPrepare(os, owner)
 
-			ctx := context.Background()
 			needsAdoption, err := c.Check(
-				ctx, owner, test.object, test.previous, test.collisionProtection)
+				owner, test.object, test.previous, test.collisionProtection)
 			if test.errorAs == nil {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
### Summary
playing w/ the code-base

### Change Type
Refactor

Do you know if we need the context?
(I see we omit when passing the object at first glance)

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

