### PR TITLE
Change trusted-ca-bundle configmap name for hosted-cluster and make the volume mount mandatory

### DIFF
--- a/config/packages/package-operator/components/hosted-cluster/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/components/hosted-cluster/package-operator-manager.Deployment.yaml.gotmpl
@@ -133,8 +133,8 @@ spec:
           items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
-          name: trusted-ca-bundle
-          optional: true
+          name: openshift-config-managed-trusted-ca-bundle
+          optional: false
         name: trusted-ca-bundle
 {{- end}}
 {{- end}}


### PR DESCRIPTION
Issue link: https://issues.redhat.com/browse/PKO-185

This PR fixes the reference to the configmap that is mounted and expected to contain the trusted ca bundle for the pko instance that runs for a hosted-cluster. 

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
