### PR TITLE
[PKO-196] Add Conventional Commits checkbox to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,8 @@
 - [ ] This PR passes all pre-commit hook validations.
 - [ ] This PR is fully tested and regression tests are included.
 - [ ] Relevant documentation has been updated.
+- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+      standard.
 
 ### Additional Information
 


### PR DESCRIPTION
### Summary
As a part of our sprint retro, the team decided to adopt the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) practice to increase the standard of quality of contributions to the PKO project.

To help with this transition, the PR template should be updated to include a new checkbox that will inform our contributors to follow our contributing practices (i.e., Conventional Commits).

### Jira
[PKO-196](https://issues.redhat.com/browse/PKO-196)

### Change Type
New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
