### PR TITLE
[PKO-169] Move repo_test.go to integration tests

### DIFF
--- a/cmd/build/cluster.go
+++ b/cmd/build/cluster.go
@@ -29,6 +29,7 @@ type Cluster struct {
 type clusterConfigLocalRegistry struct {
 	hostOverride string
 	hostPort     int32
+	authHostPort int32
 }
 
 type clusterConfig struct {
@@ -70,10 +71,11 @@ func withRegistryHostOverrideToOtherCluster(host string, targetCluster Cluster) 
 	return withRegistryHostOverride(host, targetCluster.Name()+"-control-plane")
 }
 
-func withLocalRegistry(hostOverride string, hostPort int32) clusterOption {
+func withLocalRegistry(hostOverride string, hostPort int32, authHostPort int32) clusterOption {
 	return func(cc *clusterConfig) {
 		cc.localRegistry = &clusterConfigLocalRegistry{
 			hostPort:     hostPort,
+			authHostPort: authHostPort,
 			hostOverride: hostOverride,
 		}
 	}
@@ -117,6 +119,12 @@ func NewCluster(name string, opts ...clusterOption) Cluster {
 		extraPortMappings = append(extraPortMappings, kindv1alpha4.PortMapping{
 			ContainerPort: 5001,
 			HostPort:      cfg.localRegistry.hostPort,
+			ListenAddress: "127.0.0.1",
+			Protocol:      "TCP",
+		})
+		extraPortMappings = append(extraPortMappings, kindv1alpha4.PortMapping{
+			ContainerPort: 5002,
+			HostPort:      cfg.localRegistry.authHostPort,
 			ListenAddress: "127.0.0.1",
 			Protocol:      "TCP",
 		})

--- a/cmd/build/definitions.go
+++ b/cmd/build/definitions.go
@@ -13,7 +13,8 @@ const (
 	defaultImageRegistry    = "quay.io/package-operator"
 	imageRegistryEnvvarName = "IMAGE_REGISTRY"
 
-	devClusterRegistryPort int32 = 5001
+	devClusterRegistryPort     int32 = 5001
+	devClusterRegistryAuthPort int32 = 5002
 )
 
 // Get image registry to use for tagging and pushing images

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -22,7 +22,7 @@ var (
 	test     Test
 	lint     Lint
 	cluster  = NewCluster("pko",
-		withLocalRegistry(imageRegistryHost(), devClusterRegistryPort),
+		withLocalRegistry(imageRegistryHost(), devClusterRegistryPort, devClusterRegistryAuthPort),
 		withNodeLabels(map[string]string{"hypershift-affinity-test-label": "true"}),
 	)
 	hypershiftHostedCluster = NewCluster("pko-hs-hc",

--- a/cmd/build/test.go
+++ b/cmd/build/test.go
@@ -97,6 +97,7 @@ func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) e
 
 	env := sh.WithEnvironment{
 		"CGO_ENABLED":                          "1",
+		"PKO_TEST_VERSION":                     appVersion,
 		"PKO_TEST_SUCCESS_PACKAGE_IMAGE":       imageURL(imageRegistry(), "test-stub-package", appVersion),
 		"PKO_TEST_SUCCESS_MULTI_PACKAGE_IMAGE": imageURL(imageRegistry(), "test-stub-multi-package", appVersion),
 		"PKO_TEST_SUCCESS_CEL_PACKAGE_IMAGE":   imageURL(imageRegistry(), "test-stub-cel-package", appVersion),

--- a/config/local-registry.yaml
+++ b/config/local-registry.yaml
@@ -41,6 +41,8 @@ metadata:
   namespace: dev-registry
 type: Opaque
 stringData:
+  # username: registry
+  # password: foobar
   htpasswd: |
     registry:$2y$05$tXrX0My2D/qIQAUIb7472u.ahWdG5eHp6FkSu9eyjRQCfciwAIt7a
 ---

--- a/config/local-registry.yaml
+++ b/config/local-registry.yaml
@@ -3,6 +3,47 @@ kind: Namespace
 metadata:
   name: dev-registry
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-registry-proxy-config
+  namespace: dev-registry
+data:
+  nginx.conf: |
+    events {
+      worker_connections 1024;
+    }
+    http {
+      upstream registry {
+        server localhost:5000;
+      }
+
+      server {
+        listen 5080;
+
+        location / {
+          auth_basic "Registry realm";
+          auth_basic_user_file /etc/nginx/htpasswd/htpasswd;
+
+          proxy_pass http://registry;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-htpasswd
+  namespace: dev-registry
+type: Opaque
+stringData:
+  htpasswd: |
+    registry:$2y$05$tXrX0My2D/qIQAUIb7472u.ahWdG5eHp6FkSu9eyjRQCfciwAIt7a
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,6 +70,26 @@ spec:
         ports:
         - containerPort: 5000
           hostPort: 5001
+
+      - image: nginx:alpine
+        name: nginx-auth-proxy
+        ports:
+          - containerPort: 5080
+            hostPort: 5002
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          - name: htpasswd
+            mountPath: /etc/nginx/htpasswd
+
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-registry-proxy-config
+      - name: htpasswd
+        secret:
+          secretName: registry-htpasswd
 ---
 apiVersion: v1
 kind: Service
@@ -39,10 +100,16 @@ metadata:
   namespace: dev-registry
 spec:
   ports:
-  - port: 5001
+  - name: plain
+    port: 5001
     protocol: TCP
     targetPort: 5000
     nodePort: 31320
+  - name: authenticated
+    port: 5002
+    protocol: TCP
+    targetPort: 5080
+    nodePort: 31321
   selector:
     app: dev-registry
   type: NodePort

--- a/integration/kubectl-package/repo_test.go
+++ b/integration/kubectl-package/repo_test.go
@@ -1,4 +1,6 @@
-package repocmd
+//go:build integration
+
+package kubectlpackage
 
 import (
 	"bytes"
@@ -7,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"package-operator.run/cmd/kubectl-package/repocmd"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 
@@ -195,7 +199,7 @@ func TestRepoCmdMalformedParams(t *testing.T) {
 }
 
 func newCmd(args ...string) *cobra.Command {
-	cmd := NewCmd()
+	cmd := repocmd.NewCmd()
 	cmd.SetArgs(args)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary

[JIRA Task](https://issues.redhat.com/browse/PKO-169)

#### Existing issues
* `repo_test.go` was included as unit test but is in fact an integration test because it tries to connect to an external registry (originally `quay.io`).
* the test could produce different results if the user running it was logged or not to `quay.io`.

#### What this PR does
* Move `repo_test.go` under integration tests.
* Configure `repo_test.go` to use the KinD internal registry (that we already configure) instead of `quay.io`.
* Expand the internal registry configuration adding a proxy that enables authentication, while keeping the old usage intact (`localhost:5001` still points to the plain registry, `localhost:5002` points to the authenticated registry via proxy). This allows to test unauthenticated access.

#### Out of scope
* `repo_test.go` is written with the standard test structure, while other tests in `integration/kubectl-package` uses the `ginkgo` library. Translating `repo_test.go` to run with `ginkgo` is out of scope for this PR. The test is working properly and the translation can be done in a separate task to make reviewing easier.

<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
