### PR TITLE
Explore adding condition printercolumns

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,6 +117,9 @@ issues:
   exclude-dirs:
   - internal/packages/internal/packagekickstart/rukpak
   exclude-rules:
+  - linters:
+    - lll
+    source: "^//( ?)[+]kubebuilder"
   # Integration tests MUST NOT run in parallel.
   - path: 'integration\/.+\.go'
     linters: [paralleltest]

--- a/apis/core/v1alpha1/clusterobjectdeployment_types.go
+++ b/apis/core/v1alpha1/clusterobjectdeployment_types.go
@@ -38,6 +38,8 @@ type ClusterObjectDeploymentStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjdeploy","cod"}
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/clusterobjectdeployment_types.go
+++ b/apis/core/v1alpha1/clusterobjectdeployment_types.go
@@ -39,6 +39,7 @@ type ClusterObjectDeploymentStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjdeploy","cod"}
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectDeployment struct {

--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -17,9 +17,10 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 // +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
-// +kubebuilder:printcolumn:name="Archived",type=string,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
-// +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
-// +kubebuilder:printcolumn:name="InTransition",type=string,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
+// +kubebuilder:printcolumn:name="Archived",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
+// +kubebuilder:printcolumn:name="Succeeded",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
+// +kubebuilder:printcolumn:name="InTransition",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectSet struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -15,6 +15,11 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjset","cos"}
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
+// +kubebuilder:printcolumn:name="Archived",type=string,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
+// +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
+// +kubebuilder:printcolumn:name="InTransition",type=string,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectSet struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -38,8 +43,6 @@ type ClusterObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
-//
-//nolint:lll
 type ClusterObjectSetSpec struct {
 	// Specifies the lifecycle state of the ClusterObjectSet.
 	// +kubebuilder:default="Active"

--- a/apis/core/v1alpha1/clusterobjectsetphase_types.go
+++ b/apis/core/v1alpha1/clusterobjectsetphase_types.go
@@ -8,6 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjsetphase","cosp"}
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectSetPhase struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -28,8 +30,6 @@ type ClusterObjectSetPhaseList struct {
 // ClusterObjectSetPhaseSpec defines the desired state of a ClusterObjectSetPhase.
 // +kubebuilder:validation:XValidation:rule="has(self.previous) == has(oldSelf.previous)", message="previous is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.availabilityProbes) == has(oldSelf.availabilityProbes)", message="availabilityProbes is immutable"
-//
-//nolint:lll
 type ClusterObjectSetPhaseSpec struct {
 	// Disables reconciliation of the ClusterObjectSet.
 	// Only Status updates will still be propagated, but object changes will not be reconciled.

--- a/apis/core/v1alpha1/clusterobjectsetphase_types.go
+++ b/apis/core/v1alpha1/clusterobjectsetphase_types.go
@@ -10,6 +10,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 // +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterObjectSetPhase struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/clusterobjecttemplate_types.go
+++ b/apis/core/v1alpha1/clusterobjecttemplate_types.go
@@ -8,6 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName={"clobjtmpl","cot"}
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="package-operator.run/Invalid")].status`
 type ClusterObjectTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core/v1alpha1/clusterpackage_types.go
+++ b/apis/core/v1alpha1/clusterpackage_types.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
 // +kubebuilder:printcolumn:name="Unpacked",type=string,JSONPath=`.status.conditions[?(@.type=="Unpacked")].status`
 // +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="Invalid")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterPackage struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/clusterpackage_types.go
+++ b/apis/core/v1alpha1/clusterpackage_types.go
@@ -9,6 +9,10 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=clpkg
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Unpacked",type=string,JSONPath=`.status.conditions[?(@.type=="Unpacked")].status`
+// +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="Invalid")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterPackage struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/objectdeployment_types.go
+++ b/apis/core/v1alpha1/objectdeployment_types.go
@@ -4,7 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ObjectDeploymentSpec defines the desired state of a ObjectDeployment.
+// ObjectDeploymentSpec defines the desired state of an ObjectDeployment.
 type ObjectDeploymentSpec struct {
 	// Number of old revisions in the form of archived ObjectSets to keep.
 	// +kubebuilder:default=10
@@ -23,7 +23,7 @@ type ObjectSetTemplate struct {
 	Spec ObjectSetTemplateSpec `json:"spec"`
 }
 
-// ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
+// ObjectDeploymentStatus defines the observed state of an ObjectDeployment.
 type ObjectDeploymentStatus struct {
 	// Conditions is a list of status conditions ths object is in.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -64,6 +64,8 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={"objdeploy","od"}
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/objectdeployment_types.go
+++ b/apis/core/v1alpha1/objectdeployment_types.go
@@ -66,6 +66,7 @@ const (
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 // +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -19,9 +19,10 @@ import (
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 // +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
-// +kubebuilder:printcolumn:name="Archived",type=string,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
-// +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
-// +kubebuilder:printcolumn:name="InTransition",type=string,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
+// +kubebuilder:printcolumn:name="Archived",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
+// +kubebuilder:printcolumn:name="Succeeded",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
+// +kubebuilder:printcolumn:name="InTransition",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectSet struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -17,6 +17,11 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={"objset","os"}
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
+// +kubebuilder:printcolumn:name="Archived",type=string,JSONPath=`.status.conditions[?(@.type=="Archived")].status`
+// +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
+// +kubebuilder:printcolumn:name="InTransition",type=string,JSONPath=`.status.conditions[?(@.type=="InTransition")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectSet struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -40,8 +45,6 @@ type ObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
-//
-//nolint:lll
 type ObjectSetSpec struct {
 	// Specifies the lifecycle state of the ObjectSet.
 	// +kubebuilder:default="Active"

--- a/apis/core/v1alpha1/objectsetphase_types.go
+++ b/apis/core/v1alpha1/objectsetphase_types.go
@@ -9,6 +9,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:resource:shortName={"objsetphase","osp"}
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 // +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectSetPhase struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/objectsetphase_types.go
+++ b/apis/core/v1alpha1/objectsetphase_types.go
@@ -7,6 +7,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={"objsetphase","osp"}
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Paused",type=string,JSONPath=`.status.conditions[?(@.type=="Paused")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectSetPhase struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -27,8 +29,6 @@ type ObjectSetPhaseList struct {
 // ObjectSetPhaseSpec defines the desired state of a ObjectSetPhase.
 // +kubebuilder:validation:XValidation:rule="has(self.previous) == has(oldSelf.previous)", message="previous is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.availabilityProbes) == has(oldSelf.availabilityProbes)", message="availabilityProbes is immutable"
-//
-//nolint:lll
 type ObjectSetPhaseSpec struct {
 	// Disables reconciliation of the ObjectSet.
 	// Only Status updates will still be propagated, but object changes will not be reconciled.

--- a/apis/core/v1alpha1/objecttemplate_types.go
+++ b/apis/core/v1alpha1/objecttemplate_types.go
@@ -8,6 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={"objtmpl","ot"}
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="package-operator.run/Invalid")].status`
 type ObjectTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core/v1alpha1/package_types.go
+++ b/apis/core/v1alpha1/package_types.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
 // +kubebuilder:printcolumn:name="Unpacked",type=string,JSONPath=`.status.conditions[?(@.type=="Unpacked")].status`
 // +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="Invalid")].status`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Package struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core/v1alpha1/package_types.go
+++ b/apis/core/v1alpha1/package_types.go
@@ -9,6 +9,10 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=pkg
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Unpacked",type=string,JSONPath=`.status.conditions[?(@.type=="Unpacked")].status`
+// +kubebuilder:printcolumn:name="Invalid",type=string,JSONPath=`.status.conditions[?(@.type=="Invalid")].status`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Package struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crds/package-operator.run_clusterobjectdeployments.yaml
+++ b/config/crds/package-operator.run_clusterobjectdeployments.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Progressing")].status
       name: Progressing
       type: string

--- a/config/crds/package-operator.run_clusterobjectdeployments.yaml
+++ b/config/crds/package-operator.run_clusterobjectdeployments.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_clusterobjectsetphases.yaml
+++ b/config/crds/package-operator.run_clusterobjectsetphases.yaml
@@ -18,6 +18,12 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_clusterobjectsetphases.yaml
+++ b/config/crds/package-operator.run_clusterobjectsetphases.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Paused")].status
       name: Paused
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -21,6 +21,21 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Archived")].status
+      name: Archived
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InTransition")].status
+      name: InTransition
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -29,12 +29,18 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="Archived")].status
       name: Archived
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
       name: Succeeded
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="InTransition")].status
       name: InTransition
+      priority: 1
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crds/package-operator.run_clusterobjecttemplates.yaml
+++ b/config/crds/package-operator.run_clusterobjecttemplates.yaml
@@ -17,7 +17,14 @@ spec:
     singular: clusterobjecttemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="package-operator.run/Invalid")].status
+      name: Invalid
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crds/package-operator.run_clusterpackages.yaml
+++ b/config/crds/package-operator.run_clusterpackages.yaml
@@ -20,6 +20,18 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Unpacked")].status
+      name: Unpacked
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Invalid")].status
+      name: Invalid
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_clusterpackages.yaml
+++ b/config/crds/package-operator.run_clusterpackages.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Invalid")].status
       name: Invalid
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_objectdeployments.yaml
+++ b/config/crds/package-operator.run_objectdeployments.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -47,7 +53,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ObjectDeploymentSpec defines the desired state of a ObjectDeployment.
+            description: ObjectDeploymentSpec defines the desired state of an ObjectDeployment.
             properties:
               revisionHistoryLimit:
                 default: 10
@@ -360,7 +366,7 @@ spec:
           status:
             default:
               phase: Pending
-            description: ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
+            description: ObjectDeploymentStatus defines the observed state of an ObjectDeployment.
             properties:
               collisionCount:
                 description: Count of hash collisions of the ObjectDeployment.

--- a/config/crds/package-operator.run_objectdeployments.yaml
+++ b/config/crds/package-operator.run_objectdeployments.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Progressing")].status
       name: Progressing
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_objectsetphases.yaml
+++ b/config/crds/package-operator.run_objectsetphases.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Paused")].status
       name: Paused
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_objectsetphases.yaml
+++ b/config/crds/package-operator.run_objectsetphases.yaml
@@ -18,6 +18,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -21,6 +21,21 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Archived")].status
+      name: Archived
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InTransition")].status
+      name: InTransition
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -29,12 +29,18 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="Archived")].status
       name: Archived
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
       name: Succeeded
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="InTransition")].status
       name: InTransition
+      priority: 1
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crds/package-operator.run_objecttemplates.yaml
+++ b/config/crds/package-operator.run_objecttemplates.yaml
@@ -17,7 +17,14 @@ spec:
     singular: objecttemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="package-operator.run/Invalid")].status
+      name: Invalid
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crds/package-operator.run_packages.yaml
+++ b/config/crds/package-operator.run_packages.yaml
@@ -20,6 +20,18 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Unpacked")].status
+      name: Unpacked
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Invalid")].status
+      name: Invalid
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crds/package-operator.run_packages.yaml
+++ b/config/crds/package-operator.run_packages.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Invalid")].status
       name: Invalid
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Progressing")].status
       name: Progressing
       type: string

--- a/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
@@ -18,6 +18,12 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Paused")].status
       name: Paused
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -21,6 +21,21 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Archived")].status
+      name: Archived
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InTransition")].status
+      name: InTransition
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -29,12 +29,18 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="Archived")].status
       name: Archived
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
       name: Succeeded
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="InTransition")].status
       name: InTransition
+      priority: 1
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/static-deployment/1-package-operator.run_clusterobjecttemplates.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjecttemplates.yaml
@@ -17,7 +17,14 @@ spec:
     singular: clusterobjecttemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="package-operator.run/Invalid")].status
+      name: Invalid
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/static-deployment/1-package-operator.run_clusterpackages.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterpackages.yaml
@@ -20,6 +20,18 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Unpacked")].status
+      name: Unpacked
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Invalid")].status
+      name: Invalid
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_clusterpackages.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterpackages.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Invalid")].status
       name: Invalid
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_objectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_objectdeployments.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -47,7 +53,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ObjectDeploymentSpec defines the desired state of a ObjectDeployment.
+            description: ObjectDeploymentSpec defines the desired state of an ObjectDeployment.
             properties:
               revisionHistoryLimit:
                 default: 10
@@ -360,7 +366,7 @@ spec:
           status:
             default:
               phase: Pending
-            description: ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
+            description: ObjectDeploymentStatus defines the observed state of an ObjectDeployment.
             properties:
               collisionCount:
                 description: Count of hash collisions of the ObjectDeployment.

--- a/config/static-deployment/1-package-operator.run_objectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_objectdeployments.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Progressing")].status
       name: Progressing
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_objectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsetphases.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Paused")].status
       name: Paused
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_objectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsetphases.yaml
@@ -18,6 +18,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -21,6 +21,21 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Archived")].status
+      name: Archived
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InTransition")].status
+      name: InTransition
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -29,12 +29,18 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="Archived")].status
       name: Archived
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
       name: Succeeded
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="InTransition")].status
       name: InTransition
+      priority: 1
+      type: string
+    - jsonPath: .status.revision
+      name: Revision
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/static-deployment/1-package-operator.run_objecttemplates.yaml
+++ b/config/static-deployment/1-package-operator.run_objecttemplates.yaml
@@ -17,7 +17,14 @@ spec:
     singular: objecttemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="package-operator.run/Invalid")].status
+      name: Invalid
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/static-deployment/1-package-operator.run_packages.yaml
+++ b/config/static-deployment/1-package-operator.run_packages.yaml
@@ -20,6 +20,18 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Unpacked")].status
+      name: Unpacked
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Invalid")].status
+      name: Invalid
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/static-deployment/1-package-operator.run_packages.yaml
+++ b/config/static-deployment/1-package-operator.run_packages.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Invalid")].status
       name: Invalid
       type: string
+    - jsonPath: .status.revision
+      name: Revision
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -390,8 +390,8 @@ status:
 | Field | Description |
 | ----- | ----------- |
 | `metadata` <br>metav1.ObjectMeta |  |
-| `spec` <br><a href="#objectdeploymentspec">ObjectDeploymentSpec</a> | ObjectDeploymentSpec defines the desired state of a ObjectDeployment. |
-| `status` <br><a href="#objectdeploymentstatus">ObjectDeploymentStatus</a> | ObjectDeploymentStatus defines the observed state of a ObjectDeployment. |
+| `spec` <br><a href="#objectdeploymentspec">ObjectDeploymentSpec</a> | ObjectDeploymentSpec defines the desired state of an ObjectDeployment. |
+| `status` <br><a href="#objectdeploymentstatus">ObjectDeploymentStatus</a> | ObjectDeploymentStatus defines the observed state of an ObjectDeployment. |
 
 
 ### ObjectSet
@@ -784,7 +784,7 @@ Used in:
 
 ### ObjectDeploymentSpec
 
-ObjectDeploymentSpec defines the desired state of a ObjectDeployment.
+ObjectDeploymentSpec defines the desired state of an ObjectDeployment.
 
 | Field | Description |
 | ----- | ----------- |
@@ -799,7 +799,7 @@ Used in:
 
 ### ObjectDeploymentStatus
 
-ObjectDeploymentStatus defines the observed state of a ObjectDeployment.
+ObjectDeploymentStatus defines the observed state of an ObjectDeployment.
 
 | Field | Description |
 | ----- | ----------- |


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR adds additional printer columns to the CRDs in our API. In the long run, we will be able to ditch `.status.phase` which we used to convey information to human end users instead of having them look at fine-grained status conditions.

```
kubectl get package cluster-environment 
NAME                  STATUS      AVAILABLE   PROGRESSING   UNPACKED   INVALID   REVISION   AGE
cluster-environment   Available   True        False         True                 1          7s

---

kubectl get objectdeployment cluster-environment
NAME                  STATUS      AVAILABLE   PROGRESSING   REVISION   AGE
cluster-environment   Available   True        False         1          99s

---

kubectl get objectset cluster-environment-77c7f998bd 
NAME                             STATUS      AVAILABLE   PAUSED   ARCHIVED   SUCCEEDED   INTRANSITION   REVISION   AGE
cluster-environment-77c7f998bd   Available   True                            True                       1          11s
```

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
