### PR TITLE
PKO-199 - build(dependabot): assign dependency-maintainers team instead of eqrx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
   allow:
   - dependency-type: all
     dependency-name: "*"
-  assignees: [ eqrx ]
+  reviewers:
+  - package-operator/core-maintainers/dependency-maintainers
   open-pull-requests-limit: 100
 - package-ecosystem: gomod
   directory: /apis
@@ -16,7 +17,8 @@ updates:
   allow:
   - dependency-type: all
     dependency-name: "*"
-  assignees: [ eqrx ]
+  reviewers:
+  - package-operator/core-maintainers/dependency-maintainers
   open-pull-requests-limit: 100
 - package-ecosystem: gomod
   directory: /pkg
@@ -25,11 +27,13 @@ updates:
   allow:
   - dependency-type: all
     dependency-name: "*"
-  assignees: [ eqrx ]
+  reviewers:
+  - package-operator/core-maintainers/dependency-maintainers
   open-pull-requests-limit: 100
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
-  assignees: [ eqrx ]
+  reviewers:
+  - package-operator/core-maintainers/dependency-maintainers
   open-pull-requests-limit: 100


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

Jira issue: https://issues.redhat.com/browse/PKO-199

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Distribute the workload of reviewing dependency updates

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->
Build/Updates



### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### Additional Information

<!-- Report any other relevant details below -->
