### PR TITLE
build(dependabot): fix gomod k8s.io dependency PR update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: gomod
   directory: /apis
   schedule:
@@ -43,7 +48,3 @@ updates:
     interval: daily
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
-  groups:
-    actions:
-      applies-to: version-updates
-      patterns: ["*"]


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Fixes for https://github.com/package-operator/package-operator/pull/1637

I had mistakenly added a wildcard match group to the github-actions update section when I should have added a `k8s.io/*` match group to the root go module section.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->
Build/Dependabot

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
