### PR TITLE
PKO-183: add support to resolve own ServiceAccount and attached ImagePullSecrets to authenticate package image pull requests 

### DIFF
--- a/cmd/build/test.go
+++ b/cmd/build/test.go
@@ -99,6 +99,7 @@ func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) e
 		"CGO_ENABLED":                          "1",
 		"PKO_TEST_VERSION":                     appVersion,
 		"PKO_TEST_SUCCESS_PACKAGE_IMAGE":       imageURL(imageRegistry(), "test-stub-package", appVersion),
+		"PKO_TEST_SUCCESS_PACKAGE_IMAGE_AUTH":  imageURL("dev-registry.dev-registry.svc.cluster.local:5002/package-operator", "test-stub-package", appVersion), //nolint:lll
 		"PKO_TEST_SUCCESS_MULTI_PACKAGE_IMAGE": imageURL(imageRegistry(), "test-stub-multi-package", appVersion),
 		"PKO_TEST_SUCCESS_CEL_PACKAGE_IMAGE":   imageURL(imageRegistry(), "test-stub-cel-package", appVersion),
 		"PKO_TEST_STUB_IMAGE":                  imageURL(imageRegistry(), "test-stub", appVersion),

--- a/cmd/package-operator-manager/components/package.go
+++ b/cmd/package-operator-manager/components/package.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	controllerspackages "package-operator.run/internal/controllers/packages"
@@ -22,8 +23,15 @@ type (
 	}
 )
 
-func ProvideRequestManager(log logr.Logger, opts Options) *packages.RequestManager {
-	return packages.NewRequestManager(prepareRegistryHostOverrides(log, opts.RegistryHostOverrides))
+func ProvideRequestManager(log logr.Logger, uncachedClient UncachedClient, opts Options) *packages.RequestManager {
+	return packages.NewRequestManager(
+		prepareRegistryHostOverrides(log, opts.RegistryHostOverrides),
+		uncachedClient.Client,
+		types.NamespacedName{
+			Namespace: opts.ServiceAccountNamespace,
+			Name:      opts.ServiceAccountName,
+		},
+	)
 }
 
 func prepareRegistryHostOverrides(log logr.Logger, flag string) map[string]string {

--- a/config/local-registry-pullsecret.yaml
+++ b/config/local-registry-pullsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dev-registry
+  namespace: package-operator-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJkZXYtcmVnaXN0cnkuZGV2LXJlZ2lzdHJ5LnN2Yy5jbHVzdGVyLmxvY2FsOjUwMDIiOnsidXNlcm5hbWUiOiJyZWdpc3RyeSIsInBhc3N3b3JkIjoiZm9vYmFyIiwiZW1haWwiOiJtZW93QHBhY2thZ2Utb3BlcmF0b3IucnVuIiwiYXV0aCI6ImNtVm5hWE4wY25rNlptOXZZbUZ5In19fQ==

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/yannh/kubeconform v0.6.7
 	go.uber.org/dig v1.18.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.33.0
 	golang.org/x/sys v0.28.0
 	k8s.io/api v0.30.3
@@ -146,7 +147,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/integration/package-operator/environment.go
+++ b/integration/package-operator/environment.go
@@ -49,6 +49,8 @@ var (
 	SuccessTestMultiPackageImage string
 	// SuccessTestCelPackageImage points to an image to use to test Package installation with CEL annotations.
 	SuccessTestCelPackageImage string
+	// SuccessTestPackageImageAuthenticated points to the test stub package image but requires authentication.
+	SuccessTestPackageImageAuthenticated string
 
 	FailureTestPackageImage = "localhost/does-not-exist"
 
@@ -59,6 +61,10 @@ func init() {
 	SuccessTestPackageImage = os.Getenv("PKO_TEST_SUCCESS_PACKAGE_IMAGE")
 	if len(SuccessTestPackageImage) == 0 {
 		panic("PKO_TEST_SUCCESS_PACKAGE_IMAGE not set!")
+	}
+	SuccessTestPackageImageAuthenticated = os.Getenv("PKO_TEST_SUCCESS_PACKAGE_IMAGE_AUTH")
+	if len(SuccessTestPackageImage) == 0 {
+		panic("PKO_TEST_SUCCESS_PACKAGE_IMAGE_AUTH not set!")
 	}
 	SuccessTestMultiPackageImage = os.Getenv("PKO_TEST_SUCCESS_MULTI_PACKAGE_IMAGE")
 	if len(SuccessTestMultiPackageImage) == 0 {

--- a/internal/controllers/packages/unpack_reconciler_test.go
+++ b/internal/controllers/packages/unpack_reconciler_test.go
@@ -31,7 +31,7 @@ func TestUnpackReconciler(t *testing.T) {
 
 	rawPkg := &packages.RawPackage{}
 	ipm.
-		On("Pull", mock.Anything, mock.Anything).
+		On("Pull", mock.Anything, mock.Anything, mock.Anything).
 		Return(rawPkg, nil)
 	pd.
 		On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -100,7 +100,7 @@ func TestUnpackReconciler_pullBackoff(t *testing.T) {
 
 	rawPkg := &packages.RawPackage{}
 	ipm.
-		On("Pull", mock.Anything, mock.Anything).
+		On("Pull", mock.Anything, mock.Anything, mock.Anything).
 		Return(rawPkg, errTest)
 
 	pkg := &adapters.GenericPackage{

--- a/internal/packages/export_import.go
+++ b/internal/packages/export_import.go
@@ -15,6 +15,10 @@ var (
 	// Imports a RawPackage from a container image registry.
 	FromRegistry = packageimport.FromRegistry
 
+	// Imports a RawPackage from a container image registry,
+	// while supplying pull credentials which are dynamically discovered from the ServiceAccount PKO is running under.
+	FromRegistryInCluster = packageimport.FromRegistryInCluster
+
 	// Creates a new registry instance to de-duplicate parallel container image pulls.
 	NewRequestManager = packageimport.NewRequestManager
 )

--- a/internal/packages/internal/packageimport/kubekeychain/kubekeychain.go
+++ b/internal/packages/internal/packageimport/kubekeychain/kubekeychain.go
@@ -1,0 +1,259 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code was directly inspired and copied with minimal modifications.
+//nolint:lll
+// The original source for this file can be found at: https://github.com/google/go-containerregistry/blob/6bce25ecf0297c1aa9072bc665b5cf58d53e1c54/pkg/authn/kubernetes/keychain.go
+
+//nolint:lll
+package kubekeychain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Instanciates an authn.Keychain with all PullSecrets that are attached to the given ServiceAccount.
+// The ServiceAccount and PullSecret objects will be fetched immediately.
+func FromServiceAccountPullSecrets(
+	ctx context.Context, uncachedClient client.Client,
+	serviceAccount types.NamespacedName,
+) (authn.Keychain, error) {
+	secrets, err := resolveSecrets(ctx, serviceAccount, uncachedClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return newFromPullSecrets(secrets)
+}
+
+func resolveSecrets(ctx context.Context, serviceAccountName types.NamespacedName, uncachedClient client.Client) ([]*corev1.Secret, error) {
+	// Fetch ServiceAccount.
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := uncachedClient.Get(ctx, serviceAccountName, serviceAccount); err != nil {
+		return nil, fmt.Errorf("getting service account: %w", err)
+	}
+
+	// Fetch all pull secrets attached to ServiceAccount.
+	pullSecrets := make([]*corev1.Secret, 0, len(serviceAccount.ImagePullSecrets))
+	for _, localRef := range serviceAccount.ImagePullSecrets {
+		secret := &corev1.Secret{}
+
+		if err := uncachedClient.Get(ctx, types.NamespacedName{
+			Namespace: serviceAccount.Namespace,
+			Name:      localRef.Name,
+		}, secret); k8serrors.IsNotFound(err) {
+			// TODO ignore? should we?
+			// TODO wrong logger package
+			logs.Warn.Printf("secret %s not found; ignoring", localRef.Name)
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("getting pull secret attached to sa: %w", err)
+		}
+
+		pullSecrets = append(pullSecrets, secret)
+	}
+
+	return pullSecrets, nil
+}
+
+type dockerConfigJSON struct {
+	Auths map[string]authn.AuthConfig `json:"auths"`
+}
+
+// newFromPullSecrets returns a new authn.Keychain suitable for resolving image references as
+// scoped by the pull secrets.
+func newFromPullSecrets(secrets []*corev1.Secret) (authn.Keychain, error) {
+	keyring := &keyring{
+		index: make([]string, 0),
+		creds: make(map[string][]authn.AuthConfig),
+	}
+
+	var cfg dockerConfigJSON
+
+	// From: https://github.com/kubernetes/kubernetes/blob/0dcafb1f37ee522be3c045753623138e5b907001/pkg/credentialprovider/keyring.go
+	for _, secret := range secrets {
+		if b, exists := secret.Data[corev1.DockerConfigJsonKey]; secret.Type == corev1.SecretTypeDockerConfigJson && exists && len(b) > 0 {
+			if err := json.Unmarshal(b, &cfg); err != nil {
+				return nil, err
+			}
+		}
+		if b, exists := secret.Data[corev1.DockerConfigKey]; secret.Type == corev1.SecretTypeDockercfg && exists && len(b) > 0 {
+			if err := json.Unmarshal(b, &cfg.Auths); err != nil {
+				return nil, err
+			}
+		}
+
+		for registry, v := range cfg.Auths {
+			value := registry
+			if !strings.HasPrefix(value, "https://") && !strings.HasPrefix(value, "http://") {
+				value = "https://" + value
+			}
+			parsed, err := url.Parse(value)
+			if err != nil {
+				return nil, fmt.Errorf("entry %q in dockercfg invalid (%w)", value, err)
+			}
+
+			// The docker client allows exact matches:
+			//    foo.bar.com/namespace
+			// Or hostname matches:
+			//    foo.bar.com
+			// It also considers /v2/  and /v1/ equivalent to the hostname
+			// See ResolveAuthConfig in docker/registry/auth.go.
+			effectivePath := parsed.Path
+			if strings.HasPrefix(effectivePath, "/v2/") || strings.HasPrefix(effectivePath, "/v1/") {
+				effectivePath = effectivePath[3:]
+			}
+			var key string
+			if (len(effectivePath) > 0) && (effectivePath != "/") {
+				key = parsed.Host + effectivePath
+			} else {
+				key = parsed.Host
+			}
+
+			if _, ok := keyring.creds[key]; !ok {
+				keyring.index = append(keyring.index, key)
+			}
+
+			keyring.creds[key] = append(keyring.creds[key], v)
+		}
+
+		// We reverse sort in to give more specific (aka longer) keys priority
+		// when matching for creds
+		sort.Sort(sort.Reverse(sort.StringSlice(keyring.index)))
+	}
+	return keyring, nil
+}
+
+type keyring struct {
+	index []string
+	creds map[string][]authn.AuthConfig
+}
+
+func (keyring *keyring) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	image := target.String()
+	auths := []authn.AuthConfig{}
+
+	for _, k := range keyring.index {
+		// both k and image are schemeless URLs because even though schemes are allowed
+		// in the credential configurations, we remove them when constructing the keyring
+		if matched, _ := urlsMatchStr(k, image); matched {
+			auths = append(auths, keyring.creds[k]...)
+		}
+	}
+
+	if len(auths) == 0 {
+		return authn.Anonymous, nil
+	}
+
+	return toAuthenticator(auths)
+}
+
+// urlsMatchStr is wrapper for URLsMatch, operating on strings instead of URLs.
+func urlsMatchStr(glob string, target string) (bool, error) {
+	globURL, err := parseSchemelessURL(glob)
+	if err != nil {
+		return false, err
+	}
+	targetURL, err := parseSchemelessURL(target)
+	if err != nil {
+		return false, err
+	}
+	return urlsMatch(globURL, targetURL)
+}
+
+// parseSchemelessURL parses a schemeless url and returns a url.URL
+// url.Parse require a scheme, but ours don't have schemes.  Adding a
+// scheme to make url.Parse happy, then clear out the resulting scheme.
+func parseSchemelessURL(schemelessURL string) (*url.URL, error) {
+	parsed, err := url.Parse("https://" + schemelessURL)
+	if err != nil {
+		return nil, err
+	}
+	// clear out the resulting scheme
+	parsed.Scheme = ""
+	return parsed, nil
+}
+
+// splitURL splits the host name into parts, as well as the port.
+func splitURL(url *url.URL) (parts []string, port string) {
+	host, port, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		// could not parse port
+		host, port = url.Host, ""
+	}
+	return strings.Split(host, "."), port
+}
+
+// urlsMatch checks whether the given target url matches the glob url, which may have
+// glob wild cards in the host name.
+//
+// Examples:
+//
+//	globURL=*.docker.io, targetURL=blah.docker.io => match
+//	globURL=*.docker.io, targetURL=not.right.io   => no match
+//
+// Note that we don't support wildcards in ports and paths yet.
+func urlsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
+	globURLParts, globPort := splitURL(globURL)
+	targetURLParts, targetPort := splitURL(targetURL)
+	if globPort != targetPort {
+		// port doesn't match
+		return false, nil
+	}
+	if len(globURLParts) != len(targetURLParts) {
+		// host name does not have the same number of parts
+		return false, nil
+	}
+	if !strings.HasPrefix(targetURL.Path, globURL.Path) {
+		// the path of the credential must be a prefix
+		return false, nil
+	}
+	for k, globURLPart := range globURLParts {
+		targetURLPart := targetURLParts[k]
+		matched, err := filepath.Match(globURLPart, targetURLPart)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			// glob mismatch for some part
+			return false, nil
+		}
+	}
+	// everything matches
+	return true, nil
+}
+
+func toAuthenticator(configs []authn.AuthConfig) (authn.Authenticator, error) {
+	cfg := configs[0]
+
+	if cfg.Auth != "" {
+		cfg.Auth = ""
+	}
+
+	return authn.FromConfig(cfg), nil
+}

--- a/internal/packages/internal/packageimport/kubekeychain/kubekeychain_test.go
+++ b/internal/packages/internal/packageimport/kubekeychain/kubekeychain_test.go
@@ -1,0 +1,256 @@
+package kubekeychain
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"package-operator.run/internal/testutil"
+)
+
+func newExpectedSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func TestResolveSecrets_Success(t *testing.T) {
+	t.Parallel()
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "package-operator-system",
+			Name:      "package-operator",
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+			{Name: "d"},
+		},
+	}
+	expectedSecrets := []*corev1.Secret{
+		newExpectedSecret("package-operator-system", "a"),
+		newExpectedSecret("package-operator-system", "b"),
+		newExpectedSecret("package-operator-system", "c"),
+		newExpectedSecret("package-operator-system", "d"),
+	}
+
+	c := testutil.NewClient()
+
+	c.On("Get", mock.Anything, client.ObjectKey{
+		Namespace: serviceAccount.Namespace,
+		Name:      serviceAccount.Name,
+	}, mock.IsType(&corev1.ServiceAccount{}), mock.Anything).Run(func(args mock.Arguments) {
+		sa := args.Get(2).(*corev1.ServiceAccount)
+		*sa = *serviceAccount
+	}).Return(nil)
+
+	for _, localRef := range serviceAccount.ImagePullSecrets {
+		c.On("Get", mock.Anything, client.ObjectKey{
+			Namespace: serviceAccount.Namespace,
+			Name:      localRef.Name,
+		}, mock.IsType(&corev1.Secret{}), mock.Anything).Run(func(args mock.Arguments) {
+			key := args.Get(1).(client.ObjectKey)
+			index := slices.IndexFunc(expectedSecrets, func(secret *corev1.Secret) bool {
+				return key.Name == secret.Name && key.Namespace == secret.Namespace
+			})
+			require.NotEqual(t, -1, index)
+			s := args.Get(2).(*corev1.Secret)
+			*s = *(expectedSecrets[index].DeepCopy())
+		}).Return(nil)
+	}
+
+	actual, err := resolveSecrets(context.Background(), client.ObjectKeyFromObject(serviceAccount), c)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSecrets, actual)
+}
+
+func TestResolveSecrets_GetServiceAccountError(t *testing.T) {
+	t.Parallel()
+
+	c := testutil.NewClient()
+
+	key := client.ObjectKey{
+		Namespace: "package-operator-system",
+		Name:      "package-operator",
+	}
+
+	c.On("Get", mock.Anything, key, mock.IsType(&corev1.ServiceAccount{}), mock.Anything).
+		Return(k8sapierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	_, err := resolveSecrets(context.Background(), key, c)
+	require.Error(t, err)
+	assert.True(t, k8sapierrors.IsNotFound(err))
+}
+
+func TestResolveSecrets_GetSecretError(t *testing.T) {
+	t.Parallel()
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "package-operator-system",
+			Name:      "package-operator",
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+			{Name: "d"},
+		},
+	}
+
+	c := testutil.NewClient()
+
+	c.On("Get", mock.Anything, client.ObjectKey{
+		Namespace: serviceAccount.Namespace,
+		Name:      serviceAccount.Name,
+	}, mock.IsType(&corev1.ServiceAccount{}), mock.Anything).Run(func(args mock.Arguments) {
+		sa := args.Get(2).(*corev1.ServiceAccount)
+		*sa = *serviceAccount
+	}).Return(nil)
+
+	for _, localRef := range serviceAccount.ImagePullSecrets {
+		c.On("Get", mock.Anything, client.ObjectKey{
+			Namespace: serviceAccount.Namespace,
+			Name:      localRef.Name,
+		}, mock.IsType(&corev1.Secret{}), mock.Anything).
+			Return(k8sapierrors.NewBadRequest(""))
+	}
+
+	_, err := resolveSecrets(context.Background(), client.ObjectKeyFromObject(serviceAccount), c)
+	require.Error(t, err)
+	assert.True(t, k8sapierrors.IsBadRequest(err))
+}
+
+func TestResolveSecrets_GetSecretError_IgnoreNotFound(t *testing.T) {
+	t.Parallel()
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "package-operator-system",
+			Name:      "package-operator",
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+			{Name: "d"},
+		},
+	}
+
+	c := testutil.NewClient()
+
+	c.On("Get", mock.Anything, client.ObjectKey{
+		Namespace: serviceAccount.Namespace,
+		Name:      serviceAccount.Name,
+	}, mock.IsType(&corev1.ServiceAccount{}), mock.Anything).Run(func(args mock.Arguments) {
+		sa := args.Get(2).(*corev1.ServiceAccount)
+		*sa = *serviceAccount
+	}).Return(nil)
+
+	c.On("Get", mock.Anything, mock.Anything, mock.IsType(&corev1.Secret{}), mock.Anything).
+		Return(k8sapierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	secrets, err := resolveSecrets(context.Background(), client.ObjectKeyFromObject(serviceAccount), c)
+	require.NoError(t, err)
+	assert.Empty(t, secrets)
+}
+
+func TestKubernetesAuth(t *testing.T) {
+	t.Parallel()
+
+	// From https://github.com/knative/serving/issues/12761#issuecomment-1097441770
+	// All of these should work with K8s' docker auth parsing.
+	for k, ss := range map[string][]string{
+		"registry.gitlab.com/dprotaso/test/nginx": {
+			"registry.gitlab.com",
+			"http://registry.gitlab.com",
+			"https://registry.gitlab.com",
+			"registry.gitlab.com/dprotaso",
+			"http://registry.gitlab.com/dprotaso",
+			"https://registry.gitlab.com/dprotaso",
+			"registry.gitlab.com/dprotaso/test",
+			"http://registry.gitlab.com/dprotaso/test",
+			"https://registry.gitlab.com/dprotaso/test",
+			"registry.gitlab.com/dprotaso/test/nginx",
+			"http://registry.gitlab.com/dprotaso/test/nginx",
+			"https://registry.gitlab.com/dprotaso/test/nginx",
+		},
+		"dtestcontainer.azurecr.io/dave/nginx": {
+			"dtestcontainer.azurecr.io",
+			"http://dtestcontainer.azurecr.io",
+			"https://dtestcontainer.azurecr.io",
+			"dtestcontainer.azurecr.io/dave",
+			"http://dtestcontainer.azurecr.io/dave",
+			"https://dtestcontainer.azurecr.io/dave",
+			"dtestcontainer.azurecr.io/dave/nginx",
+			"http://dtestcontainer.azurecr.io/dave/nginx",
+			"https://dtestcontainer.azurecr.io/dave/nginx",
+		},
+	} {
+		repo, err := name.NewRepository(k)
+		if err != nil {
+			t.Errorf("parsing %q: %v", k, err)
+			continue
+		}
+
+		for _, s := range ss {
+			t.Run(fmt.Sprintf("%s - %s", k, s), func(t *testing.T) {
+				t.Parallel()
+
+				username, password := "foo", "bar"
+				kc, err := newFromPullSecrets([]*corev1.Secret{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "ns",
+					},
+					Type: corev1.SecretTypeDockerConfigJson,
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte(
+							fmt.Sprintf(`{"auths":{%q:{"username":%q,"password":%q,"auth":%q}}}`,
+								s,
+								username, password,
+								base64.StdEncoding.EncodeToString([]byte(username+":"+password))),
+						),
+					},
+				}})
+				if err != nil {
+					t.Fatalf("NewFromPullSecrets() = %v", err)
+				}
+				auth, err := kc.Resolve(repo)
+				if err != nil {
+					t.Errorf("Resolve(%v) = %v", repo, err)
+				}
+				got, err := auth.Authorization()
+				if err != nil {
+					t.Errorf("Authorization() = %v", err)
+				}
+				want, err := (&authn.Basic{Username: username, Password: password}).Authorization()
+				if err != nil {
+					t.Errorf("Authorization() = %v", err)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("Resolve() = %v, want %v", got, want)
+				}
+			})
+		}
+	}
+}

--- a/internal/packages/internal/packageimport/registry.go
+++ b/internal/packages/internal/packageimport/registry.go
@@ -2,11 +2,29 @@ package packageimport
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"package-operator.run/internal/packages/internal/packageimport/kubekeychain"
 	"package-operator.run/internal/packages/internal/packagetypes"
 )
+
+// Imports a RawPackage from a container image registry,
+// while supplying pull credentials which are dynamically discovered from the ServiceAccount PKO is running under.
+func FromRegistryInCluster(
+	ctx context.Context, uncachedClient client.Client, serviceAccount types.NamespacedName,
+	ref string, opts ...crane.Option,
+) (*packagetypes.RawPackage, error) {
+	chain, err := kubekeychain.FromServiceAccountPullSecrets(ctx, uncachedClient, serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("creating keychain: %w", err)
+	}
+	opts = append(opts, crane.WithAuthFromKeychain(chain))
+	return FromRegistry(ctx, ref, opts...)
+}
 
 // Imports a RawPackage from a container image registry.
 func FromRegistry(

--- a/internal/packages/internal/packageimport/request_manager_test.go
+++ b/internal/packages/internal/packageimport/request_manager_test.go
@@ -10,22 +10,30 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"package-operator.run/internal/packages/internal/packagetypes"
+	"package-operator.run/internal/testutil"
 )
 
 func TestRequestManager_DelayedPull(t *testing.T) {
 	t.Parallel()
 
+	uncachedClient := testutil.NewClient()
+	serviceAccount := types.NamespacedName{
+		Namespace: "package-operator-system",
+		Name:      "package-operator",
+	}
 	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
-	})
+	}, uncachedClient, serviceAccount)
 	ipm := &imagePullerMock{}
 	r.pullImage = ipm.Pull
 
 	pkg := &packagetypes.RawPackage{Files: packagetypes.Files{"test": []byte{}}}
 	ipm.
-		On("Pull", mock.Anything, mock.IsType("string")).
+		On("Pull", mock.Anything, mock.Anything, mock.Anything, mock.IsType("string")).
 		Run(func(mock.Arguments) { time.Sleep(500 * time.Millisecond) }).
 		Return(pkg, nil)
 
@@ -47,7 +55,7 @@ func TestRequestManager_DelayedPull(t *testing.T) {
 	wg.Wait()
 
 	ipm.AssertNumberOfCalls(t, "Pull", 1)
-	ipm.AssertCalled(t, "Pull", mock.Anything, "localhost:123/test123:latest")
+	ipm.AssertCalled(t, "Pull", mock.Anything, mock.Anything, mock.Anything, "localhost:123/test123:latest")
 }
 
 func TestRequestManager_DelayedRequests(t *testing.T) {
@@ -60,13 +68,18 @@ func TestRequestManager_DelayedRequests(t *testing.T) {
 
 	ipm := &imagePullerMock{}
 	ipm.
-		On("Pull", mock.Anything, mock.IsType("string")).
+		On("Pull", mock.Anything, mock.Anything, mock.Anything, mock.IsType("string")).
 		Run(func(mock.Arguments) { time.Sleep(requestDelay) }).
 		Return(&packagetypes.RawPackage{Files: packagetypes.Files{"test": nil}}, nil)
 
+	uncachedClient := testutil.NewClient()
+	serviceAccount := types.NamespacedName{
+		Namespace: "package-operator-system",
+		Name:      "package-operator",
+	}
 	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
-	})
+	}, uncachedClient, serviceAccount)
 	r.pullImage = ipm.Pull
 
 	ctx := context.Background()
@@ -111,8 +124,11 @@ type imagePullerMock struct {
 }
 
 func (m *imagePullerMock) Pull(
-	ctx context.Context, ref string, _ ...crane.Option,
+	ctx context.Context,
+	uncachedClient client.Client,
+	serviceAccount types.NamespacedName,
+	ref string, _ ...crane.Option,
 ) (*packagetypes.RawPackage, error) {
-	args := m.Called(ctx, ref)
+	args := m.Called(ctx, uncachedClient, serviceAccount, ref)
 	return args.Get(0).(*packagetypes.RawPackage), args.Error(1)
 }


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
Co-authored-by: Alex Sowitzki <dev@eqrx.net>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
add support to resolve own ServiceAccount and attached ImagePullSecrets to authenticate package image pull requests made by Package Operator.

I have separated these PRs out and they have to be merged first:
- https://github.com/package-operator/package-operator/pull/1657
- https://github.com/package-operator/package-operator/pull/1658

Documentation PR: https://github.com/package-operator/website/pull/13

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] [Relevant documentation](https://github.com/package-operator/website/pull/13) has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
