### PR TITLE
refactor: rename packageimport.Registry to RequestManager

### DIFF
--- a/cmd/package-operator-manager/bootstrap/bootstrap.go
+++ b/cmd/package-operator-manager/bootstrap/bootstrap.go
@@ -35,7 +35,7 @@ type Bootstrapper struct {
 func NewBootstrapper(
 	scheme *runtime.Scheme, log logr.Logger,
 	uncachedClient components.UncachedClient,
-	registry *packages.Registry,
+	registry *packages.RequestManager,
 	opts components.Options,
 ) (*Bootstrapper, error) {
 	c := uncachedClient

--- a/cmd/package-operator-manager/components/components.go
+++ b/cmd/package-operator-manager/components/components.go
@@ -38,7 +38,7 @@ func NewComponents() (*dig.Container, error) {
 		ProvideScheme, ProvideRestConfig, ProvideManager,
 		ProvideMetricsRecorder, ProvideDynamicCache,
 		ProvideUncachedClient, ProvideOptions, ProvideLogger,
-		ProvideRegistry, ProvideDiscoveryClient, ProvideEnvironmentManager,
+		ProvideRequestManager, ProvideDiscoveryClient, ProvideEnvironmentManager,
 
 		// -----------
 		// Controllers

--- a/cmd/package-operator-manager/components/package.go
+++ b/cmd/package-operator-manager/components/package.go
@@ -22,9 +22,8 @@ type (
 	}
 )
 
-func ProvideRegistry(log logr.Logger, opts Options) *packages.Registry {
-	return packages.NewRegistry(
-		prepareRegistryHostOverrides(log, opts.RegistryHostOverrides))
+func ProvideRequestManager(log logr.Logger, opts Options) *packages.RequestManager {
+	return packages.NewRequestManager(prepareRegistryHostOverrides(log, opts.RegistryHostOverrides))
 }
 
 func prepareRegistryHostOverrides(log logr.Logger, flag string) map[string]string {
@@ -47,7 +46,7 @@ func prepareRegistryHostOverrides(log logr.Logger, flag string) map[string]strin
 
 func ProvidePackageController(
 	mgr ctrl.Manager, log logr.Logger, uncachedClient UncachedClient,
-	registry *packages.Registry,
+	requestManager *packages.RequestManager,
 	recorder *metrics.Recorder,
 	opts Options,
 ) PackageController {
@@ -57,7 +56,7 @@ func ProvidePackageController(
 			uncachedClient,
 			log.WithName("controllers").WithName("Package"),
 			mgr.GetScheme(),
-			registry, recorder, opts.PackageHashModifier,
+			requestManager, recorder, opts.PackageHashModifier,
 		),
 	}
 }
@@ -65,7 +64,7 @@ func ProvidePackageController(
 func ProvideClusterPackageController(
 	mgr ctrl.Manager, log logr.Logger,
 	uncachedClient UncachedClient,
-	registry *packages.Registry,
+	requestManager *packages.RequestManager,
 	recorder *metrics.Recorder,
 	opts Options,
 ) ClusterPackageController {
@@ -74,7 +73,7 @@ func ProvideClusterPackageController(
 			mgr.GetClient(), uncachedClient.Client,
 			log.WithName("controllers").WithName("ClusterPackage"),
 			mgr.GetScheme(),
-			registry, recorder, opts.PackageHashModifier,
+			requestManager, recorder, opts.PackageHashModifier,
 		),
 	}
 }

--- a/internal/packages/export_import.go
+++ b/internal/packages/export_import.go
@@ -5,19 +5,21 @@ import "package-operator.run/internal/packages/internal/packageimport"
 var (
 	// Import a RawPackage from the given folder path.
 	FromFolder = packageimport.FromFolder
+
 	// Import a RawPackage from the given FileSystem.
 	FromFS = packageimport.FromFS
 
 	// Imports a RawPackage from the given OCI image.
 	FromOCI = packageimport.FromOCI
+
 	// Imports a RawPackage from a container image registry.
 	FromRegistry = packageimport.FromRegistry
 
 	// Creates a new registry instance to de-duplicate parallel container image pulls.
-	NewRegistry = packageimport.NewRegistry
+	NewRequestManager = packageimport.NewRequestManager
 )
 
 type (
-	// Registry de-duplicates multiple parallel container image pulls.
-	Registry = packageimport.Registry
+	// RequestManager de-duplicates multiple parallel container image pulls.
+	RequestManager = packageimport.RequestManager
 )

--- a/internal/packages/internal/packageimport/registry.go
+++ b/internal/packages/internal/packageimport/registry.go
@@ -2,124 +2,19 @@ package packageimport
 
 import (
 	"context"
-	"strings"
-	"sync"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 
 	"package-operator.run/internal/packages/internal/packagetypes"
-	"package-operator.run/internal/utils"
 )
 
 // Imports a RawPackage from a container image registry.
-func FromRegistry(ctx context.Context, ref string, opts ...crane.Option) (
-	*packagetypes.RawPackage, error,
-) {
+func FromRegistry(
+	ctx context.Context, ref string, opts ...crane.Option,
+) (*packagetypes.RawPackage, error) {
 	img, err := crane.Pull(ref, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return FromOCI(ctx, img)
-}
-
-// Registry de-duplicates multiple parallel container image pulls.
-type Registry struct {
-	registryHostOverrides map[string]string
-
-	pullImage    pullImageFn
-	inFlight     map[string][]chan<- response
-	inFlightLock sync.Mutex
-}
-
-type response struct {
-	RawPackage *packagetypes.RawPackage
-	Err        error
-}
-
-type pullImageFn func(
-	ctx context.Context, ref string, opts ...crane.Option) (*packagetypes.RawPackage, error)
-
-// Creates a new registry instance to de-duplicate parallel container image pulls.
-func NewRegistry(registryHostOverrides map[string]string) *Registry {
-	return &Registry{
-		registryHostOverrides: registryHostOverrides,
-		pullImage:             FromRegistry,
-		inFlight:              make(map[string][]chan<- response),
-	}
-}
-
-func (r *Registry) Pull(ctx context.Context, image string) (*packagetypes.RawPackage, error) {
-	image, err := r.applyOverride(image)
-	if err != nil {
-		return nil, err
-	}
-
-	res := <-r.handleRequest(ctx, image)
-
-	return res.RawPackage, res.Err
-}
-
-func (r *Registry) applyOverride(image string) (string, error) {
-	for original, override := range r.registryHostOverrides {
-		if strings.HasPrefix(image, original) {
-			return utils.ImageURLWithOverride(image, override)
-		}
-	}
-	return image, nil
-}
-
-// handleRequest first checks if the provided image is already being pulled.
-// If it is not, a new go routine is started to pull the image and trigger
-// response handling. Then a new receiver is registered to listen for the response.
-// These steps must all occur within the same lock scope to prevent dirty reads
-// on the in flight pull requests, more specifically, a check if an image pull
-// is in flight after a pull attempt has started, but before the first receiver
-// is registered.
-func (r *Registry) handleRequest(ctx context.Context, image string) <-chan response {
-	r.inFlightLock.Lock()
-	defer r.inFlightLock.Unlock()
-
-	if _, inFlight := r.inFlight[image]; !inFlight {
-		go func(ctx context.Context, image string) {
-			rawPkg, err := r.pullImage(ctx, image)
-			r.handleResponse(image, response{
-				RawPackage: rawPkg,
-				Err:        err,
-			})
-		}(ctx, image)
-	}
-
-	// buffer size of 1 ensures that response handler
-	// is never blocked by a receiver.
-	recv := make(chan response, 1)
-
-	r.inFlight[image] = append(r.inFlight[image], recv)
-
-	return recv
-}
-
-// handleResponse broadcasts a response to all receivers listening
-// for a given image's pull request and then deletes the image's
-// entry allowing new requests to trigger a fresh pull. These
-// steps must occur within the same lock scope to prevent dirty
-// writes, more specifically, the registration of a new receiver
-// after broadcast has occurred, but before the image entry is
-// deleted.
-func (r *Registry) handleResponse(image string, res response) {
-	r.inFlightLock.Lock()
-	defer r.inFlightLock.Unlock()
-
-	for _, recv := range r.inFlight[image] {
-		var rawPkg *packagetypes.RawPackage
-		if res.RawPackage != nil {
-			// DeepCopy to ensure clients can work concurrently on the returned files map.
-			rawPkg = res.RawPackage.DeepCopy()
-		}
-		recv <- response{
-			RawPackage: rawPkg,
-			Err:        res.Err,
-		}
-	}
-
-	delete(r.inFlight, image)
 }

--- a/internal/packages/internal/packageimport/request_manager.go
+++ b/internal/packages/internal/packageimport/request_manager.go
@@ -1,0 +1,117 @@
+package packageimport
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+
+	"package-operator.run/internal/packages/internal/packagetypes"
+	"package-operator.run/internal/utils"
+)
+
+// RequestManager de-duplicates multiple parallel container image pulls.
+type RequestManager struct {
+	registryHostOverrides map[string]string
+
+	pullImage    pullImageFn
+	inFlight     map[string][]chan<- response
+	inFlightLock sync.Mutex
+}
+
+type response struct {
+	RawPackage *packagetypes.RawPackage
+	Err        error
+}
+
+type pullImageFn func(
+	ctx context.Context, ref string, opts ...crane.Option,
+) (*packagetypes.RawPackage, error)
+
+// Creates a new request manager instance to de-duplicate parallel container image pulls.
+func NewRequestManager(registryHostOverrides map[string]string) *RequestManager {
+	return &RequestManager{
+		registryHostOverrides: registryHostOverrides,
+		pullImage:             FromRegistry,
+		inFlight:              make(map[string][]chan<- response),
+	}
+}
+
+func (r *RequestManager) Pull(
+	ctx context.Context, image string,
+) (*packagetypes.RawPackage, error) {
+	image, err := r.applyOverride(image)
+	if err != nil {
+		return nil, err
+	}
+
+	res := <-r.handleRequest(ctx, image)
+
+	return res.RawPackage, res.Err
+}
+
+func (r *RequestManager) applyOverride(image string) (string, error) {
+	for original, override := range r.registryHostOverrides {
+		if strings.HasPrefix(image, original) {
+			return utils.ImageURLWithOverride(image, override)
+		}
+	}
+	return image, nil
+}
+
+// handleRequest first checks if the provided image is already being pulled.
+// If it is not, a new go routine is started to pull the image and trigger
+// response handling. Then a new receiver is registered to listen for the response.
+// These steps must all occur within the same lock scope to prevent dirty reads
+// on the in flight pull requests, more specifically, a check if an image pull
+// is in flight after a pull attempt has started, but before the first receiver
+// is registered.
+func (r *RequestManager) handleRequest(ctx context.Context, image string) <-chan response {
+	r.inFlightLock.Lock()
+	defer r.inFlightLock.Unlock()
+
+	if _, inFlight := r.inFlight[image]; !inFlight {
+		go func(ctx context.Context, image string) {
+			rawPkg, err := r.pullImage(ctx, image)
+			r.handleResponse(image, response{
+				RawPackage: rawPkg,
+				Err:        err,
+			})
+		}(ctx, image)
+	}
+
+	// buffer size of 1 ensures that response handler
+	// is never blocked by a receiver.
+	recv := make(chan response, 1)
+
+	r.inFlight[image] = append(r.inFlight[image], recv)
+
+	return recv
+}
+
+// handleResponse broadcasts a response to all receivers listening
+// for a given image's pull request and then deletes the image's
+// entry allowing new requests to trigger a fresh pull. These
+// steps must occur within the same lock scope to prevent dirty
+// writes, more specifically, the registration of a new receiver
+// after broadcast has occurred, but before the image entry is
+// deleted.
+func (r *RequestManager) handleResponse(image string, res response) {
+	r.inFlightLock.Lock()
+	defer r.inFlightLock.Unlock()
+
+	for _, recv := range r.inFlight[image] {
+		var rawPkg *packagetypes.RawPackage
+		if res.RawPackage != nil {
+			// DeepCopy to ensure clients can work concurrently on the returned files map.
+			rawPkg = res.RawPackage.DeepCopy()
+		}
+		recv <- response{
+			RawPackage: rawPkg,
+			Err:        res.Err,
+		}
+	}
+
+	delete(r.inFlight, image)
+}

--- a/internal/packages/internal/packageimport/request_manager_test.go
+++ b/internal/packages/internal/packageimport/request_manager_test.go
@@ -14,10 +14,10 @@ import (
 	"package-operator.run/internal/packages/internal/packagetypes"
 )
 
-func TestRegistry_DelayedPull(t *testing.T) {
+func TestRequestManager_DelayedPull(t *testing.T) {
 	t.Parallel()
 
-	r := NewRegistry(map[string]string{
+	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
 	})
 	ipm := &imagePullerMock{}
@@ -25,7 +25,7 @@ func TestRegistry_DelayedPull(t *testing.T) {
 
 	pkg := &packagetypes.RawPackage{Files: packagetypes.Files{"test": []byte{}}}
 	ipm.
-		On("Pull", mock.Anything, mock.Anything, mock.Anything).
+		On("Pull", mock.Anything, mock.IsType("string")).
 		Run(func(mock.Arguments) { time.Sleep(500 * time.Millisecond) }).
 		Return(pkg, nil)
 
@@ -47,10 +47,10 @@ func TestRegistry_DelayedPull(t *testing.T) {
 	wg.Wait()
 
 	ipm.AssertNumberOfCalls(t, "Pull", 1)
-	ipm.AssertCalled(t, "Pull", mock.Anything, "localhost:123/test123:latest", mock.Anything)
+	ipm.AssertCalled(t, "Pull", mock.Anything, "localhost:123/test123:latest")
 }
 
-func TestRegistry_DelayedRequests(t *testing.T) {
+func TestRequestManager_DelayedRequests(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -60,11 +60,11 @@ func TestRegistry_DelayedRequests(t *testing.T) {
 
 	ipm := &imagePullerMock{}
 	ipm.
-		On("Pull", mock.Anything, mock.Anything, mock.Anything).
+		On("Pull", mock.Anything, mock.IsType("string")).
 		Run(func(mock.Arguments) { time.Sleep(requestDelay) }).
 		Return(&packagetypes.RawPackage{Files: packagetypes.Files{"test": nil}}, nil)
 
-	r := NewRegistry(map[string]string{
+	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
 	})
 	r.pullImage = ipm.Pull
@@ -111,9 +111,8 @@ type imagePullerMock struct {
 }
 
 func (m *imagePullerMock) Pull(
-	ctx context.Context, ref string,
-	opts ...crane.Option,
+	ctx context.Context, ref string, _ ...crane.Option,
 ) (*packagetypes.RawPackage, error) {
-	args := m.Called(ctx, ref, opts)
+	args := m.Called(ctx, ref)
 	return args.Get(0).(*packagetypes.RawPackage), args.Error(1)
 }


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
having a struct definition for `Registry` in a file called registry.go, which is called like that because it contains a `FromRegistry` function that pulls a package image from an OCI registry (just like oci.go contains a `FromOCI` function!) although that `Registry` struct is actually a facility to deduplicate concurrent pull requests for the same package image.... yeah that confuses my little smoothbrain way too much, so this PR renames the struct to `RequestManager` because it manages (deduplicates) (image pull) requests.

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>


### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->
Refactoring

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
