### PR TITLE
Make ServiceAccount available to package-operator pods

### DIFF
--- a/cmd/build/dev.go
+++ b/cmd/build/dev.go
@@ -156,6 +156,8 @@ func (dev *Dev) Run(ctx context.Context, args []string) error {
 		"./cmd/package-operator-manager",
 		"-namespace", "package-operator-system",
 		"-enable-leader-election=true",
+		"-service-account-namespace", "default",
+		"-service-account-name", "default",
 		"-registry-host-overrides", imageRegistryHost() + "=localhost:5001",
 		"--package-operator-package-image", imageRegistry() + "/package-operator-package:" + appVersion,
 	}

--- a/cmd/package-operator-manager/components/options.go
+++ b/cmd/package-operator-manager/components/options.go
@@ -14,10 +14,12 @@ import (
 
 // Flags.
 const (
-	metricsAddrFlagDescription    = "The address the metric endpoint binds to."
-	pprofAddrFlagDescription      = "The address the pprof web endpoint binds to."
-	namespaceFlagDescription      = "The namespace the operator is deployed into."
-	leaderElectionFlagDescription = "Enable leader election for controller manager. " +
+	metricsAddrFlagDescription             = "The address the metric endpoint binds to."
+	pprofAddrFlagDescription               = "The address the pprof web endpoint binds to."
+	namespaceFlagDescription               = "The namespace the operator is deployed into."
+	serviceAccountNameFlagDescription      = "Name of the service-account this operator is running under."
+	serviceAccountNamespaceFlagDescription = "Namespace of the service-account this operator is running under."
+	leaderElectionFlagDescription          = "Enable leader election for controller manager. " +
 		"Enabling this will ensure there is only one active controller manager."
 	probeAddrFlagDescription   = "The address the probe endpoint binds to."
 	versionFlagDescription     = "print version information and exit."
@@ -46,6 +48,8 @@ type Options struct {
 	MetricsAddr                 string
 	PPROFAddr                   string
 	Namespace                   string
+	ServiceAccountNamespace     string
+	ServiceAccountName          string
 	EnableLeaderElection        bool
 	ProbeAddr                   string
 	RegistryHostOverrides       string
@@ -82,6 +86,14 @@ func ProvideOptions() (opts Options, err error) {
 		&opts.Namespace, "namespace",
 		os.Getenv("PKO_NAMESPACE"),
 		namespaceFlagDescription)
+	flag.StringVar(
+		&opts.ServiceAccountNamespace, "service-account-namespace",
+		os.Getenv("PKO_SERVICE_ACCOUNT_NAMESPACE"),
+		serviceAccountNamespaceFlagDescription)
+	flag.StringVar(
+		&opts.ServiceAccountName, "service-account-name",
+		os.Getenv("PKO_SERVICE_ACCOUNT_NAME"),
+		serviceAccountNameFlagDescription)
 	flag.BoolVar(
 		&opts.EnableLeaderElection, "enable-leader-election",
 		true,

--- a/config/packages/package-operator/.test-fixtures/no-config/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/.test-fixtures/no-config/package-operator-manager.Deployment.yaml
@@ -35,6 +35,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: PKO_PACKAGE_OPERATOR_PACKAGE_IMAGE
           value: "registry.package-operator.run/static-image"
         image: registry.package-operator.run/static-image

--- a/config/packages/package-operator/.test-fixtures/openshift-with-proxy/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/.test-fixtures/openshift-with-proxy/package-operator-manager.Deployment.yaml
@@ -35,6 +35,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: PKO_PACKAGE_OPERATOR_PACKAGE_IMAGE
           value: "registry.package-operator.run/static-image"
         - name: HTTP_PROXY

--- a/config/packages/package-operator/.test-fixtures/root-affinity-tolerations-resources/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/.test-fixtures/root-affinity-tolerations-resources/package-operator-manager.Deployment.yaml
@@ -37,6 +37,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: PKO_PACKAGE_OPERATOR_PACKAGE_IMAGE
           value: "registry.package-operator.run/static-image"
         image: registry.package-operator.run/static-image

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator-manager.Deployment.yaml
@@ -35,6 +35,14 @@ spec:
           value: /data/kubeconfig
         - name: PKO_NAMESPACE
           value: yet-another
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-manager.Deployment.yaml
@@ -35,6 +35,14 @@ spec:
           value: /data/kubeconfig
         - name: PKO_NAMESPACE
           value: package-operator-system
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/hosted-cluster/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/components/hosted-cluster/package-operator-manager.Deployment.yaml.gotmpl
@@ -61,6 +61,14 @@ spec:
 {{- end}}
         - name: PKO_NAMESPACE
           value: {{ .config.hostedClusterNamespace }}
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
 {{- if hasKey . "environment" }}
 {{- if hasKey .environment "proxy" }}
 {{- if hasKey .environment.proxy "httpProxy" }}

--- a/config/packages/package-operator/components/remote-phase/.test-fixtures/affinity-tolerations-resources/package-operator-remote-phase-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/remote-phase/.test-fixtures/affinity-tolerations-resources/package-operator-remote-phase-manager.Deployment.yaml
@@ -36,6 +36,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/remote-phase/.test-fixtures/namespace-scope/package-operator-remote-phase-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/remote-phase/.test-fixtures/namespace-scope/package-operator-remote-phase-manager.Deployment.yaml
@@ -34,6 +34,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/remote-phase/package-operator-remote-phase-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/components/remote-phase/package-operator-remote-phase-manager.Deployment.yaml.gotmpl
@@ -40,6 +40,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: {{ index .images "remote-phase-manager" }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -63,6 +63,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: PKO_PACKAGE_OPERATOR_PACKAGE_IMAGE
           value: {{ .package.image | quote }}
 {{- if hasKey . "environment" }}

--- a/config/remote-phase-static-deployment/deployment.yaml.tpl
+++ b/config/remote-phase-static-deployment/deployment.yaml.tpl
@@ -41,6 +41,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/self-bootstrap-job.yaml.tpl
+++ b/config/self-bootstrap-job.yaml.tpl
@@ -59,6 +59,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/static-deployment/deployment.yaml.tpl
+++ b/config/static-deployment/deployment.yaml.tpl
@@ -30,6 +30,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PKO_SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: PKO_PACKAGE_OPERATOR_PACKAGE_IMAGE
           value: "quay.io/package-operator/package-operator-package:latest"
         ports:


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

this change enables the manager binaries to discover the serviceaccount they are running under and serves as a stepping stone to later allow package-operator access to the ImagePullSecrets attached to the ServiceAccount

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
Co-authored-by: Alex Sowitzki <dev@eqrx.net>

https://github.com/package-operator/package-operator/pull/1657 must be merged first

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->
Refactoring

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x]  This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
