### PR TITLE
[PKO-60] Do not attempt to overwrite full object on teardown of object which we don't control anymore

### DIFF
--- a/integration/package-operator/objectset_test.go
+++ b/integration/package-operator/objectset_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -15,10 +16,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"pkg.package-operator.run/cardboard/kubeutils/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/internal/constants"
 )
 
 func TestCollisionPreventionPreventUnowned(t *testing.T) {
@@ -497,4 +500,82 @@ func TestObjectSet_orphanCascadeDeletion(t *testing.T) {
 			runObjectSetOrphanCascadeDeletionTest(t, "default", test.class)
 		})
 	}
+}
+
+func TestObjectSet_teardownObjectNotControlledAnymore(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-teardown-uncontrolled",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"banana":       "bread",
+			"uncontrolled": "emotions",
+		},
+	}
+
+	cmGVK, err := apiutil.GVKForObject(configMap, Scheme)
+	require.NoError(t, err)
+	configMap.SetGroupVersionKind(cmGVK)
+
+	unstructuredCM, err := runtime.DefaultUnstructuredConverter.ToUnstructured(configMap)
+	require.NoError(t, err)
+
+	objectSet := &corev1alpha1.ObjectSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-teardown-uncontrolled",
+			Namespace: "default",
+		},
+		Spec: corev1alpha1.ObjectSetSpec{
+			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
+				Phases: []corev1alpha1.ObjectSetTemplatePhase{
+					{
+						Name:  "phase-1",
+						Class: "default",
+						Objects: []corev1alpha1.ObjectSetObject{
+							{
+								CollisionProtection: "Prevent",
+								Object:              unstructured.Unstructured{Object: unstructuredCM},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply ObjectSet and wait for it to become available.
+	require.NoError(t, Client.Create(ctx, objectSet))
+	cleanupOnSuccess(ctx, t, objectSet)
+	require.NoError(t, Waiter.WaitForCondition(ctx, objectSet, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue))
+
+	// Fetch ConfigMap from API and disable the controller flag on its owner reference.
+	actualConfigMap := &corev1.ConfigMap{}
+	require.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(configMap), actualConfigMap))
+	actualConfigMap.OwnerReferences[0].Controller = ptr.To(false)
+	require.NoError(t, Client.Update(ctx, actualConfigMap))
+
+	// Delete ObjectSet.
+	require.NoError(t, Client.Delete(ctx, objectSet))
+
+	// Wait for owner reference and dynamic cache label on ConfigMap to be removed.
+	require.NoError(t,
+		Waiter.WaitForObject(
+			ctx, actualConfigMap, "internal ownerReference to be removed",
+			func(client.Object) (bool, error) {
+				configMap := &corev1.ConfigMap{}
+				err := Client.Get(ctx, client.ObjectKeyFromObject(actualConfigMap), configMap)
+				ownerRefFound := false
+				for _, owner := range configMap.GetOwnerReferences() {
+					if owner.Name == objectSet.Name {
+						ownerRefFound = true
+					}
+				}
+				label := configMap.GetLabels()
+				_, labelFound := label[constants.DynamicCacheLabel]
+				return !ownerRefFound && !labelFound, err
+			}, wait.WithTimeout(40*time.Second),
+		))
 }

--- a/integration/package-operator/package_test.go
+++ b/integration/package-operator/package_test.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"k8s.io/utils/ptr"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -18,7 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"pkg.package-operator.run/cardboard/kubeutils/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"package-operator.run/internal/constants"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
@@ -372,4 +378,69 @@ func TestPackage_AuthenticatedWithServiceAccountPullSecrets(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, env.Kubernetes.Version)
 	})
+}
+
+func TestPackage_internalObject_teardown(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+	meta := metav1.ObjectMeta{
+		Name: "success",
+	}
+	spec := corev1alpha1.PackageSpec{
+		Image: SuccessTestPackageImage,
+		Config: &runtime.RawExtension{
+			Raw: []byte(fmt.Sprintf(`{"testStubImage": "%s"}`, TestStubImage)),
+		},
+	}
+	pkg := newPackage(meta, spec, true)
+	requireDeployPackage(ctx, t, pkg, &corev1alpha1.ObjectDeployment{})
+	// Test if environment information is injected successfully.
+	deploy := &appsv1.Deployment{}
+	err := Client.Get(ctx, client.ObjectKey{
+		Name:      "test-stub-success",
+		Namespace: "default",
+	}, deploy)
+	require.NoError(t, err)
+	cleanupOnSuccess(ctx, t, deploy)
+	var env manifestsv1alpha1.PackageEnvironment
+	te := deploy.Annotations["test-environment"]
+	err = json.Unmarshal([]byte(te), &env)
+	require.NoError(t, err)
+	assert.NotEmpty(t, env.Kubernetes.Version)
+	deploy.OwnerReferences[0].Controller = ptr.To(false)
+	err = Client.Update(ctx, deploy)
+	require.NoError(t, err)
+	objDeploy := &corev1alpha1.ObjectDeployment{}
+	err = Client.Get(ctx, client.ObjectKey{
+		Name:      "success",
+		Namespace: "default",
+	}, objDeploy)
+	require.NoError(t, err)
+	templateHash := objDeploy.Status.TemplateHash
+	objectSet := &corev1alpha1.ObjectSet{}
+	err = Client.Get(ctx, client.ObjectKey{
+		Name:      "success-" + templateHash,
+		Namespace: "default",
+	}, objectSet)
+	require.NoError(t, err)
+	require.NoError(t, Client.Delete(ctx, objectSet))
+	require.NoError(t,
+		Waiter.WaitForObject(
+			ctx, deploy, "internal ownerReference to be removed",
+			func(client.Object) (bool, error) {
+				deploy = &appsv1.Deployment{}
+				err = Client.Get(ctx, client.ObjectKey{
+					Name:      "test-stub-success",
+					Namespace: "default",
+				}, deploy)
+				internalOwner := false
+				for _, own := range deploy.GetOwnerReferences() {
+					if own.Name == "success" {
+						internalOwner = true
+					}
+				}
+				label := deploy.GetLabels()
+				_, exists := label[constants.DynamicCacheLabel]
+				return !internalOwner && !exists, err
+			}, wait.WithTimeout(40*time.Second),
+		))
 }

--- a/internal/controllers/phase_reconciler.go
+++ b/internal/controllers/phase_reconciler.go
@@ -282,6 +282,10 @@ func (r *PhaseReconciler) teardownPhaseObject(
 		if !r.ownerStrategy.IsOwner(owner.ClientObject(), currentObj) {
 			return true, nil
 		}
+
+		// This object is controlled by someone else
+		// so we don't have to delete it for cleanup.
+		// But we still want to remove ourselves as potential owner.
 		object := &unstructured.Unstructured{}
 		object.SetOwnerReferences(currentObj.GetOwnerReferences())
 		r.ownerStrategy.RemoveOwner(owner.ClientObject(), object)

--- a/internal/controllers/phase_reconciler_test.go
+++ b/internal/controllers/phase_reconciler_test.go
@@ -310,7 +310,15 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) {
 			Return(false)
 		ownerStrategy.
 			On("IsOwner", ownerObj, currentObj).
+			Return(true)
+
+		ownerStrategy.
+			On("RemoveOwner", ownerObj, currentObj).
 			Return(false)
+
+		testClient.
+			On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil)
 
 		ctx := context.Background()
 		done, err := r.TeardownPhase(ctx, owner, corev1alpha1.ObjectSetTemplatePhase{
@@ -328,6 +336,8 @@ func TestPhaseReconciler_TeardownPhase(t *testing.T) {
 		// It's super important that we don't check ownership on desiredObj on accident, because that will always return true.
 		ownerStrategy.AssertCalled(t, "IsController", ownerObj, currentObj)
 		ownerStrategy.AssertCalled(t, "IsOwner", ownerObj, currentObj)
+		ownerStrategy.AssertCalled(t, "RemoveOwner", ownerObj, currentObj)
+		testClient.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Update the way to patch the object by removing ownerReference of the teardown external object

This resolves the https://issues.redhat.com/browse/PKO-60

This PR replaces https://github.com/package-operator/package-operator/pull/1382

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
