### PR TITLE
PKO-203 fix(manifests): set correct default hosted cluster namespace for (hypershift) hosted-cluster component of package-operator package

### DIFF
--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-manager.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: KUBECONFIG
           value: /data/kubeconfig
         - name: PKO_NAMESPACE
-          value: package-operator-system
+          value: openshift-package-operator
         - name: PKO_SERVICE_ACCOUNT_NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator.Namespace.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator.Namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     package-operator.run/phase: namespace
-  name: package-operator-system
+  name: openshift-package-operator
   labels:
     pod-security.kubernetes.io/enforce: 'restricted'
     pod-security.kubernetes.io/audit: 'restricted'

--- a/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
+++ b/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
@@ -42,7 +42,7 @@ spec:
         hostedClusterNamespace:
           description: Hosted cluster namespace for leader election
           type: string
-          default: package-operator-system
+          default: openshift-package-operator
         affinity:
           description: Affinity is a group of affinity scheduling rules.
           properties:


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This changes the default namespace on a (hypershift) hosted-cluster to `openshift-package-operator`.

Issue Link: https://issues.redhat.com/browse/PKO-203

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
