### PR TITLE
fix(component/hosted-cluster): deploy dummy ServiceAccount to HC and make it discoverable to package-operator-hosted-cluster-manager to enable ImagePullSecret resolution

### DIFF
--- a/cmd/package-operator-manager/components/options.go
+++ b/cmd/package-operator-manager/components/options.go
@@ -14,12 +14,14 @@ import (
 
 // Flags.
 const (
-	metricsAddrFlagDescription             = "The address the metric endpoint binds to."
-	pprofAddrFlagDescription               = "The address the pprof web endpoint binds to."
-	namespaceFlagDescription               = "The namespace the operator is deployed into."
-	serviceAccountNameFlagDescription      = "Name of the service-account this operator is running under."
-	serviceAccountNamespaceFlagDescription = "Namespace of the service-account this operator is running under."
-	leaderElectionFlagDescription          = "Enable leader election for controller manager. " +
+	metricsAddrFlagDescription        = "The address the metric endpoint binds to."
+	pprofAddrFlagDescription          = "The address the pprof web endpoint binds to."
+	namespaceFlagDescription          = "The namespace the operator is deployed into."
+	serviceAccountNameFlagDescription = "Name of the service-account this operator is running under. " +
+		"Used to resolve potentially attached ImagePullSecrets."
+	serviceAccountNamespaceFlagDescription = "Namespace of the service-account this operator is running under. " +
+		"Used to resolve potentially attached ImagePullSecrets."
+	leaderElectionFlagDescription = "Enable leader election for controller manager. " +
 		"Enabling this will ensure there is only one active controller manager."
 	probeAddrFlagDescription   = "The address the probe endpoint binds to."
 	versionFlagDescription     = "print version information and exit."

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator-hosted-cluster-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator-hosted-cluster-manager.Deployment.yaml
@@ -36,13 +36,9 @@ spec:
         - name: PKO_NAMESPACE
           value: yet-another
         - name: PKO_SERVICE_ACCOUNT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: yet-another
         - name: PKO_SERVICE_ACCOUNT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
+          value: package-operator
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator.ServiceAccount.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/with-config/package-operator.ServiceAccount.yaml
@@ -1,0 +1,9 @@
+# Administrators can attach ImagePullSecrets to this ServiceAccount.
+# Package-Operator will use these secrets to authenticate package image pull requests.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: yet-another

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-hosted-cluster-manager.Deployment.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator-hosted-cluster-manager.Deployment.yaml
@@ -36,13 +36,9 @@ spec:
         - name: PKO_NAMESPACE
           value: package-operator-system
         - name: PKO_SERVICE_ACCOUNT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: package-operator-system
         - name: PKO_SERVICE_ACCOUNT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
+          value: package-operator
         image: registry.package-operator.run/static-image
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator.ServiceAccount.yaml
+++ b/config/packages/package-operator/components/hosted-cluster/.test-fixtures/without-config/package-operator.ServiceAccount.yaml
@@ -1,0 +1,9 @@
+# Administrators can attach ImagePullSecrets to this ServiceAccount.
+# Package-Operator will use these secrets to authenticate package image pull requests.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: package-operator-system

--- a/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
+++ b/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
@@ -914,8 +914,8 @@ spec:
     class: hosted-cluster
   - name: namespace
     class: hosted-cluster
-  #- name: rbac
-  #  class: hosted-cluster
+  - name: rbac
+    class: hosted-cluster
   - name: deploy
   scopes:
   - Namespaced

--- a/config/packages/package-operator/components/hosted-cluster/package-operator-hosted-cluster-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/components/hosted-cluster/package-operator-hosted-cluster-manager.Deployment.yaml.gotmpl
@@ -62,13 +62,9 @@ spec:
         - name: PKO_NAMESPACE
           value: {{ .config.hostedClusterNamespace }}
         - name: PKO_SERVICE_ACCOUNT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: {{ .config.hostedClusterNamespace }}
         - name: PKO_SERVICE_ACCOUNT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
+          value: package-operator
 {{- if hasKey . "environment" }}
 {{- if hasKey .environment "proxy" }}
 {{- if hasKey .environment.proxy "httpProxy" }}

--- a/config/packages/package-operator/components/hosted-cluster/package-operator.ServiceAccount.yaml.gotmpl
+++ b/config/packages/package-operator/components/hosted-cluster/package-operator.ServiceAccount.yaml.gotmpl
@@ -1,0 +1,9 @@
+# Administrators can attach ImagePullSecrets to this ServiceAccount.
+# Package-Operator will use these secrets to authenticate package image pull requests.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: package-operator
+  namespace: {{ .config.hostedClusterNamespace }}


### PR DESCRIPTION
This ServiceAccount will not have any actual permissions attached because PKO uses the hypershift service-network-admin-kubeconfig secret when talking to the hosted-cluster.

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
