### PR TITLE
build(release): build and publish an OCI based helm chart for the bootstrap job on release

### DIFF
--- a/cmd/build/chart.go
+++ b/cmd/build/chart.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"pkg.package-operator.run/cardboard/run"
+	"pkg.package-operator.run/cardboard/sh"
+)
+
+// (Helm) Chart targets.
+type Chart struct{}
+
+func (ch *Chart) appToChartVersion(appVersion string) string {
+	// appVersion has format `v1.15.0-14-g96e0a7ac`
+	// helm expects chartVersion to look like `1.15.0`.
+	// Take everything until the first `-` and trim the leading `v` off:
+	return strings.TrimPrefix(
+		strings.FieldsFunc(appVersion, func(r rune) bool { return r == '-' })[0],
+		"v",
+	)
+}
+
+func (ch *Chart) prepare(ctx context.Context, _ []string) error {
+	self := run.Meth1(ch, ch.prepare, []string{})
+
+	inDir := filepath.Join("config", "chart")
+	chartDir := filepath.Join(cacheDir, "chart")
+	chartFilePath := filepath.Join(chartDir, "Chart.yaml")
+
+	// Remove chart directory, so the build process always starts from a clean slate.
+	if err := os.RemoveAll(chartDir); err != nil {
+		return err
+	}
+
+	if err := mgr.SerialDeps(ctx, self,
+		run.Fn(func() error { return shr.Run("cp", "-r", inDir, chartDir) }),
+		run.Fn2(os.MkdirAll, filepath.Join(chartDir, "templates"), os.FileMode(0o755)),
+		run.Meth(generate, generate.selfBootstrapJobHelm),
+		run.Meth(generate, generate.helmValuesYaml),
+		run.Meth3(generate, generate.generateChartYaml, chartFilePath, ch.appToChartVersion(appVersion), appVersion),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ch *Chart) build(ctx context.Context, _ []string) error {
+	self := run.Meth1(ch, ch.build, []string{})
+
+	if err := mgr.SerialDeps(ctx, self,
+		run.Meth1(ch, ch.prepare, []string{}),
+	); err != nil {
+		return err
+	}
+
+	return shr.New(sh.WithWorkDir(cacheDir)).Run("helm", "package", "chart")
+}
+
+func (ch *Chart) push(ctx context.Context, _ []string) error {
+	self := run.Meth1(ch, ch.push, []string{})
+
+	if err := mgr.SerialDeps(ctx, self,
+		run.Meth1(ch, ch.build, []string{}),
+	); err != nil {
+		return err
+	}
+
+	tarballName := fmt.Sprintf("package-operator-%s.tgz", ch.appToChartVersion(appVersion))
+	repoURL := fmt.Sprintf("oci://%s/helm-charts", imageRegistry())
+	return shr.New(sh.WithWorkDir(cacheDir)).Run("helm", "push", tarballName, repoURL)
+}

--- a/cmd/build/ci.go
+++ b/cmd/build/ci.go
@@ -44,7 +44,7 @@ func (ci *CI) RegistryLogin(_ context.Context, args []string) error {
 	return shr.Run("crane", append([]string{"auth", "login"}, args...)...)
 }
 
-// Release builds binaries (if not exluded with the 'images-only" arg) and releases the
+// Release builds binaries and helm chart (if not exluded with the 'images-only" arg) and releases the
 // CLI, PKO manager, RP manager, PKO webhooks and test-stub images to the given registry.
 func (ci *CI) Release(ctx context.Context, args []string) error {
 	registry := imageRegistry()
@@ -63,6 +63,8 @@ func (ci *CI) Release(ctx context.Context, args []string) error {
 			run.Fn3(compile, "kubectl-package", "linux", "arm64"),
 			run.Fn3(compile, "kubectl-package", "darwin", "amd64"),
 			run.Fn3(compile, "kubectl-package", "darwin", "arm64"),
+			// helm chart
+			run.Meth1(chart, chart.push, []string{}),
 		)
 	}
 

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -21,7 +21,9 @@ var (
 	generate Generate
 	test     Test
 	lint     Lint
-	cluster  = NewCluster("pko",
+	chart    Chart
+
+	cluster = NewCluster("pko",
 		withLocalRegistry(imageRegistryHost(), devClusterRegistryPort, devClusterRegistryAuthPort),
 		withNodeLabels(map[string]string{"hypershift-affinity-test-label": "true"}),
 	)
@@ -47,7 +49,7 @@ func main() {
 		mgr.RegisterGoTool("k8s-docgen", "github.com/thetechnick/k8s-docgen", "0.6.2"),
 		mgr.RegisterGoTool("helm", "helm.sh/helm/v3/cmd/helm", "3.15.3"),
 		mgr.RegisterGoTool("govulncheck", "golang.org/x/vuln/cmd/govulncheck", "1.1.3"),
-		mgr.Register(&Dev{}, &CI{}),
+		mgr.Register(&Dev{}, &CI{}, &Chart{}),
 	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n%s\n", err)

--- a/config/chart/.helmignore
+++ b/config/chart/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+Chart.yaml.tpl

--- a/config/chart/Chart.yaml.tpl
+++ b/config/chart/Chart.yaml.tpl
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: package-operator
+description: |-
+  Package Operator is an open source operator, managing packages as collections of arbitrary objects, to install and maintain applications on one or multiple clusters.
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "##chart-version##"
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "##app-version##"

--- a/config/chart/values.yaml.tpl
+++ b/config/chart/values.yaml.tpl
@@ -1,0 +1,9 @@
+Images:
+  package-operator-manager: "##pko-manager-image##"
+  package-operator-package: "##pko-package-image##"
+
+# `Config` gives the installing user direct access to the package-operator package's configuration key.
+# It first gets passed into bootstrap job as envvar PKO_CONFIG.
+# Then the bootstrap job creates ClusterPackage/package-operator and supplies given data into `.spec.config`, which is PKO's official configuration API.
+# Look at `config/packages/package-operator/manifest.yaml.tpl` in the pko upstream repo to discover available configuration options.
+Config: {}


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR adds a helm chart for the bootstrap job that is published during the release process.
The helm chart is published to the same OCI registry, that is used to publish our workload and package images.

The chart will be published to `quay.io/package-operator/helm-charts/package-operator` and allows an end-user to install and upgrade a package-operator installation by running `helm upgrade --install package-operator oci://quay.io/package-operator/helm-charts/package-operator`.

The chart allows the following customizations through `values.yaml`:
- Using another workload image for the bootstrap job itself: `.Images.package-operator-manager`
- Using another package image for the package-operator installation (you'll need to use your own image if you want to use workload images from your own registry): `.Images.package-operator-package`
- Passing config to the package-operator ClusterPackage's `.spec.config`: `.Config`


I have published a test-release to `quay.io/erdii-pko-release-test/helm-charts/package-operator` by checking out this PR and running: `IMAGE_REGISTRY=quay.io/erdii-pko-release-test ./do ci:release`
You can do the same when reviewing.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
