### PR TITLE
fix(dependabot): group cardboard upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       applies-to: version-updates
       patterns:
       - golang.org/x/*
+    cardboard:
+      applies-to: version-updates
+      patterns:
+      - pkg.package-operator.run
+      - pkg.package-operator.run/cardboard/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: gomod
@@ -40,6 +45,11 @@ updates:
       applies-to: version-updates
       patterns:
       - golang.org/x/*
+    cardboard:
+      applies-to: version-updates
+      patterns:
+      - pkg.package-operator.run
+      - pkg.package-operator.run/cardboard/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: gomod
@@ -61,6 +71,11 @@ updates:
       applies-to: version-updates
       patterns:
       - golang.org/x/*
+    cardboard:
+      applies-to: version-updates
+      patterns:
+      - pkg.package-operator.run
+      - pkg.package-operator.run/cardboard/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: github-actions


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR reduces a small amount of toil since a single bump to cardboard currently opens 4 separate PRs:

- https://github.com/package-operator/package-operator/pull/1740
- https://github.com/package-operator/package-operator/pull/1741
- https://github.com/package-operator/package-operator/pull/1742
- https://github.com/package-operator/package-operator/pull/1743

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
