### PR TITLE
group dependabot prs for golangx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+    golangx:
+      applies-to: version-updates
+      patterns:
+      - golang.org/x/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: gomod
@@ -32,6 +36,10 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+    golangx:
+      applies-to: version-updates
+      patterns:
+      - golang.org/x/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: gomod
@@ -49,6 +57,10 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+    golangx:
+      applies-to: version-updates
+      patterns:
+      - golang.org/x/*
   commit-message:
     prefix: "build(deps)"
 - package-ecosystem: github-actions
@@ -60,4 +72,3 @@ updates:
   open-pull-requests-limit: 100
   commit-message:
     prefix: "build(deps)"
-


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Similar to https://github.com/package-operator/package-operator/pull/1744 this pr ensures that the golang.org/x modules get bumped together, since they tend to have interdependencies.

Example PR: https://github.com/package-operator/package-operator/pull/1748

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
