### PR TITLE
[PKO-208]Add GH Action that runs go mod tidy on dependabot PRs

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -12,7 +12,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  update-go-modules:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22'
+          cache-dependency-path: "**/*.sum"
+          check-latest: true
+
+      - name: Detect Go modules
+        id: detect_modules
+        run: |
+          echo "Finding all Go modules..."
+          MODULES=$(find . -mindepth 1 -name "go.mod" | sort | xargs -n1 dirname)
+          MODULES=". $MODULES"
+          MODULES=$(echo "$MODULES" | tr '\n' ' ')  # Convert newlines to spaces
+          echo "Detected modules: $MODULES"
+          echo "MODULES=$MODULES" >> $GITHUB_ENV
+
+      - name: Run go mod tidy for all modules
+        run: |
+          UPDATE=""
+          for module in $MODULES; do
+            echo "Processing module: $module"
+            cd "$module" || exit 1
+            go mod tidy
+            if ! git diff --quiet; then
+              echo "Detected changes in $module"
+              UPDATE="$UPDATE $module"
+              git add go.mod go.sum
+            fi
+            cd - > /dev/null
+          done
+          echo "UPDATE=$UPDATE" >> $GITHUB_ENV
+
+      - name: Run go work sync
+        if: env.UPDATE != ''
+        run: go work sync
+
+      - name: Commit and push changes
+        if: env.UPDATE != ''
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "fix: sync dependencies with go mod tidy" || echo "No changes to commit"
+          git push origin HEAD:${{ github.head_ref }}
+
   lint-unit-int:
+    needs: [ update-go-modules ]
+    if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -34,9 +34,9 @@ jobs:
         id: detect_modules
         run: |
           echo "Finding all Go modules..."
-          MODULES=$(find . -mindepth 1 -name "go.mod" | sort | xargs -n1 dirname)
-          MODULES=". $MODULES"
+          MODULES=$(find . -mindepth 2 -name "go.mod" | sort | xargs -n1 dirname)
           MODULES=$(echo "$MODULES" | tr '\n' ' ')  # Convert newlines to spaces
+          MODULES=". $MODULES"
           echo "Detected modules: $MODULES"
           echo "MODULES=$MODULES" >> $GITHUB_ENV
 
@@ -45,14 +45,14 @@ jobs:
           UPDATE=""
           for module in $MODULES; do
             echo "Processing module: $module"
-            cd "$module" || exit 1
+            pushd "$module" || exit 1
             go mod tidy
             if ! git diff --quiet; then
               echo "Detected changes in $module"
               UPDATE="$UPDATE $module"
               git add go.mod go.sum
             fi
-            cd - > /dev/null
+            popd
           done
           echo "UPDATE=$UPDATE" >> $GITHUB_ENV
 
@@ -65,7 +65,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "fix: sync dependencies with go mod tidy" || echo "No changes to commit"
+          git commit -m "fix: sync dependencies with go mod tidy / go work sync" || echo "No changes to commit"
           git push origin HEAD:${{ github.head_ref }}
 
   lint-unit-int:


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
This is to resolve https://issues.redhat.com/browse/PKO-208 for adding a github action to run go mod tidy to keep the module clean

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
 Bug Fix 
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
