### PR TITLE
Revert "[PKO-208]Add GH Action that runs go mod tidy on dependabot PRs (#1768)

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -12,65 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  update-go-modules:
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '>=1.22'
-          cache-dependency-path: "**/*.sum"
-          check-latest: true
-
-      - name: Detect Go modules
-        id: detect_modules
-        run: |
-          echo "Finding all Go modules..."
-          MODULES=$(find . -mindepth 2 -name "go.mod" | sort | xargs -n1 dirname)
-          MODULES=$(echo "$MODULES" | tr '\n' ' ')  # Convert newlines to spaces
-          MODULES=". $MODULES"
-          echo "Detected modules: $MODULES"
-          echo "MODULES=$MODULES" >> $GITHUB_ENV
-
-      - name: Run go mod tidy for all modules
-        run: |
-          UPDATE=""
-          for module in $MODULES; do
-            echo "Processing module: $module"
-            pushd "$module" || exit 1
-            go mod tidy
-            if ! git diff --quiet; then
-              echo "Detected changes in $module"
-              UPDATE="$UPDATE $module"
-              git add go.mod go.sum
-            fi
-            popd
-          done
-          echo "UPDATE=$UPDATE" >> $GITHUB_ENV
-
-      - name: Run go work sync
-        if: env.UPDATE != ''
-        run: go work sync
-
-      - name: Commit and push changes
-        if: env.UPDATE != ''
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "fix: sync dependencies with go mod tidy / go work sync" || echo "No changes to commit"
-          git push origin HEAD:${{ github.head_ref }}
-
   lint-unit-int:
-    needs: [ update-go-modules ]
-    if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
This reverts commit d1edcee25b11908d9ef3c8da6f614f8ad2cfa9a0.

Does not work since the PR creates an additonal job that creates new commits. The existing job never sees them though since they run in parallel.
