### PR TITLE
Add some newlines to kubectl-package output.

### DIFF
--- a/cmd/kubectl-package/buildcmd/build.go
+++ b/cmd/kubectl-package/buildcmd/build.go
@@ -64,7 +64,7 @@ func NewCmd(builderFactory BuilderFactory) *cobra.Command {
 			return fmt.Errorf("building from source: %w", err)
 		}
 
-		if _, err := fmt.Fprint(cmd.OutOrStdout(), buildSuccessMessage); err != nil {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), buildSuccessMessage); err != nil {
 			panic(err)
 		}
 		return nil

--- a/cmd/kubectl-package/buildcmd/build_test.go
+++ b/cmd/kubectl-package/buildcmd/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -37,7 +38,7 @@ func TestBuildOutput(t *testing.T) {
 	cmd.SetArgs([]string{packagePath, "--tag", "chicken:oldest", "--output", f.Name()})
 
 	require.NoError(t, cmd.Execute())
-	require.EqualValues(t, "Package built successfully!", stdout.String())
+	require.EqualValues(t, "Package built successfully!", strings.TrimSpace(stdout.String()))
 	require.Empty(t, stderr.String())
 
 	i, err := tarball.ImageFromPath(f.Name(), nil)
@@ -142,7 +143,7 @@ func TestBuildWithPath(t *testing.T) {
 	cmd.SetArgs([]string{packagePath})
 
 	require.NoError(t, cmd.Execute())
-	require.EqualValues(t, "Package built successfully!", stdout.String())
+	require.EqualValues(t, "Package built successfully!", strings.TrimSpace(stdout.String()))
 	require.Empty(t, stderr.String())
 }
 

--- a/config/packages/invalid/missing-annotation-and-phases/configmap.yaml
+++ b/config/packages/invalid/missing-annotation-and-phases/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+data:
+  i am: missing the package-operator.run/phase annotation

--- a/config/packages/invalid/missing-annotation-and-phases/manifest.yaml
+++ b/config/packages/invalid/missing-annotation-and-phases/manifest.yaml
@@ -1,0 +1,8 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: missing-annotation
+spec:
+  scopes:
+  - Namespaced
+  phases: []

--- a/config/packages/invalid/missing-annotation/configmap.yaml
+++ b/config/packages/invalid/missing-annotation/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+data:
+  i am: missing the package-operator.run/phase annotation

--- a/config/packages/invalid/missing-annotation/manifest.yaml
+++ b/config/packages/invalid/missing-annotation/manifest.yaml
@@ -1,0 +1,9 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: missing-annotation
+spec:
+  scopes:
+  - Namespaced
+  phases:
+  - name: data

--- a/config/packages/invalid/missing-phases/configmap.yaml
+++ b/config/packages/invalid/missing-phases/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+  annotations:
+    package-operator.run/phase: data
+data:
+  i am: missing the package-operator.run/phase annotation

--- a/config/packages/invalid/missing-phases/manifest.yaml
+++ b/config/packages/invalid/missing-phases/manifest.yaml
@@ -1,0 +1,8 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: missing-annotation
+spec:
+  scopes:
+  - Namespaced
+  phases: []

--- a/integration/kubectl-package/build_test.go
+++ b/integration/kubectl-package/build_test.go
@@ -33,7 +33,7 @@ var _ = ginkgo.DescribeTable("build subcommand",
 	ginkgo.Entry("given '--output' with a not previsouly existing path",
 		subCommandTestCase{
 			Args: []string{
-				"--output", filepath.Join("dne", "dne"),
+				"--output", filepath.Join(".cache", "dne", "dne"),
 				"--tag", "test",
 				sourcePathFixture("valid_without_config"),
 			},

--- a/internal/packages/internal/packagevalidation/errors.go
+++ b/internal/packages/internal/packagevalidation/errors.go
@@ -1,0 +1,67 @@
+// Partially: Copyright 2022 The Go Authors. All rights reserved.
+// Slightly modified errors.Join implementation.
+
+package packagevalidation
+
+import (
+	"strings"
+)
+
+// joinErrorsReadable returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if every value in errs is nil.
+// The error formats as the concatenation of the `-`-prefixed strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+// It also optionally prefixes the whole error string with a newline,
+// which can be useful when wrapping this error and printing it directly.
+//
+// A non-nil error returned by Join implements the Unwrap() []error method.
+func joinErrorsReadable(prefixNewline bool, errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &readableJoinError{
+		prefixNewline: prefixNewline,
+		errs:          make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+// Never instantiate readableJoinError directly!
+// Use `joinErrorsReadable(...)` instead.
+type readableJoinError struct {
+	prefixNewline bool
+	errs          []error
+}
+
+func (e *readableJoinError) Error() string {
+	// Since Join returns nil if every value in errs is nil,
+	// e.errs cannot be empty.
+	sb := strings.Builder{}
+	if e.prefixNewline {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("- " + e.errs[0].Error())
+
+	for _, err := range e.errs[1:] {
+		sb.WriteByte('\n')
+		sb.WriteString("- " + err.Error())
+	}
+	return sb.String()
+}
+
+func (e *readableJoinError) Unwrap() []error {
+	return e.errs
+}

--- a/internal/packages/internal/packagevalidation/validation.go
+++ b/internal/packages/internal/packagevalidation/validation.go
@@ -2,7 +2,6 @@ package packagevalidation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 
@@ -34,7 +33,14 @@ func (l PackageValidatorList) ValidatePackage(ctx context.Context, pkg *packaget
 			errs = append(errs, err)
 		}
 	}
-	return errors.Join(errs...)
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		return joinErrorsReadable(true, errs...)
+	}
 }
 
 // Validates PackageManifests and PackageManifestLock.


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR is a proposal to change the newline behaviour/formatting of two subcommands of kubectl-package:

#### **chore(package-validation): join validation errors in a readable manner**

kubectl-package validation failures will now print the separate errors prefixed with dashes
```
$ go run ./cmd/kubectl-package build config/packages/invalid/missing-annotation-and-phases 
Error: building from source: loading package from files: 
- spec.phases: Required value
- loading package from files: Missing package-operator.run/phase Annotation in configmap.yaml idx 0
```
instead of 
```
$ kubectl package build config/packages/invalid/missing-annotation-and-phases 
Error: building from source: loading package from files: spec.phases: Required value
loading package from files: Missing package-operator.run/phase Annotation in configmap.yaml idx 0
```

Errors won't be broken out onto a new line and won't be prefixed when only a singular validation error occurs:
```
$ go run ./cmd/kubectl-package build config/packages/invalid/missing-annotation
Error: building from source: loading package from files: loading package from files: Missing package-operator.run/phase Annotation in configmap.yaml idx 0
```


#### **fix(kubectl-package): print final newline after successfully building a package**

kubectl-package build successes will now make the users shell look like
```
$ go run ./cmd/kubectl-package build config/packages/nginx 
Package built successfully!
$
```
instead of
```
$ kubectl package build config/packages/nginx 
Package built successfully!$ 
```

#### Misc

It also includes a quality-of-life change to a kubectl-package integration test to keep the repo clean on running said test:
- **chore(integration/kubectl-package): store package tarball in .cache prefixed folder to keep repo clean when running integration tests**

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
