### PR TITLE
Add image label to pkg availability metric

### DIFF
--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -46,7 +46,7 @@ func NewRecorder() *Recorder {
 		prometheus.GaugeOpts{
 			Name: "package_operator_package_availability",
 			Help: "Package availability 0=Unavailable,1=Available,2=Unknown.",
-		}, []string{"pko_name", "pko_namespace"},
+		}, []string{"pko_name", "pko_namespace", "image"},
 	)
 	packageCreated := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -107,6 +107,7 @@ func (r *Recorder) Register() {
 
 type GenericPackage interface {
 	ClientObject() client.Object
+	GetImage() string
 	GetConditions() *[]metav1.Condition
 	GetStatusRevision() int64
 }
@@ -136,7 +137,7 @@ func (r *Recorder) RecordPackageMetrics(pkg GenericPackage) {
 	}
 
 	r.packageAvailability.WithLabelValues(
-		obj.GetName(), obj.GetNamespace(),
+		obj.GetName(), obj.GetNamespace(), pkg.GetImage(),
 	).Set(float64(healthStatus))
 	r.packageCreated.WithLabelValues(
 		obj.GetName(), obj.GetNamespace(),

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -136,9 +136,20 @@ func (r *Recorder) RecordPackageMetrics(pkg GenericPackage) {
 		}
 	}
 
+	// Delete all old availability timeseries for this package first.
+	// This is needed because changes to the image label will introduce a new timeseries
+	// and we only want 1 timeseries for any given package.
+	// This is racy, because scraping could happen in between and result in 0 timeseries.
+	// OLM does the same though:
+	// https://github.com/operator-framework/operator-lifecycle-manager/blob/abd99636e779f0bfbce31225e377d6bfd4fa3b9b/pkg/metrics/metrics.go#L302-L324
+	r.packageAvailability.DeletePartialMatch(prometheus.Labels{
+		"pko_name":      obj.GetName(),
+		"pko_namespace": obj.GetNamespace(),
+	})
 	r.packageAvailability.WithLabelValues(
 		obj.GetName(), obj.GetNamespace(), pkg.GetImage(),
 	).Set(float64(healthStatus))
+
 	r.packageCreated.WithLabelValues(
 		obj.GetName(), obj.GetNamespace(),
 	).Set(float64(obj.GetCreationTimestamp().Unix()))

--- a/internal/metrics/recorder_test.go
+++ b/internal/metrics/recorder_test.go
@@ -137,6 +137,43 @@ func TestRecorder_RecordPackageMetrics(t *testing.T) {
 	}
 }
 
+// Ensures that only a single package availability timeseries is exposed after image changes.
+func TestRecorder_RecordPackageMetrics_updateImage(t *testing.T) {
+	t.Parallel()
+
+	newPackage := func(image string) *adapters.GenericPackage {
+		return &adapters.GenericPackage{
+			Package: corev1alpha1.Package{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.Time{Time: time.Date(2022, 5, 27, 15, 37, 19, 0, time.UTC)},
+				},
+				Spec: corev1alpha1.PackageSpec{
+					Image: image,
+				},
+			},
+		}
+	}
+
+	recorder := NewRecorder()
+
+	for _, image := range []string{
+		"image:a",
+		"image:b",
+		"image:c",
+	} {
+		pkg := newPackage(image)
+		recorder.RecordPackageMetrics(pkg)
+
+		// Assert that only a single timeseries is present. (Timeseries with a previous image label must be dropped.)
+		assert.Equal(t, 1, testutil.CollectAndCount(recorder.packageAvailability))
+		// Assert that the present timeseries is using the correct up-to-date label.
+		assert.Equal(t, 1, testutil.CollectAndCount(
+			recorder.packageAvailability.WithLabelValues(pkg.Name, pkg.Namespace, pkg.Spec.Image)))
+	}
+}
+
 func TestRecorder_RecordPackageMetrics_delete(t *testing.T) {
 	t.Parallel()
 	d := metav1.Now()

--- a/internal/metrics/recorder_test.go
+++ b/internal/metrics/recorder_test.go
@@ -115,7 +115,7 @@ func TestRecorder_RecordPackageMetrics(t *testing.T) {
 			assert.InDelta(t,
 				test.expectedAvailability,
 				testutil.ToFloat64(recorder.packageAvailability.WithLabelValues(
-					test.pkg.GetName(), test.pkg.GetNamespace(),
+					test.pkg.GetName(), test.pkg.GetNamespace(), test.pkg.Spec.Image,
 				)),
 				0.01,
 			)


### PR DESCRIPTION
### Summary
Add the currently active image to the availability metric to give users the ability to correlate the status to a specific version.

Issue Link: https://issues.redhat.com/browse/PKO-251

### Change Type
New Feature

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
