### PR TITLE
chore(cmd/build): change default dev registry address to free up access to quay

### DIFF
--- a/cmd/build/definitions.go
+++ b/cmd/build/definitions.go
@@ -10,7 +10,7 @@ import (
 const (
 	cacheDir = ".cache"
 
-	defaultImageRegistry    = "quay.io/package-operator"
+	defaultImageRegistry    = "dev.package-operator.run/package-operator"
 	imageRegistryEnvvarName = "IMAGE_REGISTRY"
 
 	devClusterRegistryPort     int32 = 5001


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

I got fed up forgetting to use `IMAGE_REGISTRY=foo.bar.dev ./do dev:...` when creating my local dev env and then having to re-create it just to be able to deploy a dev package image from quay.io, hence I propose:

Let's stop shadowing the real quay.io in our dev environments.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
