### PR TITLE
[PKO-242]Reduce loglevel to ERROR by default

### DIFF
--- a/cmd/package-operator-manager/main.go
+++ b/cmd/package-operator-manager/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
@@ -30,7 +32,11 @@ const (
 var di *dig.Container
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	opts := zap.Options{
+		Development: false,
+		Level:       zapcore.Level(1),
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	var err error
 	di, err = components.NewComponents()

--- a/cmd/remote-phase-manager/main.go
+++ b/cmd/remote-phase-manager/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,7 +78,11 @@ func main() {
 		os.Exit(2)
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	zapOpts := zap.Options{
+		Development: false,
+		Level:       zapcore.Level(1),
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
 	ourScheme := runtime.NewScheme()
 	setupLog := ctrl.Log.WithName("setup")


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
This is to resolve https://issues.redhat.com/browse/PKO-242. For binaries
package-operator
remote-phase-manager
to reduce the log level to Error by default and make it optional 

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
Test results for reducing the log level:
```
I0314 14:35:20.111683   34531 leaderelection.go:257] attempting to acquire leader lease package-operator-system/8a4hp84a6s.package-operator-lock...
I0314 14:36:11.106208   34531 leaderelection.go:271] successfully acquired lease package-operator-system/8a4hp84a6s.package-operator-lock
{"level":"error","ts":"2025-03-14T14:36:32+11:00","msg":"Reconciler error","controller":"clusterobjectset","controllerGroup":"package-operator.run","controllerKind":"ClusterObjectSet","ClusterObjectSet":{"name":"package-operator-8f5f9d9b4"},"namespace":"","name":"package-operator-8f5f9d9b4","reconcileID":"2ed7ea17-194f-4cef-98aa-a36c7a2dd66b","error":"updating ObjectSet status: Operation cannot be fulfilled on clusterobjectsets.package-operator.run \"package-operator-8f5f9d9b4\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/wehe/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:341\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/wehe/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:288\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/wehe/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:249"}
```