### PR TITLE
[PKO-231] Remove govulncheck from precommit

### DIFF
--- a/cmd/build/dev.go
+++ b/cmd/build/dev.go
@@ -26,7 +26,6 @@ func (dev *Dev) PreCommit(ctx context.Context, args []string) error {
 		run.Meth(generate, generate.All),
 		run.Meth(lint, lint.glciFix),
 		run.Meth(lint, lint.goModTidyAll),
-		run.Meth(lint, lint.govulnCheck),
 	)
 }
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Remove govulncheck execution from the precommit run. Devs sometimes have outdated go versions which causes alerts to pop up that are specific to the developer, not our deployment.
### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
Docs/Test

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
