### PR TITLE
Update tools

### DIFF
--- a/cmd/build/generate.go
+++ b/cmd/build/generate.go
@@ -69,11 +69,10 @@ func (Generate) code() error {
 
 	// conversion generator
 	if err := shr.Run(
-		"conversion-gen", "--input-dirs", "./internal/apis/manifests",
+		"conversion-gen",
 		"--extra-peer-dirs=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1",
-		"--output-base=./",
-		"--output-file-base=zz_generated.conversion",
-		"-h", "/dev/null"); err != nil {
+		"--output-file=zz_generated.conversion.go", "./internal/apis/manifests",
+	); err != nil {
 		return (fmt.Errorf("generating conversion methods: %w", err))
 	}
 	// conversion-gen expects the SchemeBuilder to be called "localSchemeBuilder"

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -40,15 +40,15 @@ func main() {
 
 	err := errors.Join(
 		// Required by cardboard itself.
-		mgr.RegisterGoTool("crane", "github.com/google/go-containerregistry/cmd/crane", "0.20.2"),
+		mgr.RegisterGoTool("crane", "github.com/google/go-containerregistry/cmd/crane", "0.20.3"),
 		// Our deps
 		mgr.RegisterGoTool("gotestfmt", "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt", "2.5.0"),
-		mgr.RegisterGoTool("controller-gen", "sigs.k8s.io/controller-tools/cmd/controller-gen", "0.17.0"),
-		mgr.RegisterGoTool("conversion-gen", "k8s.io/code-generator/cmd/conversion-gen", "0.29.4"),
-		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/cmd/golangci-lint", "1.63.3"),
+		mgr.RegisterGoTool("controller-gen", "sigs.k8s.io/controller-tools/cmd/controller-gen", "0.17.2"),
+		mgr.RegisterGoTool("conversion-gen", "k8s.io/code-generator/cmd/conversion-gen", "0.32.2"),
+		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/cmd/golangci-lint", "1.64.8"),
 		mgr.RegisterGoTool("k8s-docgen", "github.com/thetechnick/k8s-docgen", "0.6.2"),
-		mgr.RegisterGoTool("helm", "helm.sh/helm/v3/cmd/helm", "3.15.3"),
-		mgr.RegisterGoTool("govulncheck", "golang.org/x/vuln/cmd/govulncheck", "1.1.3"),
+		mgr.RegisterGoTool("helm", "helm.sh/helm/v3/cmd/helm", "3.17.2"),
+		mgr.RegisterGoTool("govulncheck", "golang.org/x/vuln/cmd/govulncheck", "1.1.4"),
 		mgr.Register(&Dev{}, &CI{}),
 	)
 	if err != nil {

--- a/config/crds/package-operator.run_clusterobjectdeployments.yaml
+++ b/config/crds/package-operator.run_clusterobjectdeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectdeployments.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_clusterobjectsetphases.yaml
+++ b/config/crds/package-operator.run_clusterobjectsetphases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectsetphases.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectsets.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_clusterobjectslices.yaml
+++ b/config/crds/package-operator.run_clusterobjectslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectslices.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_clusterobjecttemplates.yaml
+++ b/config/crds/package-operator.run_clusterobjecttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjecttemplates.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_clusterpackages.yaml
+++ b/config/crds/package-operator.run_clusterpackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterpackages.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_objectdeployments.yaml
+++ b/config/crds/package-operator.run_objectdeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectdeployments.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_objectsetphases.yaml
+++ b/config/crds/package-operator.run_objectsetphases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectsetphases.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectsets.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_objectslices.yaml
+++ b/config/crds/package-operator.run_objectslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectslices.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_objecttemplates.yaml
+++ b/config/crds/package-operator.run_objecttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objecttemplates.package-operator.run
 spec:
   group: package-operator.run

--- a/config/crds/package-operator.run_packages.yaml
+++ b/config/crds/package-operator.run_packages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: packages.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectdeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectdeployments.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsetphases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectsetphases.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectsets.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterobjectslices.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjectslices.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterobjecttemplates.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjecttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterobjecttemplates.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_clusterpackages.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterpackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterpackages.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_objectdeployments.yaml
+++ b/config/static-deployment/1-package-operator.run_objectdeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectdeployments.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_objectsetphases.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsetphases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectsetphases.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectsets.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_objectslices.yaml
+++ b/config/static-deployment/1-package-operator.run_objectslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objectslices.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_objecttemplates.yaml
+++ b/config/static-deployment/1-package-operator.run_objecttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: objecttemplates.package-operator.run
 spec:
   group: package-operator.run

--- a/config/static-deployment/1-package-operator.run_packages.yaml
+++ b/config/static-deployment/1-package-operator.run_packages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: packages.package-operator.run
 spec:
   group: package-operator.run


### PR DESCRIPTION
conversion-gen has remove the "--input-dirs" flag and replaced it by positional arguments.
conversion-gen has remove the "-h" flag.
conversion-gen has renamed the "--out-file-base" to "--output-file"
conversion-gen has remove the "--output-base" flag

