### PR TITLE
Image prefix overrides

### DIFF
--- a/cmd/build/generate.go
+++ b/cmd/build/generate.go
@@ -122,6 +122,7 @@ func (g Generate) selfBootstrapJobLocal(context.Context) error {
 
 	type cfg struct {
 		RegistryHostOverrides                       string              `json:"registryHostOverrides"`
+		ImagePrefixOverrides                        string              `json:"imagePrefixOverrides"`
 		ObjectTemplateOptionalResourceRetryInterval string              `json:"objectTemplateOptionalResourceRetryInterval"`
 		ObjectTemplateResourceRetryInterval         string              `json:"objectTemplateResourceRetryInterval"`
 		SubcomponentAffinity                        corev1.Affinity     `json:"subcomponentAffinity,omitempty"`
@@ -150,6 +151,7 @@ func (g Generate) selfBootstrapJobLocal(context.Context) error {
 		SubcomponentTolerations: []corev1.Toleration{
 			{Effect: "NoSchedule", Key: "node-role.kubernetes.io/infra"},
 		},
+		ImagePrefixOverrides: "",
 	})
 	if err != nil {
 		return err

--- a/cmd/package-operator-manager/bootstrap/bootstrap.go
+++ b/cmd/package-operator-manager/bootstrap/bootstrap.go
@@ -41,7 +41,7 @@ func NewBootstrapper(
 	c := uncachedClient
 	init := newInitializer(
 		c, scheme, &packageObjectLoad{},
-		registry.Pull, opts.Namespace, opts.SelfBootstrap, opts.SelfBootstrapConfig,
+		registry.Pull, opts.Namespace, opts.SelfBootstrap, opts.SelfBootstrapConfig, opts.ImagePrefixOverrides,
 	)
 	fixer := newFixer(c, log, opts.Namespace)
 

--- a/cmd/package-operator-manager/bootstrap/init.go
+++ b/cmd/package-operator-manager/bootstrap/init.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -42,6 +43,7 @@ type initializer struct {
 	packageOperatorNamespace string
 	selfBootstrapImage       string
 	selfConfig               string
+	imagePrefixOverrides     string
 }
 
 func newInitializer(
@@ -54,6 +56,7 @@ func newInitializer(
 	packageOperatorNamespace string,
 	selfBootstrapImage string,
 	selfConfig string,
+	imagePrefixOverrides string,
 ) *initializer {
 	return &initializer{
 		client:    client,
@@ -64,6 +67,7 @@ func newInitializer(
 		packageOperatorNamespace: packageOperatorNamespace,
 		selfBootstrapImage:       selfBootstrapImage,
 		selfConfig:               selfConfig,
+		imagePrefixOverrides:     imagePrefixOverrides,
 	}
 }
 
@@ -220,6 +224,18 @@ func (init *initializer) config() *runtime.RawExtension {
 		packageConfig = &runtime.RawExtension{
 			Raw: []byte(init.selfConfig),
 		}
+	}
+	if len(init.imagePrefixOverrides) > 0 {
+		rawConfig := make(map[string]any)
+		if err := json.Unmarshal(packageConfig.Raw, &rawConfig); err != nil {
+			panic(err)
+		}
+		rawConfig["imagePrefixOverrides"] = init.imagePrefixOverrides
+		jsonConfig, err := json.Marshal(&rawConfig)
+		if err != nil {
+			panic(err)
+		}
+		packageConfig.Raw = jsonConfig
 	}
 	return packageConfig
 }

--- a/cmd/package-operator-manager/bootstrap/init_test.go
+++ b/cmd/package-operator-manager/bootstrap/init_test.go
@@ -117,7 +117,9 @@ func Test_initializer_ensureUpdatedPKO(t *testing.T) {
 					mock.Anything,
 				).Run(func(args mock.Arguments) {
 					pkg := args.Get(2).(*corev1alpha1.ClusterPackage)
-					*pkg = *i.newPKOClusterPackage()
+					clPkg, err := i.newPKOClusterPackage()
+					require.NoError(t, err)
+					*pkg = *clPkg
 				}).Return(nil)
 
 				// it has to check if PKO deployment is available
@@ -151,7 +153,9 @@ func Test_initializer_ensureUpdatedPKO(t *testing.T) {
 					mock.Anything,
 				).Run(func(args mock.Arguments) {
 					pkg := args.Get(2).(*corev1alpha1.ClusterPackage)
-					*pkg = *i.newPKOClusterPackage()
+					clPkg, err := i.newPKOClusterPackage()
+					require.NoError(t, err)
+					*pkg = *clPkg
 					pkg.Generation = 5
 					meta.SetStatusCondition(&pkg.Status.Conditions, metav1.Condition{
 						Type:               corev1alpha1.PackageAvailable,
@@ -186,7 +190,8 @@ func Test_initializer_ensureUpdatedPKO(t *testing.T) {
 				t.Helper()
 
 				// mock existing ClusterPackage with different spec
-				existingPkg := i.newPKOClusterPackage()
+				existingPkg, err := i.newPKOClusterPackage()
+				require.NoError(t, err)
 				existingPkg.Spec.Image = "thisimagedoesnotexist.com"
 
 				c.On("Get",

--- a/cmd/package-operator-manager/components/options.go
+++ b/cmd/package-operator-manager/components/options.go
@@ -43,6 +43,9 @@ const (
 		"getting optional source resource for an ObjectTemplate."
 	objectTemplateResourceRetryIntervalFlagDescription = "The interval at which the controller will retry " +
 		"getting source resource for an ObjectTemplate."
+	imagePrefixOverrides = "List of image prefix overrides to change during image pulling. " +
+		"e.g. quay.io/foo=quay.io/bar/qux,<source-prefix>=<target-prefix>. If multiple prefixes match" +
+		"an image address, the most specific match wins."
 )
 
 type Options struct {
@@ -56,6 +59,7 @@ type Options struct {
 	RegistryHostOverrides       string
 	PackageHashModifier         *int32
 	PackageOperatorPackageImage string
+	ImagePrefixOverrides        string
 
 	// sub commands
 	SelfBootstrap       string
@@ -124,7 +128,10 @@ func ProvideOptions() (opts Options, err error) {
 		&opts.ObjectTemplateOptionalResourceRetryInterval,
 		"object-template-optional-resource-retry-interval",
 		time.Second*60, objectTemplateOptionalResourceRetryIntervalFlagDescription)
-
+	flag.StringVar(
+		&opts.ImagePrefixOverrides, "image-prefix-overrides",
+		os.Getenv("PKO_IMAGE_PREFIX_OVERRIDES"),
+		imagePrefixOverrides)
 	var (
 		subComponentAffinityJSON    string
 		subComponentTolerationsJSON string

--- a/cmd/package-operator-manager/components/package.go
+++ b/cmd/package-operator-manager/components/package.go
@@ -8,6 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	controllerspackages "package-operator.run/internal/controllers/packages"
+	"package-operator.run/internal/imageprefix"
 	"package-operator.run/internal/metrics"
 	"package-operator.run/internal/packages"
 )
@@ -26,6 +27,7 @@ type (
 func ProvideRequestManager(log logr.Logger, uncachedClient UncachedClient, opts Options) *packages.RequestManager {
 	return packages.NewRequestManager(
 		prepareRegistryHostOverrides(log, opts.RegistryHostOverrides),
+		prepareImagePrefixOverrides(log, opts.ImagePrefixOverrides),
 		uncachedClient.Client,
 		types.NamespacedName{
 			Namespace: opts.ServiceAccountNamespace,
@@ -52,6 +54,24 @@ func prepareRegistryHostOverrides(log logr.Logger, flag string) map[string]strin
 	return out
 }
 
+func prepareImagePrefixOverrides(log logr.Logger, flag string) []imageprefix.Override {
+	if len(flag) == 0 {
+		return nil
+	}
+
+	log.WithName("ImagePrefix").Info("image prefix overrides active", "overrides", flag)
+	out := []imageprefix.Override{}
+	overrides := strings.Split(flag, ",")
+	for _, or := range overrides {
+		parts := strings.SplitN(or, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out = append(out, imageprefix.Override{From: parts[0], To: parts[1]})
+	}
+	return out
+}
+
 func ProvidePackageController(
 	mgr ctrl.Manager, log logr.Logger, uncachedClient UncachedClient,
 	requestManager *packages.RequestManager,
@@ -65,6 +85,7 @@ func ProvidePackageController(
 			log.WithName("controllers").WithName("Package"),
 			mgr.GetScheme(),
 			requestManager, recorder, opts.PackageHashModifier,
+			prepareImagePrefixOverrides(log, opts.ImagePrefixOverrides),
 		),
 	}
 }
@@ -82,6 +103,7 @@ func ProvideClusterPackageController(
 			log.WithName("controllers").WithName("ClusterPackage"),
 			mgr.GetScheme(),
 			requestManager, recorder, opts.PackageHashModifier,
+			prepareImagePrefixOverrides(log, opts.ImagePrefixOverrides),
 		),
 	}
 }

--- a/cmd/package-operator-manager/components/package_test.go
+++ b/cmd/package-operator-manager/components/package_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
+
+	"package-operator.run/internal/imageprefix"
 )
 
 func Test_prepareRegistryHostOverrides(t *testing.T) {
@@ -12,4 +14,16 @@ func Test_prepareRegistryHostOverrides(t *testing.T) {
 	log := testr.New(t)
 	or := prepareRegistryHostOverrides(log, "quay.io=dev-registry.dev-registry.svc.cluster.local:5001")
 	assert.Equal(t, map[string]string{"quay.io": "dev-registry.dev-registry.svc.cluster.local:5001"}, or)
+}
+
+func Test_prepareImagePrefixOverrides(t *testing.T) {
+	t.Parallel()
+	log := testr.New(t)
+	or := prepareImagePrefixOverrides(log, "quay.io/foo/=quay.io/bar/")
+	assert.Equal(t, []imageprefix.Override{
+		{
+			From: "quay.io/foo/",
+			To:   "quay.io/bar/",
+		},
+	}, or)
 }

--- a/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
+++ b/config/packages/package-operator/components/hosted-cluster/manifest.yaml.tpl
@@ -35,6 +35,8 @@ spec:
           format: int32
         registryHostOverrides:
           type: string
+        imagePrefixOverrides:
+          type: string
         namespace:
           description: Namespace to install package operator into. If empty, the Package namespace will be used.
           type: string

--- a/config/packages/package-operator/components/hosted-cluster/package-operator-hosted-cluster-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/components/hosted-cluster/package-operator-hosted-cluster-manager.Deployment.yaml.gotmpl
@@ -47,6 +47,10 @@ spec:
         - name: PKO_REGISTRY_HOST_OVERRIDES
           value: {{ .config.registryHostOverrides }}
 {{- end}}
+{{- if hasKey .config "imagePrefixOverrides" }}
+        - name: PKO_IMAGE_PREFIX_OVERRIDES
+          value: {{ .config.imagePrefixOverrides }}
+{{- end}}
 {{- if hasKey .config "packageHashModifier" }}
         - name: PKO_PACKAGE_HASH_MODIFIER
           value: {{ .config.packageHashModifier | quote }}

--- a/config/packages/package-operator/manifest.yaml.tpl
+++ b/config/packages/package-operator/manifest.yaml.tpl
@@ -36,6 +36,8 @@ spec:
           format: int32
         registryHostOverrides:
           type: string
+        imagePrefixOverrides:
+          type: string
         objectTemplateResourceRetryInterval:
           type: string
         objectTemplateOptionalResourceRetryInterval:

--- a/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
+++ b/config/packages/package-operator/package-operator-manager.Deployment.yaml.gotmpl
@@ -47,6 +47,10 @@ spec:
         - name: PKO_REGISTRY_HOST_OVERRIDES
           value: {{ .config.registryHostOverrides }}
 {{- end}}
+{{- if hasKey .config "imagePrefixOverrides" }}
+        - name: PKO_IMAGE_PREFIX_OVERRIDES
+          value: {{ .config.imagePrefixOverrides }}
+{{- end}}
 {{- if hasKey .config "packageHashModifier" }}
         - name: PKO_PACKAGE_HASH_MODIFIER
           value: {{ .config.packageHashModifier | quote }}

--- a/config/self-bootstrap-job.yaml.tpl
+++ b/config/self-bootstrap-job.yaml.tpl
@@ -53,6 +53,8 @@ spec:
         env:
         - name: PKO_REGISTRY_HOST_OVERRIDES
           value: "##registry-overrides##"
+        - name: PKO_IMAGE_PREFIX_OVERRIDES
+          value: ""
         - name: PKO_CONFIG
           value: '##pko-config##'
         - name: PKO_NAMESPACE

--- a/internal/controllers/packages/package_controller.go
+++ b/internal/controllers/packages/package_controller.go
@@ -57,7 +57,8 @@ func NewPackageController(
 ) *GenericPackageController {
 	return newGenericPackageController(
 		adapters.NewGenericPackage, adapters.NewObjectDeployment,
-		c, uncachedClient, log, scheme, imagePuller, packages.NewPackageDeployer(c, uncachedClient, scheme, imagePrefixOverrides),
+		c, uncachedClient, log, scheme, imagePuller,
+		packages.NewPackageDeployer(c, uncachedClient, scheme, imagePrefixOverrides),
 		metricsRecorder, packageHashModifier, imagePrefixOverrides,
 	)
 }

--- a/internal/controllers/packages/package_controller.go
+++ b/internal/controllers/packages/package_controller.go
@@ -15,6 +15,7 @@ import (
 	"package-operator.run/internal/apis/manifests"
 	"package-operator.run/internal/controllers"
 	"package-operator.run/internal/environment"
+	"package-operator.run/internal/imageprefix"
 	"package-operator.run/internal/metrics"
 	"package-operator.run/internal/packages"
 )
@@ -52,11 +53,12 @@ func NewPackageController(
 	imagePuller imagePuller,
 	metricsRecorder metricsRecorder,
 	packageHashModifier *int32,
+	imagePrefixOverrides []imageprefix.Override,
 ) *GenericPackageController {
 	return newGenericPackageController(
 		adapters.NewGenericPackage, adapters.NewObjectDeployment,
-		c, uncachedClient, log, scheme, imagePuller, packages.NewPackageDeployer(c, uncachedClient, scheme),
-		metricsRecorder, packageHashModifier,
+		c, uncachedClient, log, scheme, imagePuller, packages.NewPackageDeployer(c, uncachedClient, scheme, imagePrefixOverrides),
+		metricsRecorder, packageHashModifier, imagePrefixOverrides,
 	)
 }
 
@@ -66,11 +68,12 @@ func NewClusterPackageController(
 	imagePuller imagePuller,
 	metricsRecorder metricsRecorder,
 	packageHashModifier *int32,
+	imagePrefixOverrides []imageprefix.Override,
 ) *GenericPackageController {
 	return newGenericPackageController(
 		adapters.NewGenericClusterPackage, adapters.NewClusterObjectDeployment,
-		c, uncachedClient, log, scheme, imagePuller, packages.NewClusterPackageDeployer(c, scheme),
-		metricsRecorder, packageHashModifier,
+		c, uncachedClient, log, scheme, imagePuller, packages.NewClusterPackageDeployer(c, scheme, imagePrefixOverrides),
+		metricsRecorder, packageHashModifier, imagePrefixOverrides,
 	)
 }
 
@@ -83,6 +86,7 @@ func newGenericPackageController(
 	packageDeployer packageDeployer,
 	metricsRecorder metricsRecorder,
 	packageHashModifier *int32,
+	imagePrefixOverrides []imageprefix.Override,
 ) *GenericPackageController {
 	controller := &GenericPackageController{
 		newPackage:          newPackage,
@@ -94,6 +98,7 @@ func newGenericPackageController(
 		unpackReconciler: newUnpackReconciler(
 			uncachedClient, imagePuller, packageDeployer,
 			metricsRecorder, environment.NewSink(client), packageHashModifier,
+			imagePrefixOverrides,
 		),
 		objDepStatusReconciler: &objectDeploymentStatusReconciler{
 			client:              client,

--- a/internal/controllers/packages/package_controller_test.go
+++ b/internal/controllers/packages/package_controller_test.go
@@ -45,6 +45,7 @@ func TestPackageController_Err(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 
 	clientMock.
@@ -77,6 +78,7 @@ func TestPackageController_NotFound(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 
@@ -126,9 +128,10 @@ func TestPackageController_Paused(t *testing.T) {
 		ctrl.Log.WithName("paused package test"),
 		packageScheme,
 		ipm,
-		packages.NewClusterPackageDeployer(clientMock, packageScheme),
+		packages.NewClusterPackageDeployer(clientMock, packageScheme, nil),
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 
@@ -173,6 +176,7 @@ func TestPackageController_Reconcile(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 
@@ -216,6 +220,7 @@ func TestClusterPackageController_Err(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 	clientMock.
 		On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.ClusterPackage"), mock.Anything).
@@ -247,6 +252,7 @@ func TestClusterOPackageController_NotFound(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 
@@ -296,9 +302,10 @@ func TestClusterPackageController_Paused(t *testing.T) {
 		ctrl.Log.WithName("paused cluster package test"),
 		packageScheme,
 		ipm,
-		packages.NewClusterPackageDeployer(clientMock, packageScheme),
+		packages.NewClusterPackageDeployer(clientMock, packageScheme, nil),
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 
@@ -343,6 +350,7 @@ func TestClusterPackageController_Reconcile(t *testing.T) {
 		ipm,
 		mr,
 		&hash,
+		nil,
 	)
 	c.reconciler = nil
 

--- a/internal/controllers/packages/unpack_reconciler_test.go
+++ b/internal/controllers/packages/unpack_reconciler_test.go
@@ -26,7 +26,7 @@ func TestUnpackReconciler(t *testing.T) {
 
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil)
+	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil, nil)
 
 	const image = "test123:latest"
 
@@ -67,7 +67,7 @@ func TestUnpackReconciler_noop(t *testing.T) {
 
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil)
+	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil, nil)
 
 	const image = "test123:latest"
 
@@ -94,7 +94,7 @@ func TestUnpackReconciler_pullBackoff(t *testing.T) {
 
 	ipm := &imagePullerMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil)
+	ur := newUnpackReconciler(uc, ipm, pd, nil, environment.NewSink(c), nil, nil)
 
 	const image = "test123:latest"
 
@@ -127,7 +127,7 @@ func TestUnpackReconciler_getEnvironment_error(t *testing.T) {
 	ipm := &imagePullerMock{}
 	sink := &environmentSinkMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(uc, ipm, pd, nil, sink, nil)
+	ur := newUnpackReconciler(uc, ipm, pd, nil, sink, nil, nil)
 
 	ipm.On("Pull", mock.Anything, mock.Anything).Return(&packages.RawPackage{}, nil)
 	sink.On("GetEnvironment", mock.Anything, mock.Anything).Return(&manifests.PackageEnvironment{}, errTest)
@@ -155,7 +155,7 @@ func TestUnpackReconciler_packageDeploy_error(t *testing.T) {
 	ipm := &imagePullerMock{}
 	sink := &environmentSinkMock{}
 	pd := &packageDeployerMock{}
-	ur := newUnpackReconciler(uc, ipm, pd, nil, sink, nil)
+	ur := newUnpackReconciler(uc, ipm, pd, nil, sink, nil, nil)
 
 	ipm.
 		On("Pull", mock.Anything, mock.Anything, mock.Anything).

--- a/internal/imageprefix/imageprefix.go
+++ b/internal/imageprefix/imageprefix.go
@@ -1,0 +1,47 @@
+package imageprefix
+
+import (
+	"strings"
+)
+
+// Override is a prefix replacement rule.
+type Override struct {
+	From, To string
+}
+
+// Replace replaces image prefix with most specific matching override.
+func Replace(image string, overrides []Override) string {
+	// Find most specific override.
+	bestMatch := mostSpecificIndex(image, overrides)
+	// No match found. Return original string.
+	if bestMatch == -1 {
+		return image
+	}
+
+	// Return image address with replaced prefix.
+	override := overrides[bestMatch]
+	return override.To + image[len(override.From):]
+}
+
+func mostSpecificIndex(image string, overrides []Override) int {
+	bestMatchLen := 0
+	bestMatch := -1
+
+	for i, override := range overrides {
+		// Skip not matching prefixes.
+		if !strings.HasPrefix(image, override.From) {
+			continue
+		}
+		// Skip if match is not longer than previous best match.
+		if bestMatchLen >= len(override.From) {
+			continue
+		}
+
+		// This override was the longest match yet.
+		// Store it:
+		bestMatch = i
+		bestMatchLen = len(override.From)
+	}
+
+	return bestMatch
+}

--- a/internal/imageprefix/imageprefix_test.go
+++ b/internal/imageprefix/imageprefix_test.go
@@ -1,0 +1,35 @@
+package imageprefix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMostSpecificOverride(t *testing.T) {
+	t.Parallel()
+
+	overrides := []Override{
+		{From: "quay.io/original/", To: "quay.io/mirror/"},
+		{From: "quay.io/original/foo", To: "quay.io/mirror/bar"},
+		{From: "quay.io/original/f", To: "quay.io/mirror/baz"},
+	}
+
+	originalImage := "quay.io/original/foo:tag"
+
+	overridden := Replace(originalImage, overrides)
+	assert.Equal(t, "quay.io/mirror/bar:tag", overridden)
+}
+
+func TestNoAppliedOverride(t *testing.T) {
+	t.Parallel()
+
+	overrides := []Override{
+		{From: "quay.io/notmatching/", To: "quay.io/mirror/"},
+	}
+
+	originalImage := "quay.io/original/foo:tag"
+
+	overridden := Replace(originalImage, overrides)
+	assert.Equal(t, "quay.io/original/foo:tag", overridden)
+}

--- a/internal/packages/internal/packagedeploy/deployer.go
+++ b/internal/packages/internal/packagedeploy/deployer.go
@@ -62,7 +62,11 @@ type (
 )
 
 // Returns a new namespace-scoped loader for the Package API.
-func NewPackageDeployer(c client.Client, uncachedClient client.Client, scheme *runtime.Scheme, imagePrefixOverrides []imageprefix.Override) *PackageDeployer {
+func NewPackageDeployer(
+	c client.Client, uncachedClient client.Client,
+	scheme *runtime.Scheme,
+	imagePrefixOverrides []imageprefix.Override,
+) *PackageDeployer {
 	return &PackageDeployer{
 		client:         c,
 		uncachedClient: uncachedClient,
@@ -86,7 +90,11 @@ func NewPackageDeployer(c client.Client, uncachedClient client.Client, scheme *r
 }
 
 // Returns a new cluster-scoped loader for the ClusterPackage API.
-func NewClusterPackageDeployer(c client.Client, scheme *runtime.Scheme, imagePrefixOverrides []imageprefix.Override) *PackageDeployer {
+func NewClusterPackageDeployer(
+	c client.Client,
+	scheme *runtime.Scheme,
+	imagePrefixOverrides []imageprefix.Override,
+) *PackageDeployer {
 	return &PackageDeployer{
 		client: c,
 		scheme: scheme,

--- a/internal/packages/internal/packagedeploy/deployer.go
+++ b/internal/packages/internal/packagedeploy/deployer.go
@@ -174,11 +174,13 @@ func (l *PackageDeployer) Deploy(
 	images := map[string]string{}
 	if pkg.ManifestLock != nil {
 		for _, packageImage := range pkg.ManifestLock.Spec.Images {
-			resolvedImage, err := ImageWithDigest(packageImage.Image, packageImage.Digest)
+			replacedImage := imageprefix.Replace(packageImage.Image, l.imagePrefixOverrides)
+
+			resolvedImage, err := ImageWithDigest(replacedImage, packageImage.Digest)
 			if err != nil {
 				return err
 			}
-			images[packageImage.Name] = imageprefix.Replace(resolvedImage, l.imagePrefixOverrides)
+			images[packageImage.Name] = resolvedImage
 		}
 	}
 

--- a/internal/packages/internal/packagedeploy/deployer_test.go
+++ b/internal/packages/internal/packagedeploy/deployer_test.go
@@ -32,7 +32,7 @@ func TestNewPackageDeployer(t *testing.T) {
 
 	c := testutil.NewClient()
 	uc := testutil.NewClient()
-	l := NewPackageDeployer(c, uc, testScheme)
+	l := NewPackageDeployer(c, uc, testScheme, nil)
 	assert.NotNil(t, l)
 }
 
@@ -121,7 +121,7 @@ func TestNewClustePackageDeployer(t *testing.T) {
 	t.Parallel()
 
 	c := testutil.NewClient()
-	l := NewClusterPackageDeployer(c, testScheme)
+	l := NewClusterPackageDeployer(c, testScheme, nil)
 	assert.NotNil(t, l)
 }
 

--- a/internal/packages/internal/packageimport/request_manager.go
+++ b/internal/packages/internal/packageimport/request_manager.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"package-operator.run/internal/imageprefix"
 	"package-operator.run/internal/packages/internal/packagetypes"
 	"package-operator.run/internal/utils"
 )
@@ -17,6 +18,7 @@ import (
 // Has a (semi) in-cluster dependency because it uses `FromRegistryInCluster`.
 type RequestManager struct {
 	registryHostOverrides map[string]string
+	imagePrefixOverrides  []imageprefix.Override
 
 	pullImage    pullImageFn
 	inFlight     map[string][]chan<- response
@@ -40,10 +42,12 @@ type pullImageFn func(
 // Creates a new request manager instance to de-duplicate parallel container image pulls.
 func NewRequestManager(
 	registryHostOverrides map[string]string,
+	imagePrefixOverrides []imageprefix.Override,
 	uncachedClient client.Client, serviceAccount types.NamespacedName,
 ) *RequestManager {
 	return &RequestManager{
 		registryHostOverrides: registryHostOverrides,
+		imagePrefixOverrides:  imagePrefixOverrides,
 		pullImage:             FromRegistryInCluster,
 		inFlight:              make(map[string][]chan<- response),
 		serviceAccount:        serviceAccount,
@@ -58,6 +62,8 @@ func (r *RequestManager) Pull(
 	if err != nil {
 		return nil, err
 	}
+	// TODO: should this happen before or after the registry host override?
+	image = imageprefix.Replace(image, r.imagePrefixOverrides)
 
 	res := <-r.handleRequest(ctx, image)
 

--- a/internal/packages/internal/packageimport/request_manager.go
+++ b/internal/packages/internal/packageimport/request_manager.go
@@ -58,12 +58,11 @@ func NewRequestManager(
 func (r *RequestManager) Pull(
 	ctx context.Context, image string,
 ) (*packagetypes.RawPackage, error) {
+	image = imageprefix.Replace(image, r.imagePrefixOverrides)
 	image, err := r.applyOverride(image)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: should this happen before or after the registry host override?
-	image = imageprefix.Replace(image, r.imagePrefixOverrides)
 
 	res := <-r.handleRequest(ctx, image)
 

--- a/internal/packages/internal/packageimport/request_manager_test.go
+++ b/internal/packages/internal/packageimport/request_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"package-operator.run/internal/imageprefix"
 	"package-operator.run/internal/packages/internal/packagetypes"
 	"package-operator.run/internal/testutil"
 )
@@ -27,7 +28,9 @@ func TestRequestManager_DelayedPull(t *testing.T) {
 	}
 	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
-	}, uncachedClient, serviceAccount)
+	},
+		[]imageprefix.Override{},
+		uncachedClient, serviceAccount)
 	ipm := &imagePullerMock{}
 	r.pullImage = ipm.Pull
 
@@ -79,7 +82,9 @@ func TestRequestManager_DelayedRequests(t *testing.T) {
 	}
 	r := NewRequestManager(map[string]string{
 		"quay.io": "localhost:123",
-	}, uncachedClient, serviceAccount)
+	},
+		[]imageprefix.Override{},
+		uncachedClient, serviceAccount)
 	r.pullImage = ipm.Pull
 
 	ctx := context.Background()


### PR DESCRIPTION
### Summary
This PR implements global image prefix overrides.
You can apply them by passing them in a `PKO_IMAGE_PREFIX_OVERRIDES` env var or in `image-prefix-overrides` flag in `from=to` format, eg. `quay.io/my-org/=mirror.example.com/mirror-org/`
Jira: [PKO-237](https://issues.redhat.com/browse/PKO-237)

This PR does not contain integration tests and must be manually tested before merging. 
More information in [PKO-264](https://issues.redhat.com/browse/PKO-264)

### Change Type

New Feature

### Check List Before Merging

- [X] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [X] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.
