### PR TITLE
[PKO-254]Enable go work sync for dependabot

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -12,6 +12,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  update-go-modules:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      UPDATE: ${{ steps.detect_changes.outputs.UPDATE }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
+          check-latest: true
+
+      - name: Run go work sync
+        run: go work sync
+
+      - name: Run go mod tidy for each module
+        run: |
+          go mod tidy
+          for mod in ./pkg ./apis; do
+            if [ -f "$mod/go.mod" ]; then
+              (cd "$mod" && go mod tidy)
+            fi
+          done
+
+      - name: Detect changes
+        id: detect_changes
+        run: |
+          if git diff --quiet; then
+            echo "UPDATE=false" >> "$GITHUB_ENV"
+          else
+            echo "UPDATE=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Commit and push changes
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN}}
+        if: env.UPDATE == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fix: sync dependencies with go work sync"
+          git push https://x-access-token:${{ env.PAT_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.head_ref }}
+
   lint-unit-int:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.UPDATE_GO_MODULES_PAT }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -56,14 +56,14 @@ jobs:
 
       - name: Commit and push changes
         env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN}}
+          UPDATE_GO_MODULES_PAT: ${{ secrets.UPDATE_GO_MODULES_PAT}}
         if: env.UPDATE == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "fix: sync dependencies with go work sync"
-          git push https://x-access-token:${{ env.PAT_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.head_ref }}
+          git push https://x-access-token:${{ env.UPDATE_GO_MODULES_PAT }}@github.com/${{ github.repository }}.git HEAD:${{ github.head_ref }}
 
   lint-unit-int:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
This is to resolve PKO-254, to add a new job for dependabot only to run `go work sync` and `go mod tidy`

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
This PR need the PAT token first to allow the github-action bot to merge and sync the dependencies and report the CI status. Pls check PKO-255
