### PR TITLE
fix: garbage collect metrics for deleted objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/operator-framework/api v0.30.0
 	github.com/operator-framework/deppy v0.3.0
 	github.com/prometheus/client_golang v1.21.1
+	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/common v0.63.0
 	github.com/pterm/pterm v0.12.80
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -125,8 +127,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect

--- a/integration/package-operator/helpers_test.go
+++ b/integration/package-operator/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -918,4 +919,121 @@ func requireDeployPackage(ctx context.Context, t *testing.T, pkg, objectDeployme
 	require.NoError(t, Client.Get(ctx, client.ObjectKey{
 		Name: pkg.GetName(), Namespace: pkg.GetNamespace(),
 	}, objectDeployment))
+}
+
+func hashCollisionTestProbe(configmapFieldA, configmapFieldB string) []corev1alpha1.ObjectSetProbe {
+	return []corev1alpha1.ObjectSetProbe{
+		{
+			Selector: corev1alpha1.ProbeSelector{
+				Kind: &corev1alpha1.PackageProbeKindSpec{
+					Kind: "ConfigMap",
+				},
+			},
+			Probes: []corev1alpha1.Probe{
+				{
+					FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
+						FieldA: configmapFieldA,
+						FieldB: configmapFieldB,
+					},
+				},
+			},
+		},
+	}
+}
+
+func cmTemplate(name string, data map[string]string, t require.TestingT) unstructured.Unstructured {
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"test.package-operator.run/test-1": "True"},
+		},
+		Data: data,
+	}
+	GVK, err := apiutil.GVKForObject(&cm, Scheme)
+	require.NoError(t, err)
+	cm.SetGroupVersionKind(GVK)
+
+	resObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cm)
+	require.NoError(t, err)
+	return unstructured.Unstructured{Object: resObj}
+}
+
+func objectDeploymentTemplate(
+	objectSetPhases []corev1alpha1.ObjectSetTemplatePhase,
+	probes []corev1alpha1.ObjectSetProbe, name string, revisionHistoryLimit int32,
+) *corev1alpha1.ObjectDeployment {
+	label := "test.package-operator.run/" + name
+	return &corev1alpha1.ObjectDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: corev1alpha1.ObjectDeploymentSpec{
+			RevisionHistoryLimit: &revisionHistoryLimit,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{label: "True"},
+			},
+			Template: corev1alpha1.ObjectSetTemplate{
+				Metadata: metav1.ObjectMeta{
+					Labels: map[string]string{label: "True"},
+				},
+				Spec: corev1alpha1.ObjectSetTemplateSpec{
+					Phases:             objectSetPhases,
+					AvailabilityProbes: probes,
+				},
+			},
+		},
+	}
+}
+
+func deploymentTemplate(deploymentName string, podImage string, t require.TestingT) unstructured.Unstructured {
+	obj := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   deploymentName,
+			Labels: map[string]string{"test.package-operator.run/test-1": "True"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"test.package-operator.run/test-1": "True"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "nginx",
+					Labels: map[string]string{"test.package-operator.run/test-1": "True"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: podImage,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	GVK, err := apiutil.GVKForObject(&obj, Scheme)
+	require.NoError(t, err)
+	obj.SetGroupVersionKind(GVK)
+	resObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&obj)
+	require.NoError(t, err)
+	return unstructured.Unstructured{Object: resObj}
+}
+
+func clusterPackageTemplate(name string) client.Object {
+	meta := metav1.ObjectMeta{
+		Name: name,
+	}
+	spec := corev1alpha1.PackageSpec{
+		Image: SuccessTestPackageImage,
+		Config: &runtime.RawExtension{
+			Raw: []byte(fmt.Sprintf(`{"testStubImage": "%s"}`, TestStubImage)),
+		},
+	}
+
+	return &corev1alpha1.ClusterPackage{
+		ObjectMeta: meta,
+		Spec:       spec,
+	}
 }

--- a/integration/package-operator/metrics_test.go
+++ b/integration/package-operator/metrics_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+
+package packageoperator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/internal/testutil"
+)
+
+func TestPackageMetrics_PackageDeleted(t *testing.T) {
+	packageName := "test-package"
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+
+	// Deploy a package and verify the metrics exist
+	pkg := clusterPackageTemplate(packageName)
+	requireDeployPackage(ctx, t, pkg, &corev1alpha1.ClusterObjectDeployment{})
+	found, err := testutil.VerifyMetrics(ctx, "package_availability", "pko_name", packageName)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Get the package and then delete it
+	require.NoError(t, Client.Get(ctx, client.ObjectKey{Name: packageName}, pkg))
+	require.NoError(t, Client.Delete(ctx, pkg))
+	require.NoError(t, Waiter.WaitToBeGone(ctx, pkg, func(client.Object) (bool, error) { return false, nil }))
+
+	// Get the metrics again and verify there's no vector for the package
+	found, err = testutil.VerifyMetrics(ctx, "package_availability", "pko_name", packageName)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestObjectSetMetrics_RevisionHistoryGreaterThanZero(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+
+	probe := hashCollisionTestProbe(".metadata.name", ".data.name")
+	phases := []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm1", map[string]string{"name": "cm1"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm2", map[string]string{"name": "cm2"}, t),
+				},
+			},
+		},
+	}
+
+	// Create object deployment with revision history limit of 1
+	objectDeployment := objectDeploymentTemplate(phases, probe, "test-objectdeployment", 1)
+	require.NoError(t, Client.Create(ctx, objectDeployment), "error creating object set")
+	require.NoError(t,
+		Waiter.WaitForCondition(ctx, objectDeployment, corev1alpha1.ObjectDeploymentAvailable, metav1.ConditionTrue))
+	cleanupOnSuccess(ctx, t, objectDeployment)
+
+	objectSetList := listObjectSetRevisions(ctx, t, objectDeployment)
+	objset := objectSetList.Items[0]
+
+	found, err := testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Update the objectdeployment to create revion 2
+	phases = []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm1", map[string]string{"name": "cm1"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: deploymentTemplate("nginx-1", "nginx:1.14.2", t),
+				},
+			},
+		},
+	}
+
+	objectDeployment.Spec.Template.Spec.Phases = phases
+	require.NoError(t, Client.Update(ctx, objectDeployment))
+	require.NoError(t,
+		Waiter.WaitForCondition(ctx, objectDeployment, corev1alpha1.ObjectDeploymentProgressing, metav1.ConditionFalse))
+	require.NoError(t,
+		Waiter.WaitForCondition(ctx, objectDeployment, corev1alpha1.ObjectDeploymentAvailable, metav1.ConditionTrue))
+
+	// Verify metrics are still there for revision 1
+	found, err = testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Update the objectdeployment to create revision 3
+	phases = []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm3", map[string]string{"name": "cm3"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: deploymentTemplate("nginx-1", "nginx:1.14.2", t),
+				},
+			},
+		},
+	}
+
+	objectDeployment.Spec.Template.Spec.Phases = phases
+	require.NoError(t, Client.Update(ctx, objectDeployment))
+	require.NoError(t,
+		Waiter.WaitToBeGone(ctx, &objset, func(client.Object) (bool, error) { return false, nil }))
+
+	// Verify there are no metrics for revision 1
+	found, err = testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestObjectSetMetrics_RevisionHistoryZero(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+
+	probe := hashCollisionTestProbe(".metadata.name", ".data.name")
+	phases := []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm1", map[string]string{"name": "cm1"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm2", map[string]string{"name": "cm2"}, t),
+				},
+			},
+		},
+	}
+
+	// Create object deployment with revision history limit of 1
+	objectDeployment := objectDeploymentTemplate(phases, probe, "test-objectdeployment", 0)
+	require.NoError(t, Client.Create(ctx, objectDeployment), "error creating object set")
+	require.NoError(t,
+		Waiter.WaitForCondition(ctx, objectDeployment, corev1alpha1.ObjectDeploymentAvailable, metav1.ConditionTrue))
+	cleanupOnSuccess(ctx, t, objectDeployment)
+
+	objectSetList := listObjectSetRevisions(ctx, t, objectDeployment)
+	objset := objectSetList.Items[0]
+	found, err := testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Update the objectdeployment to create revion 2
+	phases = []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm1", map[string]string{"name": "cm1"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: deploymentTemplate("nginx-1", "nginx:1.14.2", t),
+				},
+			},
+		},
+	}
+
+	objectDeployment.Spec.Template.Spec.Phases = phases
+	require.NoError(t, Client.Update(ctx, objectDeployment))
+	require.NoError(t, Waiter.WaitToBeGone(ctx, &objset, func(client.Object) (bool, error) { return false, nil }))
+
+	// Verify there are no metrics for revision 1
+	found, err = testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestObjectSetMetrics_ObjectDeploymentDeleted(t *testing.T) {
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+
+	probe := hashCollisionTestProbe(".metadata.name", ".data.name")
+	phases := []corev1alpha1.ObjectSetTemplatePhase{
+		{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm1", map[string]string{"name": "cm1"}, t),
+				},
+			},
+		},
+		{
+			Name: "phase-2",
+			Objects: []corev1alpha1.ObjectSetObject{
+				{
+					Object: cmTemplate("cm2", map[string]string{"name": "cm2"}, t),
+				},
+			},
+		},
+	}
+
+	// Create object deployment
+	objectDeployment := objectDeploymentTemplate(phases, probe, "test-objectdeployment", 10)
+	require.NoError(t, Client.Create(ctx, objectDeployment), "error creating object set")
+	require.NoError(t,
+		Waiter.WaitForCondition(ctx, objectDeployment, corev1alpha1.ObjectDeploymentAvailable, metav1.ConditionTrue))
+	cleanupOnSuccess(ctx, t, objectDeployment)
+
+	// Verify metrics exist for the objectset
+	objectSetList := listObjectSetRevisions(ctx, t, objectDeployment)
+	objset := objectSetList.Items[0]
+	found, err := testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Delete the objectdeployment
+	require.NoError(t, Client.Delete(ctx, objectDeployment))
+	require.NoError(t, Waiter.WaitToBeGone(ctx, &objset, func(client.Object) (bool, error) { return false, nil }))
+
+	// Verify there are no metrics for the objectset
+	found, err = testutil.VerifyMetrics(ctx, "object_set_created_timestamp_seconds", "pko_name", objset.Name)
+	require.NoError(t, err)
+	require.False(t, found)
+}

--- a/integration/package-operator/objectdeployment_test.go
+++ b/integration/package-operator/objectdeployment_test.go
@@ -126,7 +126,7 @@ func TestObjectDeployment_availability_and_hash_collision(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Logf("Running revision: %d \n", testCase.deploymentRevision)
-		concernedDeployment := objectDeploymentTemplate(testCase.phases, testCase.probe, "test-objectdeployment")
+		concernedDeployment := objectDeploymentTemplate(testCase.phases, testCase.probe, "test-objectdeployment", 10)
 		currentInClusterDeployment := &corev1alpha1.ObjectDeployment{}
 		err := Client.Get(ctx, client.ObjectKeyFromObject(concernedDeployment), currentInClusterDeployment)
 		if errors.IsNotFound(err) {
@@ -393,7 +393,7 @@ func TestObjectDeployment_ObjectSetArchival(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Logf("Running revision %s \n", testCase.revision)
-		concernedDeployment := objectDeploymentTemplate(testCase.phases, testCase.probes, "test-objectdeployment-1")
+		concernedDeployment := objectDeploymentTemplate(testCase.phases, testCase.probes, "test-objectdeployment-1", 10)
 		currentInClusterDeployment := &corev1alpha1.ObjectDeployment{}
 		err := Client.Get(ctx, client.ObjectKeyFromObject(concernedDeployment), currentInClusterDeployment)
 		if errors.IsNotFound(err) {
@@ -470,7 +470,7 @@ func TestObjectDeployment_Pause(t *testing.T) {
 				},
 			},
 		},
-	}, nil, "test-od")
+	}, nil, "test-od", 10)
 
 	require.NoError(t, Client.Create(ctx, objectDeployment))
 	cleanupOnSuccess(ctx, t, objectDeployment)
@@ -546,50 +546,6 @@ func ExpectedObjectSetName(deployment *corev1alpha1.ObjectDeployment) string {
 	return fmt.Sprintf("%s-%s", deployment.GetName(), deployment.Status.TemplateHash)
 }
 
-func objectDeploymentTemplate(
-	objectSetPhases []corev1alpha1.ObjectSetTemplatePhase,
-	probes []corev1alpha1.ObjectSetProbe, name string,
-) *corev1alpha1.ObjectDeployment {
-	label := "test.package-operator.run/" + name
-	return &corev1alpha1.ObjectDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
-		Spec: corev1alpha1.ObjectDeploymentSpec{
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{label: "True"},
-			},
-			Template: corev1alpha1.ObjectSetTemplate{
-				Metadata: metav1.ObjectMeta{
-					Labels: map[string]string{label: "True"},
-				},
-				Spec: corev1alpha1.ObjectSetTemplateSpec{
-					Phases:             objectSetPhases,
-					AvailabilityProbes: probes,
-				},
-			},
-		},
-	}
-}
-
-func cmTemplate(name string, data map[string]string, t require.TestingT) unstructured.Unstructured {
-	cm := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"test.package-operator.run/test-1": "True"},
-		},
-		Data: data,
-	}
-	GVK, err := apiutil.GVKForObject(&cm, Scheme)
-	require.NoError(t, err)
-	cm.SetGroupVersionKind(GVK)
-
-	resObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cm)
-	require.NoError(t, err)
-	return unstructured.Unstructured{Object: resObj}
-}
-
 func secret(name string, t require.TestingT) unstructured.Unstructured {
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -605,41 +561,6 @@ func secret(name string, t require.TestingT) unstructured.Unstructured {
 	require.NoError(t, err)
 	secret.SetGroupVersionKind(GVK)
 	resObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
-	require.NoError(t, err)
-	return unstructured.Unstructured{Object: resObj}
-}
-
-func deploymentTemplate(deploymentName string, podImage string, t require.TestingT) unstructured.Unstructured {
-	obj := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   deploymentName,
-			Labels: map[string]string{"test.package-operator.run/test-1": "True"},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"test.package-operator.run/test-1": "True"},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "nginx",
-					Labels: map[string]string{"test.package-operator.run/test-1": "True"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "nginx",
-							Image: podImage,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	GVK, err := apiutil.GVKForObject(&obj, Scheme)
-	require.NoError(t, err)
-	obj.SetGroupVersionKind(GVK)
-	resObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&obj)
 	require.NoError(t, err)
 	return unstructured.Unstructured{Object: resObj}
 }
@@ -679,26 +600,6 @@ func newArchivalTestProbes() []corev1alpha1.ObjectSetProbe {
 					Condition: &corev1alpha1.ProbeConditionSpec{
 						Type:   string(appsv1.DeploymentAvailable),
 						Status: string(metav1.ConditionTrue),
-					},
-				},
-			},
-		},
-	}
-}
-
-func hashCollisionTestProbe(configmapFieldA, configmapFieldB string) []corev1alpha1.ObjectSetProbe {
-	return []corev1alpha1.ObjectSetProbe{
-		{
-			Selector: corev1alpha1.ProbeSelector{
-				Kind: &corev1alpha1.PackageProbeKindSpec{
-					Kind: "ConfigMap",
-				},
-			},
-			Probes: []corev1alpha1.Probe{
-				{
-					FieldsEqual: &corev1alpha1.ProbeFieldsEqualSpec{
-						FieldA: configmapFieldA,
-						FieldB: configmapFieldB,
 					},
 				},
 			},

--- a/internal/controllers/objectsets/objectset_controller.go
+++ b/internal/controllers/objectsets/objectset_controller.go
@@ -187,12 +187,24 @@ func (c *GenericObjectSetController) Reconcile(ctx context.Context, req ctrl.Req
 		ctx, req.NamespacedName, objectSet.ClientObject()); err != nil {
 		return res, client.IgnoreNotFound(err)
 	}
+
 	defer func() {
 		if err != nil {
 			return
 		}
+		// Add the metrics finalizer if the object doesn't have a deletion timestamp
+		if objectSet.ClientObject().GetDeletionTimestamp().IsZero() {
+			if err = controllers.EnsureFinalizer(ctx, c.client, objectSet.ClientObject(), metrics.MetricsFinalizer); err != nil {
+				return
+			}
+		}
 		if c.recorder != nil {
 			c.recorder.RecordObjectSetMetrics(objectSet)
+		}
+		// If the objectset has a deletion timestamp, remove the metrics finalizer
+		if !objectSet.ClientObject().GetDeletionTimestamp().IsZero() {
+			err = client.IgnoreNotFound(controllers.RemoveFinalizer(
+				ctx, c.client, objectSet.ClientObject(), metrics.MetricsFinalizer))
 		}
 	}()
 
@@ -207,13 +219,11 @@ func (c *GenericObjectSetController) Reconcile(ctx context.Context, req ctrl.Req
 			return res, err
 		}
 
-		if !objectSet.IsArchived() {
-			// Object was deleted and not just archived.
-			// no way to update status now :)
-			return res, nil
+		// only try to update status if the object was archived, not if it was deleted
+		if objectSet.ClientObject().GetDeletionTimestamp().IsZero() {
+			err = c.updateStatus(ctx, objectSet)
 		}
-
-		return res, c.updateStatus(ctx, objectSet)
+		return res, err
 	}
 
 	if err := controllers.EnsureCachedFinalizer(ctx, c.client, objectSet.ClientObject()); err != nil {

--- a/internal/controllers/packages/package_controller.go
+++ b/internal/controllers/packages/package_controller.go
@@ -19,8 +19,6 @@ import (
 	"package-operator.run/internal/packages"
 )
 
-const loaderJobFinalizer = "package-operator.run/loader-job"
-
 var _ environment.Sinker = (*GenericPackageController)(nil)
 
 type reconciler interface {
@@ -137,20 +135,30 @@ func (c *GenericPackageController) Reconcile(
 		ctx, req.NamespacedName, pkg.ClientObject()); err != nil {
 		return res, client.IgnoreNotFound(err)
 	}
+
+	pkgClientObject := pkg.ClientObject()
+	if err = controllers.EnsureFinalizer(ctx, c.client, pkgClientObject, metrics.MetricsFinalizer); err != nil {
+		return
+	}
+
 	defer func() {
-		if err != nil {
-			return
+		if pkg.ClientObject().GetDeletionTimestamp().IsZero() {
+			if err = controllers.EnsureFinalizer(ctx, c.client, pkgClientObject, metrics.MetricsFinalizer); err != nil {
+				return
+			}
 		}
 		if c.recorder != nil {
 			c.recorder.RecordPackageMetrics(pkg)
 		}
+		// If the package has a deletion timestamp, remove the metrics finalizer
+		if !pkg.ClientObject().GetDeletionTimestamp().IsZero() {
+			log.Info("Removing metrics finalizer...")
+			err = client.IgnoreNotFound(controllers.RemoveFinalizer(ctx, c.client, pkg.ClientObject(), metrics.MetricsFinalizer))
+		}
 	}()
 
-	pkgClientObject := pkg.ClientObject()
-	if !pkgClientObject.GetDeletionTimestamp().IsZero() {
-		if err := c.handleDeletion(ctx, pkg); err != nil {
-			return res, err
-		}
+	if !pkg.ClientObject().GetDeletionTimestamp().IsZero() {
+		// Package deleting... Do nothing
 		return res, nil
 	}
 
@@ -201,16 +209,4 @@ func (c *GenericPackageController) updateStatus(ctx context.Context, pkg adapter
 		return fmt.Errorf("updating Package status: %w", err)
 	}
 	return nil
-}
-
-func (c *GenericPackageController) handleDeletion(
-	ctx context.Context, pkg adapters.GenericPackageAccessor,
-) error {
-	// Remove finalizer from previous versions of PKO.
-	if err := controllers.RemoveFinalizer(
-		ctx, c.client, pkg.ClientObject(), loaderJobFinalizer); err != nil {
-		return err
-	}
-
-	return c.client.Update(ctx, pkg.ClientObject())
 }

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -14,6 +14,8 @@ import (
 	manifestsv1alpha1 "package-operator.run/apis/manifests/v1alpha1"
 )
 
+const MetricsFinalizer = "package-operator.run/metrics"
+
 // Recorder stores all the metrics related to Addons.
 type Recorder struct {
 	dynamicCacheInformers prometheus.Gauge

--- a/internal/testutil/kube_api_http_client.go
+++ b/internal/testutil/kube_api_http_client.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func GetEndpointOnCluster(ctx context.Context, namespace, service, path string, port int) ([]byte, error) {
+	restConfig := config.GetConfigOrDie()
+	transport, err := rest.TransportFor(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct an http.Client that authenticates with the apiserver.
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	// Construct request
+	requestURL, err := createURL(restConfig.Host, namespace, service, path, port)
+	if err != nil {
+		return nil, err
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), nil) // OK
+	resp, err := client.Do(req)
+	// resp, err := client.Get(requestURL.String())
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func createURL(host, namespace, service, path string, port int) (requestURL *url.URL, err error) {
+	if !strings.HasSuffix(host, "/") {
+		host += "/"
+	}
+	requestURL, err = url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	requestURL.Path = fmt.Sprintf(
+		"/api/v1/namespaces/%s/services/%s:%d/proxy%s",
+		namespace,
+		service,
+		port,
+		path,
+	)
+	return
+}

--- a/internal/testutil/metrics.go
+++ b/internal/testutil/metrics.go
@@ -1,0 +1,77 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+func ParseMetrics(metricBytes []byte) (map[string][]*io_prometheus_client.Metric, error) {
+	reader := bytes.NewReader(metricBytes)
+	parser := &expfmt.TextParser{}
+
+	mfs, err := parser.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := make(map[string][]*io_prometheus_client.Metric)
+	pfx := strings.ReplaceAll("package-operator", "-", "_") + "_"
+
+	for name, mf := range mfs {
+		if strings.HasPrefix(name, pfx) {
+			metrics[strings.TrimPrefix(name, pfx)] = mf.GetMetric()
+		}
+	}
+	return metrics, nil
+}
+
+func VerifyMetrics(ctx context.Context, metric, label, value string) (bool, error) {
+	respBytes, err := GetEndpointOnCluster(ctx, "package-operator-system", "package-operator-metrics", "/metrics", 8080)
+	if err != nil {
+		return false, err
+	}
+	metrics, err := ParseMetrics(respBytes)
+	if err != nil {
+		return false, err
+	}
+
+	// Verify there's a vector for the package
+	vectors := metrics[metric]
+	vector := searchableMetrics(vectors).FindMetric(label, value)
+	if vector != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+type searchableMetrics []*io_prometheus_client.Metric
+
+func (ms searchableMetrics) FindMetric(label, value string) *io_prometheus_client.Metric {
+	for _, m := range ms {
+		labels := searchableLables(m.GetLabel())
+
+		if labels.Contains(label, value) {
+			return m
+		}
+	}
+	return nil
+}
+
+type searchableLables []*io_prometheus_client.LabelPair
+
+func (ls searchableLables) Contains(name, val string) bool {
+	for _, l := range ls {
+		if l.GetName() != name {
+			continue
+		}
+
+		if l.GetValue() == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Fix bug in which metrics continue to be exported for packages and objectsets which have been deleted. 
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
