### PR TITLE
fix: add write permissions to update-go-modules job

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,6 +15,8 @@ jobs:
   update-go-modules:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       UPDATE: ${{ steps.detect_changes.outputs.UPDATE }}
     steps:


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
