### PR TITLE
fix(testing/update-go-modules): drop fetch-depth from checkout action

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
because
https://github.com/actions/checkout#push-a-commit-to-a-pr-using-the-built-in-token
says so

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
