### PR TITLE
[PKO-267] Move ObjectTemplate adapter into adapters package

### DIFF
--- a/internal/adapters/objecttemplate.go
+++ b/internal/adapters/objecttemplate.go
@@ -1,4 +1,4 @@
-package objecttemplate
+package adapters
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,7 +8,7 @@ import (
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
 
-type genericObjectTemplate interface {
+type GenericObjectTemplateAccessor interface {
 	ClientObject() client.Object
 	GetTemplate() string
 	GetSources() []corev1alpha1.ObjectTemplateSource
@@ -18,15 +18,15 @@ type genericObjectTemplate interface {
 	GetStatusControllerOf() corev1alpha1.ControlledObjectReference
 }
 
-type genericObjectTemplateFactory func(
-	scheme *runtime.Scheme) genericObjectTemplate
+type GenericObjectTemplateFactory func(
+	scheme *runtime.Scheme) GenericObjectTemplateAccessor
 
 var (
 	objectTemplateGVK        = corev1alpha1.GroupVersion.WithKind("ObjectTemplate")
 	clusterObjectTemplateGVK = corev1alpha1.GroupVersion.WithKind("ClusterObjectTemplate")
 )
 
-func newGenericObjectTemplate(scheme *runtime.Scheme) genericObjectTemplate {
+func NewGenericObjectTemplate(scheme *runtime.Scheme) GenericObjectTemplateAccessor {
 	obj, err := scheme.New(objectTemplateGVK)
 	if err != nil {
 		panic(err)
@@ -37,7 +37,7 @@ func newGenericObjectTemplate(scheme *runtime.Scheme) genericObjectTemplate {
 	}
 }
 
-func newGenericClusterObjectTemplate(scheme *runtime.Scheme) genericObjectTemplate {
+func NewGenericClusterObjectTemplate(scheme *runtime.Scheme) GenericObjectTemplateAccessor {
 	obj, err := scheme.New(clusterObjectTemplateGVK)
 	if err != nil {
 		panic(err)

--- a/internal/adapters/objecttemplate.go
+++ b/internal/adapters/objecttemplate.go
@@ -8,7 +8,7 @@ import (
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
 
-type GenericObjectTemplateAccessor interface {
+type ObjectTemplateAccessor interface {
 	ClientObject() client.Object
 	GetTemplate() string
 	GetSources() []corev1alpha1.ObjectTemplateSource
@@ -19,14 +19,14 @@ type GenericObjectTemplateAccessor interface {
 }
 
 type GenericObjectTemplateFactory func(
-	scheme *runtime.Scheme) GenericObjectTemplateAccessor
+	scheme *runtime.Scheme) ObjectTemplateAccessor
 
 var (
 	objectTemplateGVK        = corev1alpha1.GroupVersion.WithKind("ObjectTemplate")
 	clusterObjectTemplateGVK = corev1alpha1.GroupVersion.WithKind("ClusterObjectTemplate")
 )
 
-func NewGenericObjectTemplate(scheme *runtime.Scheme) GenericObjectTemplateAccessor {
+func NewGenericObjectTemplate(scheme *runtime.Scheme) ObjectTemplateAccessor {
 	obj, err := scheme.New(objectTemplateGVK)
 	if err != nil {
 		panic(err)
@@ -37,7 +37,7 @@ func NewGenericObjectTemplate(scheme *runtime.Scheme) GenericObjectTemplateAcces
 	}
 }
 
-func NewGenericClusterObjectTemplate(scheme *runtime.Scheme) GenericObjectTemplateAccessor {
+func NewGenericClusterObjectTemplate(scheme *runtime.Scheme) ObjectTemplateAccessor {
 	obj, err := scheme.New(clusterObjectTemplateGVK)
 	if err != nil {
 		panic(err)

--- a/internal/adapters/objecttemplate_test.go
+++ b/internal/adapters/objecttemplate_test.go
@@ -1,0 +1,64 @@
+package adapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+)
+
+func TestGenericObjectTemplate(t *testing.T) {
+	t.Parallel()
+
+	ot := NewGenericObjectTemplate(testScheme).(*GenericObjectTemplate)
+
+	co := ot.ClientObject()
+	assert.IsType(t, &corev1alpha1.ObjectTemplate{}, co)
+
+	var generation int64 = 2
+	ot.Generation = generation
+	assert.Equal(t, generation, ot.GetGeneration())
+
+	controlledObj := corev1alpha1.ControlledObjectReference{}
+	ot.SetStatusControllerOf(controlledObj)
+	assert.Equal(t, controlledObj, ot.GetStatusControllerOf())
+
+	ot.Status.Conditions = []metav1.Condition{}
+	assert.Equal(t, ot.Status.Conditions, *ot.GetConditions())
+
+	sources := []corev1alpha1.ObjectTemplateSource{}
+	ot.Spec.Sources = sources
+	assert.Equal(t, sources, ot.GetSources())
+
+	ot.Spec.Template = ""
+	assert.Equal(t, ot.Spec.Template, ot.GetTemplate())
+}
+
+func TestGenericClusterObjectTemplate(t *testing.T) {
+	t.Parallel()
+
+	ot := NewGenericClusterObjectTemplate(testScheme).(*GenericClusterObjectTemplate)
+
+	co := ot.ClientObject()
+	assert.IsType(t, &corev1alpha1.ClusterObjectTemplate{}, co)
+
+	var generation int64 = 2
+	ot.Generation = generation
+	assert.Equal(t, generation, ot.GetGeneration())
+
+	controlledObj := corev1alpha1.ControlledObjectReference{}
+	ot.SetStatusControllerOf(controlledObj)
+	assert.Equal(t, controlledObj, ot.GetStatusControllerOf())
+
+	ot.Status.Conditions = []metav1.Condition{}
+	assert.Equal(t, ot.Status.Conditions, *ot.GetConditions())
+
+	sources := []corev1alpha1.ObjectTemplateSource{}
+	ot.Spec.Sources = sources
+	assert.Equal(t, sources, ot.GetSources())
+
+	ot.Spec.Template = ""
+	assert.Equal(t, ot.Spec.Template, ot.GetTemplate())
+}

--- a/internal/autoimpersonation/ownership/ownership_test.go
+++ b/internal/autoimpersonation/ownership/ownership_test.go
@@ -16,7 +16,6 @@ import (
 	"package-operator.run/apis"
 	"package-operator.run/apis/core/v1alpha1"
 	"package-operator.run/internal/adapters"
-	"package-operator.run/internal/controllers/objecttemplate"
 )
 
 var testScheme = runtime.NewScheme()
@@ -128,7 +127,7 @@ func TestVerifyOwnership_ClusterPackage(t *testing.T) {
 func TestVerifyOwnership_ObjectTemplate(t *testing.T) {
 	t.Parallel()
 
-	objectTemplate := objecttemplate.GenericObjectTemplate{
+	objectTemplate := adapters.GenericObjectTemplate{
 		ObjectTemplate: v1alpha1.ObjectTemplate{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ObjectTemplate",

--- a/internal/controllers/objecttemplate/objecttemplate_controller.go
+++ b/internal/controllers/objecttemplate/objecttemplate_controller.go
@@ -32,7 +32,7 @@ type dynamicCache interface {
 }
 
 type reconciler interface {
-	Reconcile(ctx context.Context, pkg adapters.GenericObjectTemplateAccessor) (ctrl.Result, error)
+	Reconcile(ctx context.Context, pkg adapters.ObjectTemplateAccessor) (ctrl.Result, error)
 }
 
 type preflightChecker interface {
@@ -165,7 +165,7 @@ func (c *GenericObjectTemplateController) Reconcile(
 }
 
 func (c *GenericObjectTemplateController) updateStatus(
-	ctx context.Context, objectTemplate adapters.GenericObjectTemplateAccessor,
+	ctx context.Context, objectTemplate adapters.ObjectTemplateAccessor,
 ) error {
 	if err := c.client.Status().Update(ctx, objectTemplate.ClientObject()); err != nil {
 		return fmt.Errorf("updating ObjectTemplate status: %w", err)

--- a/internal/controllers/objecttemplate/template_reconciler.go
+++ b/internal/controllers/objecttemplate/template_reconciler.go
@@ -68,7 +68,7 @@ func newTemplateReconciler(
 }
 
 func (r *templateReconciler) Reconcile(
-	ctx context.Context, objectTemplate adapters.GenericObjectTemplateAccessor,
+	ctx context.Context, objectTemplate adapters.ObjectTemplateAccessor,
 ) (res ctrl.Result, err error) {
 	defer func() {
 		err = setObjectTemplateConditionBasedOnError(objectTemplate, err)
@@ -148,7 +148,7 @@ func (r *templateReconciler) handleCreation(ctx context.Context, owner, object c
 }
 
 func (r *templateReconciler) getValuesFromSources(
-	ctx context.Context, objectTemplate adapters.GenericObjectTemplateAccessor,
+	ctx context.Context, objectTemplate adapters.ObjectTemplateAccessor,
 	sourcesConfig map[string]any,
 ) (retryLater bool, err error) {
 	log := logr.FromContextOrDiscard(ctx)
@@ -293,7 +293,7 @@ func copySourceItem(
 
 func (r *templateReconciler) templateObject(
 	ctx context.Context, sourcesConfig map[string]any,
-	objectTemplate adapters.GenericObjectTemplateAccessor, object client.Object,
+	objectTemplate adapters.ObjectTemplateAccessor, object client.Object,
 ) error {
 	env, err := r.getEnvironment(ctx, objectTemplate.ClientObject().GetNamespace())
 	if err != nil {
@@ -352,7 +352,7 @@ func (r *templateReconciler) getEnvironment(ctx context.Context, namespace strin
 }
 
 func updateStatusConditionsFromOwnedObject(
-	_ context.Context, objectTemplate adapters.GenericObjectTemplateAccessor, existingObj *unstructured.Unstructured,
+	_ context.Context, objectTemplate adapters.ObjectTemplateAccessor, existingObj *unstructured.Unstructured,
 ) error {
 	statusObservedGeneration, ok, err := unstructured.NestedInt64(existingObj.Object, "status", "observedGeneration")
 	if err != nil {
@@ -401,7 +401,7 @@ func updateStatusConditionsFromOwnedObject(
 	return nil
 }
 
-func setObjectTemplateConditionBasedOnError(objectTemplate adapters.GenericObjectTemplateAccessor, err error) error {
+func setObjectTemplateConditionBasedOnError(objectTemplate adapters.ObjectTemplateAccessor, err error) error {
 	var sourceError *SourceError
 	if errors.As(err, &sourceError) {
 		meta.SetStatusCondition(objectTemplate.GetConditions(), metav1.Condition{

--- a/internal/controllers/objecttemplate/template_reconciler_test.go
+++ b/internal/controllers/objecttemplate/template_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
+	"package-operator.run/internal/adapters"
 	"package-operator.run/internal/apis/manifests"
 	"package-operator.run/internal/constants"
 	"package-operator.run/internal/environment"
@@ -246,7 +247,7 @@ func Test_templateReconciler_templateObject(t *testing.T) {
 			template, err := os.ReadFile(filepath.Join("testdata", test.packageFile))
 			require.NoError(t, err)
 
-			objectTemplate := GenericObjectTemplate{
+			objectTemplate := adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -357,7 +358,7 @@ func Test_updateStatusConditionsFromOwnedObject(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			objectTemplate := &GenericObjectTemplate{
+			objectTemplate := &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Generation: 4,
@@ -412,7 +413,7 @@ func Test_templateReconcilerReconcile(t *testing.T) {
 
 			template, err := os.ReadFile("testdata/package_template_to_json.yaml")
 			require.NoError(t, err)
-			objectTemplate := &GenericObjectTemplate{
+			objectTemplate := &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{
@@ -467,14 +468,14 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		objectTemplate     *GenericObjectTemplate
+		objectTemplate     *adapters.GenericObjectTemplate
 		err                error
 		expectedConditions []metav1.Condition
 		expectedErr        error
 	}{
 		{
 			name: "sets invalid condition for SourceError",
-			objectTemplate: &GenericObjectTemplate{
+			objectTemplate: &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{},
 			},
 			err: &SourceError{
@@ -492,7 +493,7 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 		},
 		{
 			name: "sets invalid condition for TemplateError",
-			objectTemplate: &GenericObjectTemplate{
+			objectTemplate: &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{},
 			},
 			err: &TemplateError{Err: errTest},
@@ -508,7 +509,7 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 		},
 		{
 			name: "removes invalid condition",
-			objectTemplate: &GenericObjectTemplate{
+			objectTemplate: &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{
 					Status: corev1alpha1.ObjectTemplateStatus{
 						Conditions: []metav1.Condition{
@@ -528,7 +529,7 @@ func Test_setObjectTemplateConditionBasedOnError(t *testing.T) {
 		},
 		{
 			name: "just returns other errors",
-			objectTemplate: &GenericObjectTemplate{
+			objectTemplate: &adapters.GenericObjectTemplate{
 				ObjectTemplate: corev1alpha1.ObjectTemplate{},
 			},
 			err:                errTest,
@@ -597,7 +598,7 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 
 		template, err := os.ReadFile("testdata/package_template_to_json.yaml")
 		require.NoError(t, err)
-		objectTemplate := &GenericObjectTemplate{
+		objectTemplate := &adapters.GenericObjectTemplate{
 			ObjectTemplate: corev1alpha1.ObjectTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{
@@ -645,7 +646,7 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 
 		template, err := os.ReadFile("testdata/package_template_to_json.yaml")
 		require.NoError(t, err)
-		objectTemplate := &GenericObjectTemplate{
+		objectTemplate := &adapters.GenericObjectTemplate{
 			ObjectTemplate: corev1alpha1.ObjectTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{
@@ -695,7 +696,7 @@ func TestRequeueDurationOnMissingSource(t *testing.T) {
 
 		template, err := os.ReadFile("testdata/package_template_to_json.yaml")
 		require.NoError(t, err)
-		objectTemplate := &GenericObjectTemplate{
+		objectTemplate := &adapters.GenericObjectTemplate{
 			ObjectTemplate: corev1alpha1.ObjectTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{


### PR DESCRIPTION

### Summary

This PR  the ObjectTemplate adapter (`genericObjectTemplate`) interface and implementation from the `internal/controllers/objecttemplate` package to the `internal/adapters` package.
[PKO-267](https://issues.redhat.com/browse/PKO-267)
### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [X] This PR passes all pre-commit hook validations.
- [X] This PR is fully tested and regression tests are included.
- [X] Relevant documentation has been updated.
- [X] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
