### PR TITLE
[PKO-263] Expose cardboard compile logic

### DIFF
--- a/cmd/build/binary.go
+++ b/cmd/build/binary.go
@@ -12,10 +12,12 @@ import (
 	"pkg.package-operator.run/cardboard/sh"
 )
 
+type Compile struct{}
+
 // compiles code in /cmd/<cmd> for the given OS and ARCH.
 // Binaries will be put in /bin/<cmd>_<os>_<arch>.
-func compile(ctx context.Context, cmd string, goos, goarch string) error {
-	self := run.Fn3(compile, cmd, goos, goarch)
+func (c Compile) compile(ctx context.Context, cmd string, goos, goarch string) error {
+	self := run.Meth3(c, c.compile, cmd, goos, goarch)
 	err := mgr.SerialDeps(ctx,
 		self,
 		run.Meth(generate, generate.All),

--- a/cmd/build/image.go
+++ b/cmd/build/image.go
@@ -36,7 +36,7 @@ func buildImage(ctx context.Context, name, registry, goarch string) error {
 
 	self := run.Fn3(buildImage, name, registry, goarch)
 	if err := mgr.SerialDeps(ctx, self,
-		run.Fn3(compile, binaryName, "linux", goarch),
+		run.Meth3(compile, compile.compile, binaryName, "linux", goarch),
 	); err != nil {
 		return err
 	}

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -22,6 +22,7 @@ var (
 	test     Test
 	lint     Lint
 	chart    Chart
+	compile  Compile
 
 	cluster = NewCluster("pko",
 		withLocalRegistry(imageRegistryHost(), devClusterRegistryPort, devClusterRegistryAuthPort),


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Exposes the binary compilation logic to enable building `kubectl-package` in a Containerfile.

Usage:
```
./do CI:Compile kubectl-package linux amd64
```
Jira: [PKO-263](https://issues.redhat.com/browse/PKO-263)

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.
