### PR TITLE
fix(ObjectTemplate controller): copy finalizers from existing templated object to prevent removing them

### DIFF
--- a/internal/controllers/objecttemplate/template_reconciler.go
+++ b/internal/controllers/objecttemplate/template_reconciler.go
@@ -114,6 +114,7 @@ func (r *templateReconciler) Reconcile(
 	}
 
 	obj.SetOwnerReferences(existingObj.GetOwnerReferences())
+	obj.SetFinalizers(existingObj.GetFinalizers())
 	obj.SetLabels(labels.Merge(existingObj.GetLabels(), obj.GetLabels()))
 	obj.SetAnnotations(labels.Merge(existingObj.GetAnnotations(), obj.GetAnnotations()))
 


### PR DESCRIPTION
this was causing issues with Packages owned by ObjectTemplates because there was a hot-loop to add and remove the metrics finalizer that was recently added in https://github.com/package-operator/package-operator/pull/1927

Co-Authored-By: Petr Babic <pbabic@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
