### PR TITLE
[PKO-293] Fix: Ignore NotFound error when getting previous revisions

### DIFF
--- a/integration/package-operator/objectset_test.go
+++ b/integration/package-operator/objectset_test.go
@@ -702,41 +702,74 @@ func TestObjectSet_immutability(t *testing.T) {
 func TestObjectSet_invalidPreviousReference(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 
-	configMap := cmTemplate("test-invalid-previous-reference", "", map[string]string{"banana": "bread"}, t)
+	configMap := cmTemplate("test-invalid-previous-reference", "default", map[string]string{"banana": "bread"}, t)
+	objectSetTemplateSpec := corev1alpha1.ObjectSetTemplateSpec{
+		Phases: []corev1alpha1.ObjectSetTemplatePhase{{
+			Name: "phase-1",
+			Objects: []corev1alpha1.ObjectSetObject{{
+				CollisionProtection: "Prevent",
+				Object:              configMap,
+			}},
+		}},
+	}
 
-	prev := &corev1alpha1.ObjectSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "previous-revision",
-			Namespace: "default",
-		},
-		Spec: corev1alpha1.ObjectSetSpec{
-			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
-				Phases: []corev1alpha1.ObjectSetTemplatePhase{{
-					Name: "phase-1",
-					Objects: []corev1alpha1.ObjectSetObject{{
-						CollisionProtection: "Prevent",
-						Object:              configMap,
-					}},
-				}},
+	t.Run("namespaced", func(t *testing.T) {
+		prev := &corev1alpha1.ObjectSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "previous-revision",
+				Namespace: "default",
 			},
-		},
-	}
+			Spec: corev1alpha1.ObjectSetSpec{
+				ObjectSetTemplateSpec: objectSetTemplateSpec,
+			},
+		}
 
-	objectSet := prev.DeepCopy()
-	objectSet.Name = "test-invalid-previous-reference"
-	objectSet.Spec.Previous = []corev1alpha1.PreviousRevisionReference{
-		{Name: prev.Name},
-		{Name: "non-existent-revision"},
-	}
+		objectSet := prev.DeepCopy()
+		objectSet.Name = "test-invalid-previous-reference"
+		objectSet.Spec.Previous = []corev1alpha1.PreviousRevisionReference{
+			{Name: prev.Name},
+			{Name: "non-existent-revision"},
+		}
 
-	// Create previous ObjectSet
-	require.NoError(t, Client.Create(ctx, prev))
-	cleanupOnSuccess(ctx, t, prev)
-	requireCondition(ctx, t, prev, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
+		// Create previous ObjectSet
+		require.NoError(t, Client.Create(ctx, prev))
+		cleanupOnSuccess(ctx, t, prev)
+		requireCondition(ctx, t, prev, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
 
-	// Create new ObjectSet with reference to previous and non-existent
-	require.NoError(t, Client.Create(ctx, objectSet))
-	cleanupOnSuccess(ctx, t, objectSet)
-	requireCondition(ctx, t, objectSet, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
-	assert.Equal(t, prev.Status.Revision+1, objectSet.Status.Revision)
+		// Create new ObjectSet with reference to previous and non-existent
+		require.NoError(t, Client.Create(ctx, objectSet))
+		cleanupOnSuccess(ctx, t, objectSet)
+		requireCondition(ctx, t, objectSet, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
+		assert.Equal(t, prev.Status.Revision+1, objectSet.Status.Revision)
+	})
+
+	t.Run("cluster", func(t *testing.T) {
+		prev := &corev1alpha1.ClusterObjectSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "previous-revision",
+				Namespace: "default",
+			},
+			Spec: corev1alpha1.ClusterObjectSetSpec{
+				ObjectSetTemplateSpec: objectSetTemplateSpec,
+			},
+		}
+
+		clusterObjectSet := prev.DeepCopy()
+		clusterObjectSet.Name = "test-invalid-previous-reference"
+		clusterObjectSet.Spec.Previous = []corev1alpha1.PreviousRevisionReference{
+			{Name: prev.Name},
+			{Name: "non-existent-revision"},
+		}
+
+		// Create previous ClusterObjectSet
+		require.NoError(t, Client.Create(ctx, prev))
+		cleanupOnSuccess(ctx, t, prev)
+		requireCondition(ctx, t, prev, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
+
+		// Create new ClusterObjectSet with reference to previous and non-existent
+		require.NoError(t, Client.Create(ctx, clusterObjectSet))
+		cleanupOnSuccess(ctx, t, clusterObjectSet)
+		requireCondition(ctx, t, clusterObjectSet, corev1alpha1.ObjectSetAvailable, metav1.ConditionTrue)
+		assert.Equal(t, prev.Status.Revision+1, clusterObjectSet.Status.Revision)
+	})
 }

--- a/internal/controllers/objectsets/revision_reconciler.go
+++ b/internal/controllers/objectsets/revision_reconciler.go
@@ -44,7 +44,7 @@ func (r *revisionReconciler) Reconcile(
 			Name:      prev.Name,
 			Namespace: objectSet.ClientObject().GetNamespace(),
 		}
-		if err := r.client.Get(ctx, key, prevObjectSet.ClientObject()); err != nil {
+		if err := client.IgnoreNotFound(r.client.Get(ctx, key, prevObjectSet.ClientObject())); err != nil {
 			return res, fmt.Errorf("getting previous revision: %w", err)
 		}
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
**Bug:** If an ObjectSet had an outdated list of previous revisions (e.g., includes deleted revisions),
the ObjectSet controller would error when trying to get a non-existing previous revision.
The fix is to ignore non-existing previous revisions.

Jira: [PKO-293](https://issues.redhat.com/browse/PKO-293)

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.
