### PR TITLE
ci: Ignore integration folder in codecov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,3 +6,4 @@ ignore:
   - "cmd/build"
   - "cmd/test-stub"
   - internal/packages/internal/packagekickstart/rukpak
+  - "integration"


### PR DESCRIPTION
Integration tests do not need coverage by unit tests (https://issues.redhat.com/browse/PKO-299)