### PR TITLE
[PKO-297] Assign ObjectSet revision number in the ObjectDeployment controller

### DIFF
--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -42,6 +42,7 @@ type ClusterObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
+// +kubebuilder:validation:XValidation:rule="self.revision == oldSelf.revision", message="revision is immutable"
 type ClusterObjectSetSpec struct {
 	// Specifies the lifecycle state of the ClusterObjectSet.
 	// +kubebuilder:default="Active"

--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -54,6 +54,9 @@ type ClusterObjectSetSpec struct {
 	Previous []PreviousRevisionReference `json:"previous,omitempty"`
 
 	ObjectSetTemplateSpec `json:",inline"`
+
+	// Computed revision number, monotonically increasing.
+	Revision int64 `json:"revision"`
 }
 
 // ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.

--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -42,7 +42,7 @@ type ClusterObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
-// +kubebuilder:validation:XValidation:rule="self.revision == oldSelf.revision", message="revision is immutable"
+// +kubebuilder:validation:XValidation:rule="(has(self.revision) == has(oldSelf.revision)) && (!has(self.revision) || (self.revision == oldSelf.revision))", message="revision is immutable"
 type ClusterObjectSetSpec struct {
 	// Specifies the lifecycle state of the ClusterObjectSet.
 	// +kubebuilder:default="Active"
@@ -57,7 +57,7 @@ type ClusterObjectSetSpec struct {
 	ObjectSetTemplateSpec `json:",inline"`
 
 	// Computed revision number, monotonically increasing.
-	Revision int64 `json:"revision"`
+	Revision int64 `json:"revision,omitempty"`
 }
 
 // ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -44,6 +44,7 @@ type ObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
+// +kubebuilder:validation:XValidation:rule="self.revision == oldSelf.revision", message="revision is immutable"
 type ObjectSetSpec struct {
 	// Specifies the lifecycle state of the ObjectSet.
 	// +kubebuilder:default="Active"

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -44,7 +44,7 @@ type ObjectSetList struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.phases) == has(oldSelf.phases)) && (!has(self.phases) || (self.phases == oldSelf.phases))", message="phases is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.availabilityProbes) == has(oldSelf.availabilityProbes)) && (!has(self.availabilityProbes) || (self.availabilityProbes == oldSelf.availabilityProbes))", message="availabilityProbes is immutable"
 // +kubebuilder:validation:XValidation:rule="(has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds)) && (!has(self.successDelaySeconds) || (self.successDelaySeconds == oldSelf.successDelaySeconds))", message="successDelaySeconds is immutable"
-// +kubebuilder:validation:XValidation:rule="self.revision == oldSelf.revision", message="revision is immutable"
+// +kubebuilder:validation:XValidation:rule="(has(self.revision) == has(oldSelf.revision)) && (!has(self.revision) || (self.revision == oldSelf.revision))", message="revision is immutable"
 type ObjectSetSpec struct {
 	// Specifies the lifecycle state of the ObjectSet.
 	// +kubebuilder:default="Active"
@@ -59,7 +59,7 @@ type ObjectSetSpec struct {
 	ObjectSetTemplateSpec `json:",inline"`
 
 	// Computed revision number, monotonically increasing.
-	Revision int64 `json:"revision"`
+	Revision int64 `json:"revision,omitempty"`
 }
 
 // ObjectSetStatus defines the observed state of a ObjectSet.

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -56,6 +56,9 @@ type ObjectSetSpec struct {
 	Previous []PreviousRevisionReference `json:"previous,omitempty"`
 
 	ObjectSetTemplateSpec `json:",inline"`
+
+	// Computed revision number, monotonically increasing.
+	Revision int64 `json:"revision"`
 }
 
 // ObjectSetStatus defines the observed state of a ObjectSet.

--- a/cmd/kubectl-package/rolloutcmd/history_test.go
+++ b/cmd/kubectl-package/rolloutcmd/history_test.go
@@ -201,6 +201,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
 					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 1,
+					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 1,
 					},
@@ -218,7 +221,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 				`                "package-operator.run/instance": "test"`,
 				"            }",
 				"        },",
-				`        "spec": {},`,
+				`        "spec": {`,
+				`            "revision": 1`,
+				"        },",
 				`        "status": {`,
 				`            "revision": 1`,
 				"        }",
@@ -242,6 +247,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
 					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 1,
+					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 1,
 					},
@@ -255,7 +263,8 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 				"      package-operator.run/instance: test",
 				"    name: test",
 				`    resourceVersion: "999"`,
-				"  spec: {}",
+				"  spec:",
+				"    revision: 1",
 				"  status:",
 				"    revision: 1",
 				"",
@@ -276,6 +285,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
 					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 1,
+					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 1,
 					},
@@ -286,6 +298,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 						Labels: map[string]string{
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
+					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 2,
 					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 2,
@@ -300,7 +315,8 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 				"    package-operator.run/instance: test",
 				"  name: test-2",
 				`  resourceVersion: "999"`,
-				"spec: {}",
+				"spec:",
+				"  revision: 2",
 				"status:",
 				"  revision: 2",
 				"",
@@ -321,6 +337,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
 					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 1,
+					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 1,
 					},
@@ -331,6 +350,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 						Labels: map[string]string{
 							manifestsv1alpha1.PackageInstanceLabel: "test",
 						},
+					},
+					Spec: corev1alpha1.ClusterObjectSetSpec{
+						Revision: 2,
 					},
 					Status: corev1alpha1.ClusterObjectSetStatus{
 						Revision: 2,
@@ -348,7 +370,9 @@ func TestHistoryCmd(t *testing.T) { //nolint:maintidx
 				`            "package-operator.run/instance": "test"`,
 				"        }",
 				"    },",
-				`    "spec": {},`,
+				`    "spec": {`,
+				`        "revision": 2`,
+				"    },",
 				`    "status": {`,
 				`        "revision": 2`,
 				"    }",

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -320,8 +320,6 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
-            required:
-            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable
@@ -338,7 +336,8 @@ spec:
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
             - message: revision is immutable
-              rule: self.revision == oldSelf.revision
+              rule: (has(self.revision) == has(oldSelf.revision)) && (!has(self.revision)
+                || (self.revision == oldSelf.revision))
           status:
             description: ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.
             properties:

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -307,6 +307,10 @@ spec:
                   - name
                   type: object
                 type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
               successDelaySeconds:
                 description: |-
                   Success Delay Seconds applies a wait period from the time an
@@ -316,6 +320,8 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
+            required:
+            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -337,6 +337,8 @@ spec:
               rule: (has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds))
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
+            - message: revision is immutable
+              rule: self.revision == oldSelf.revision
           status:
             description: ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.
             properties:

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -320,8 +320,6 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
-            required:
-            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable
@@ -338,7 +336,8 @@ spec:
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
             - message: revision is immutable
-              rule: self.revision == oldSelf.revision
+              rule: (has(self.revision) == has(oldSelf.revision)) && (!has(self.revision)
+                || (self.revision == oldSelf.revision))
           status:
             description: ObjectSetStatus defines the observed state of a ObjectSet.
             properties:

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -307,6 +307,10 @@ spec:
                   - name
                   type: object
                 type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
               successDelaySeconds:
                 description: |-
                   Success Delay Seconds applies a wait period from the time an
@@ -316,6 +320,8 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
+            required:
+            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -337,6 +337,8 @@ spec:
               rule: (has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds))
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
+            - message: revision is immutable
+              rule: self.revision == oldSelf.revision
           status:
             description: ObjectSetStatus defines the observed state of a ObjectSet.
             properties:

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -320,8 +320,6 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
-            required:
-            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable
@@ -338,7 +336,8 @@ spec:
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
             - message: revision is immutable
-              rule: self.revision == oldSelf.revision
+              rule: (has(self.revision) == has(oldSelf.revision)) && (!has(self.revision)
+                || (self.revision == oldSelf.revision))
           status:
             description: ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.
             properties:

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -307,6 +307,10 @@ spec:
                   - name
                   type: object
                 type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
               successDelaySeconds:
                 description: |-
                   Success Delay Seconds applies a wait period from the time an
@@ -316,6 +320,8 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
+            required:
+            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -337,6 +337,8 @@ spec:
               rule: (has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds))
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
+            - message: revision is immutable
+              rule: self.revision == oldSelf.revision
           status:
             description: ClusterObjectSetStatus defines the observed state of a ClusterObjectSet.
             properties:

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -320,8 +320,6 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
-            required:
-            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable
@@ -338,7 +336,8 @@ spec:
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
             - message: revision is immutable
-              rule: self.revision == oldSelf.revision
+              rule: (has(self.revision) == has(oldSelf.revision)) && (!has(self.revision)
+                || (self.revision == oldSelf.revision))
           status:
             description: ObjectSetStatus defines the observed state of a ObjectSet.
             properties:

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -307,6 +307,10 @@ spec:
                   - name
                   type: object
                 type: array
+              revision:
+                description: Computed revision number, monotonically increasing.
+                format: int64
+                type: integer
               successDelaySeconds:
                 description: |-
                   Success Delay Seconds applies a wait period from the time an
@@ -316,6 +320,8 @@ spec:
                   probes, but are ultimately unstable.
                 format: int32
                 type: integer
+            required:
+            - revision
             type: object
             x-kubernetes-validations:
             - message: previous is immutable

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -337,6 +337,8 @@ spec:
               rule: (has(self.successDelaySeconds) == has(oldSelf.successDelaySeconds))
                 && (!has(self.successDelaySeconds) || (self.successDelaySeconds ==
                 oldSelf.successDelaySeconds))
+            - message: revision is immutable
+              rule: self.revision == oldSelf.revision
           status:
             description: ObjectSetStatus defines the observed state of a ObjectSet.
             properties:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -800,7 +800,7 @@ ClusterObjectSetSpec defines the desired state of a ClusterObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ClusterObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ClusterObjectSet to adopt objects from. |
-| `revision` <b>required</b><br>int64 | Computed revision number, monotonically increasing. |
+| `revision` <br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |
@@ -971,7 +971,7 @@ ObjectSetSpec defines the desired state of a ObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ObjectSet to adopt objects from. |
-| `revision` <b>required</b><br>int64 | Computed revision number, monotonically increasing. |
+| `revision` <br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -156,6 +156,7 @@ spec:
     - ipsum
   previous:
   - name: previous-revision
+  revision: 42
   successDelaySeconds: 42
 status:
   conditions:
@@ -508,6 +509,7 @@ spec:
     - amet
   previous:
   - name: previous-revision
+  revision: 42
   successDelaySeconds: 42
 status:
   conditions:
@@ -798,6 +800,7 @@ ClusterObjectSetSpec defines the desired state of a ClusterObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ClusterObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ClusterObjectSet to adopt objects from. |
+| `revision` <b>required</b><br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |
@@ -968,6 +971,7 @@ ObjectSetSpec defines the desired state of a ObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ObjectSet to adopt objects from. |
+| `revision` <b>required</b><br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |

--- a/integration/package-operator/objectdeployment_test.go
+++ b/integration/package-operator/objectdeployment_test.go
@@ -158,6 +158,9 @@ func TestObjectDeployment_availability_and_hash_collision(t *testing.T) {
 		require.Equal(t,
 			concernedDeployment.Generation,
 			currentObjectSet.Status.Revision)
+		require.Equal(t,
+			concernedDeployment.Generation,
+			currentObjectSet.Spec.Revision)
 
 		// Expect ObjectSet to be created
 		// Expect concerned ObjectSet to be created
@@ -426,6 +429,9 @@ func TestObjectDeployment_ObjectSetArchival(t *testing.T) {
 		require.Equal(t,
 			concernedDeployment.Generation,
 			currentObjectSet.Status.Revision)
+		require.Equal(t,
+			concernedDeployment.Generation,
+			currentObjectSet.Spec.Revision)
 
 		// Expect concerned ObjectSet to be created
 		currObjectSetList := listObjectSetRevisions(ctx, t, concernedDeployment)

--- a/integration/package-operator/objectset_test.go
+++ b/integration/package-operator/objectset_test.go
@@ -679,6 +679,12 @@ func TestObjectSet_immutability(t *testing.T) {
 				os.SetSpecPreviousRevisions([]adapters.ObjectSetAccessor{os})
 			},
 		},
+		{
+			field: "revision",
+			modify: func(os adapters.ObjectSetAccessor) {
+				os.SetSpecRevision(os.GetSpecRevision() + 42)
+			},
+		},
 	} {
 		t.Run(tc.field, func(t *testing.T) {
 			newObjectSet := objectSet.DeepCopy()

--- a/internal/adapters/objectset.go
+++ b/internal/adapters/objectset.go
@@ -43,6 +43,8 @@ type ObjectSetAccessor interface {
 	GetSpecPrevious() []corev1alpha1.PreviousRevisionReference
 	SetSpecPreviousRevisions(prev []ObjectSetAccessor)
 	GetSpecSuccessDelaySeconds() int32
+	SetSpecRevision(int64)
+	GetSpecRevision() int64
 
 	IsStatusPaused() bool
 	GetStatusRevision() int64
@@ -191,6 +193,14 @@ func (a *ObjectSetAdapter) GetSpecSuccessDelaySeconds() int32 {
 	return a.Spec.SuccessDelaySeconds
 }
 
+func (a *ObjectSetAdapter) SetSpecRevision(revision int64) {
+	a.Spec.Revision = revision
+}
+
+func (a *ObjectSetAdapter) GetSpecRevision() int64 {
+	return a.Spec.Revision
+}
+
 func (a *ObjectSetAdapter) GetStatusRemotePhases() []corev1alpha1.RemotePhaseReference {
 	return a.Status.RemotePhases
 }
@@ -312,6 +322,14 @@ func (a *ClusterObjectSetAdapter) GetAvailabilityProbes() []corev1alpha1.ObjectS
 
 func (a *ClusterObjectSetAdapter) GetSpecSuccessDelaySeconds() int32 {
 	return a.Spec.SuccessDelaySeconds
+}
+
+func (a *ClusterObjectSetAdapter) SetSpecRevision(revision int64) {
+	a.Spec.Revision = revision
+}
+
+func (a *ClusterObjectSetAdapter) GetSpecRevision() int64 {
+	return a.Spec.Revision
 }
 
 func (a *ClusterObjectSetAdapter) GetStatusRemotePhases() []corev1alpha1.RemotePhaseReference {

--- a/internal/adapters/objectset_test.go
+++ b/internal/adapters/objectset_test.go
@@ -39,6 +39,8 @@ func TestObjectSet(t *testing.T) {
 	var revision int64 = 34
 	objectSet.SetStatusRevision(revision)
 	assert.Equal(t, revision, objectSet.GetStatusRevision())
+	objectSet.SetSpecRevision(revision)
+	assert.Equal(t, revision, objectSet.GetSpecRevision())
 
 	objectSet.Spec.Previous = []corev1alpha1.PreviousRevisionReference{
 		{},
@@ -107,6 +109,8 @@ func TestClusterObjectSet(t *testing.T) {
 	var revision int64 = 34
 	objectSet.SetStatusRevision(revision)
 	assert.Equal(t, revision, objectSet.GetStatusRevision())
+	objectSet.SetSpecRevision(revision)
+	assert.Equal(t, revision, objectSet.GetSpecRevision())
 
 	objectSet.Spec.Previous = []corev1alpha1.PreviousRevisionReference{
 		{},

--- a/internal/cmd/client_test.go
+++ b/internal/cmd/client_test.go
@@ -876,7 +876,8 @@ func TestObjectSetList_RenderYAML(t *testing.T) {
 	expected := strings.Join([]string{
 		"- metadata:",
 		"    creationTimestamp: null",
-		"  spec: {}",
+		"  spec:",
+		"    revision: 1",
 		"  status:",
 		"    revision: 1",
 		"",
@@ -884,6 +885,9 @@ func TestObjectSetList_RenderYAML(t *testing.T) {
 
 	list := ObjectSetList{
 		NewObjectSet(&corev1alpha1.ClusterObjectSet{
+			Spec: corev1alpha1.ClusterObjectSetSpec{
+				Revision: 1,
+			},
 			Status: corev1alpha1.ClusterObjectSetStatus{
 				Revision: 1,
 			},
@@ -905,7 +909,9 @@ func TestObjectSetList_RenderJSON(t *testing.T) {
 		`        "metadata": {`,
 		`            "creationTimestamp": null`,
 		"        },",
-		`        "spec": {},`,
+		`        "spec": {`,
+		`            "revision": 1`,
+		"        },",
 		`        "status": {`,
 		`            "revision": 1`,
 		"        }",
@@ -915,6 +921,9 @@ func TestObjectSetList_RenderJSON(t *testing.T) {
 
 	list := ObjectSetList{
 		NewObjectSet(&corev1alpha1.ClusterObjectSet{
+			Spec: corev1alpha1.ClusterObjectSetSpec{
+				Revision: 1,
+			},
 			Status: corev1alpha1.ClusterObjectSetStatus{
 				Revision: 1,
 			},

--- a/internal/controllers/objectdeployments/new_revision_reconciler.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler.go
@@ -107,6 +107,7 @@ func (r *newRevisionReconciler) newObjectSetFromDeployment(
 		objectDeployment.GetSpecObjectSetTemplate().Spec,
 	)
 	newObjectSet.SetSpecPreviousRevisions(prevObjectSets)
+	newObjectSet.SetSpecRevision(latestRevisionNumber(prevObjectSets) + 1)
 
 	if newObjectSetClientObj.GetLabels() == nil {
 		newObjectSetClientObj.SetLabels(map[string]string{})

--- a/internal/controllers/objectdeployments/new_revision_reconciler_test.go
+++ b/internal/controllers/objectdeployments/new_revision_reconciler_test.go
@@ -245,7 +245,11 @@ func requireObject(t *testing.T,
 	for i, prev := range obj.Spec.Previous {
 		objprevs[i] = prev.Name
 	}
+
+	latestRevision := int64(0)
 	for _, prev := range prevs {
+		latestRevision = max(latestRevision, prev.Spec.Revision)
 		require.Contains(t, objprevs, prev.Name)
 	}
+	require.Equal(t, latestRevision+1, obj.Spec.Revision)
 }

--- a/internal/controllers/objectdeployments/objectset_reconciler_test.go
+++ b/internal/controllers/objectdeployments/objectset_reconciler_test.go
@@ -371,6 +371,7 @@ func newObjectSet(
 			ObjectSetTemplateSpec: corev1alpha1.ObjectSetTemplateSpec{
 				Phases: []corev1alpha1.ObjectSetTemplatePhase{{}},
 			},
+			Revision: deploymentRevision,
 		},
 		Status: corev1alpha1.ObjectSetStatus{
 			Revision: deploymentRevision,

--- a/internal/controllers/objectsets/revision_reconciler.go
+++ b/internal/controllers/objectsets/revision_reconciler.go
@@ -32,6 +32,12 @@ func (r *revisionReconciler) Reconcile(
 		return
 	}
 
+	if objectSet.GetSpecRevision() != 0 {
+		// Prioritize .spec.revision set by ObjectDeploymentController's newRevisionReconciler
+		objectSet.SetStatusRevision(objectSet.GetSpecRevision())
+		return
+	}
+
 	if len(objectSet.GetSpecPrevious()) == 0 {
 		// no previous revision(s) specified, default to revision 1
 		objectSet.SetStatusRevision(1)

--- a/internal/testutil/adaptermocks/objectset_mock.go
+++ b/internal/testutil/adaptermocks/objectset_mock.go
@@ -138,6 +138,15 @@ func (o *ObjectSetMock) GetSpecPausedByParent() bool {
 	return args.Get(0).(bool)
 }
 
+func (o *ObjectSetMock) GetSpecRevision() int64 {
+	args := o.Called()
+	return args.Get(0).(int64)
+}
+
+func (o *ObjectSetMock) SetSpecRevision(revision int64) {
+	o.Called(revision)
+}
+
 func (o *ObjectSetMock) DeepCopyObject() runtime.Object {
 	args := o.Called()
 	return args.Get(0).(runtime.Object)


### PR DESCRIPTION
### Summary
Add revision assignment logic to the NewRevisionReconciler in the ObjectDeployment controller:
* Add an immutable `.spec.revision` field to the (Cluster)ObjectSet API.
* Assign `.spec.revision` to new revisions as they're created by the NewRevisionReconciler (in the ObjectDeployment controller).
* `.spec.revision` is computed from the previous revisions as `latestRevision + 1` (or `1` if no previous).
* The RevisionReconciler (in the ObjectSet controller) assigns `.status.revision` based on `.spec.revision` (if present).

Implements the first part of [PKO-297](https://issues.redhat.com/browse/PKO-297). The revision assignment logic in the ObjectSet controller will be removed in a follow-up ticket.

### Change Type
New Feature

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.