### PR TITLE
[PKO-318] Fix os revisions

### DIFF
--- a/apis/core/v1alpha1/clusterobjectset_types.go
+++ b/apis/core/v1alpha1/clusterobjectset_types.go
@@ -57,9 +57,9 @@ type ClusterObjectSetSpec struct {
 	ObjectSetTemplateSpec `json:",inline"`
 
 	// Computed revision number, monotonically increasing.
-	// TODO: after soaking, update the validation rule to match the other ones.
-	// Currently, the rule allows adding the revision field to existing ClusterObjectSets
-	// to phase in the new revision numbering approach.
+	// TODO: After soaking, update the validation rule to match the other ones.
+	// TODO: Currently, the rule allows adding the revision field to existing ClusterObjectSets
+	// TODO: to phase in the new revision numbering approach.
 	Revision int64 `json:"revision,omitempty"`
 }
 

--- a/apis/core/v1alpha1/objectset_types.go
+++ b/apis/core/v1alpha1/objectset_types.go
@@ -59,9 +59,9 @@ type ObjectSetSpec struct {
 	ObjectSetTemplateSpec `json:",inline"`
 
 	// Computed revision number, monotonically increasing.
-	// TODO: after soaking, update the validation rule to match the other ones.
-	// Currently, the rule allows adding the revision field to existing ObjectSets
-	// to phase in the new revision numbering approach.
+	// TODO: After soaking, update the validation rule to match the other ones.
+	// TODO: Currently, the rule allows adding the revision field to existing ObjectSets
+	// TODO: to phase in the new revision numbering approach.
 	Revision int64 `json:"revision,omitempty"`
 }
 

--- a/config/crds/package-operator.run_clusterobjectsets.yaml
+++ b/config/crds/package-operator.run_clusterobjectsets.yaml
@@ -308,10 +308,7 @@ spec:
                   type: object
                 type: array
               revision:
-                description: |-
-                  Computed revision number, monotonically increasing.
-                  Currently, the rule allows adding the revision field to existing ClusterObjectSets
-                  to phase in the new revision numbering approach.
+                description: Computed revision number, monotonically increasing.
                 format: int64
                 type: integer
               successDelaySeconds:

--- a/config/crds/package-operator.run_objectsets.yaml
+++ b/config/crds/package-operator.run_objectsets.yaml
@@ -308,10 +308,7 @@ spec:
                   type: object
                 type: array
               revision:
-                description: |-
-                  Computed revision number, monotonically increasing.
-                  Currently, the rule allows adding the revision field to existing ObjectSets
-                  to phase in the new revision numbering approach.
+                description: Computed revision number, monotonically increasing.
                 format: int64
                 type: integer
               successDelaySeconds:

--- a/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_clusterobjectsets.yaml
@@ -308,10 +308,7 @@ spec:
                   type: object
                 type: array
               revision:
-                description: |-
-                  Computed revision number, monotonically increasing.
-                  Currently, the rule allows adding the revision field to existing ClusterObjectSets
-                  to phase in the new revision numbering approach.
+                description: Computed revision number, monotonically increasing.
                 format: int64
                 type: integer
               successDelaySeconds:

--- a/config/static-deployment/1-package-operator.run_objectsets.yaml
+++ b/config/static-deployment/1-package-operator.run_objectsets.yaml
@@ -308,10 +308,7 @@ spec:
                   type: object
                 type: array
               revision:
-                description: |-
-                  Computed revision number, monotonically increasing.
-                  Currently, the rule allows adding the revision field to existing ObjectSets
-                  to phase in the new revision numbering approach.
+                description: Computed revision number, monotonically increasing.
                 format: int64
                 type: integer
               successDelaySeconds:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -808,7 +808,7 @@ ClusterObjectSetSpec defines the desired state of a ClusterObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ClusterObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ClusterObjectSet to adopt objects from. |
-| `revision` <br>int64 | Computed revision number, monotonically increasing.<br>Currently, the rule allows adding the revision field to existing ClusterObjectSets<br>to phase in the new revision numbering approach. |
+| `revision` <br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |
@@ -980,7 +980,7 @@ ObjectSetSpec defines the desired state of a ObjectSet.
 | ----- | ----------- |
 | `lifecycleState` <br><a href="#objectsetlifecyclestate">ObjectSetLifecycleState</a> | Specifies the lifecycle state of the ObjectSet. |
 | `previous` <br><a href="#previousrevisionreference">[]PreviousRevisionReference</a> | Previous revisions of the ObjectSet to adopt objects from. |
-| `revision` <br>int64 | Computed revision number, monotonically increasing.<br>Currently, the rule allows adding the revision field to existing ObjectSets<br>to phase in the new revision numbering approach. |
+| `revision` <br>int64 | Computed revision number, monotonically increasing. |
 | `phases` <br><a href="#objectsettemplatephase">[]ObjectSetTemplatePhase</a> | Reconcile phase configuration for a ObjectSet.<br>Phases will be reconciled in order and the contained objects checked<br>against given probes before continuing with the next phase. |
 | `availabilityProbes` <br><a href="#objectsetprobe">[]ObjectSetProbe</a> | Availability Probes check objects that are part of the package.<br>All probes need to succeed for a package to be considered Available.<br>Failing probes will prevent the reconciliation of objects in later phases. |
 | `successDelaySeconds` <br>int32 | Success Delay Seconds applies a wait period from the time an<br>Object Set is available to the time it is marked as successful.<br>This can be used to prevent false reporting of success when<br>the underlying objects may initially satisfy the availability<br>probes, but are ultimately unstable. |


### PR DESCRIPTION
### Summary
**TL;DR**: This PR re-adds the logic that will assign `.spec.revision := .status.revision` in existing revisions.

This PR re-reverts changes from #2155 which were made to assign `.spec.revision := .status.revision` in existing revisions. The PR broke stage because the CRDs needed to be rolled out and soaked before the PKO manager logic could kick in. The changes were reverted by #2203, except for the CRD update which has been rolled out.

Most of the changes are refactoring `Test_revisionReconciler` after the linter complained about its complexity.

Jira: [PKO-318](https://issues.redhat.com/browse/PKO-318)

Codecov is complaining about a single if statement which will be removed as a part of [PKO-316](https://issues.redhat.com/browse/PKO-316).

### Change Type
Bug Fix

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.
