### PR TITLE
PKO-384 fix(controllers/objectsetphases): use correct client to apply cache label to conflicting object

### DIFF
--- a/internal/controllers/objectsetphases/objectsetphase_controller.go
+++ b/internal/controllers/objectsetphases/objectsetphase_controller.go
@@ -171,7 +171,6 @@ func NewGenericObjectSetPhaseController(
 	phaseReconciler := newObjectSetPhaseReconciler(
 		scheme,
 		accessManager,
-		client,
 		boxcutterutil.NewPhaseEngineFactory(
 			scheme, discoveryClient, targetRESTMapper, phaseValidator),
 		controllers.NewPreviousRevisionLookup(

--- a/internal/controllers/objectsetphases/objectsetphase_reconciler.go
+++ b/internal/controllers/objectsetphases/objectsetphase_reconciler.go
@@ -33,7 +33,6 @@ import (
 type objectSetPhaseReconciler struct {
 	scheme                  *runtime.Scheme
 	accessManager           managedcache.ObjectBoundAccessManager[client.Object]
-	uncachedclient          client.Client
 	phaseEngineFactory      boxcutterutil.PhaseEngineFactory
 	lookupPreviousRevisions lookupPreviousRevisions
 	ownerStrategy           boxcutterutil.OwnerStrategy
@@ -43,7 +42,6 @@ type objectSetPhaseReconciler struct {
 func newObjectSetPhaseReconciler(
 	scheme *runtime.Scheme,
 	accessManager managedcache.ObjectBoundAccessManager[client.Object],
-	uncachedClient client.Client,
 	phaseEngineFactory boxcutterutil.PhaseEngineFactory,
 	lookupPreviousRevisions lookupPreviousRevisions,
 	ownerStrategy boxcutterutil.OwnerStrategy,
@@ -55,7 +53,6 @@ func newObjectSetPhaseReconciler(
 	return &objectSetPhaseReconciler{
 		scheme:                  scheme,
 		accessManager:           accessManager,
-		uncachedclient:          uncachedClient,
 		phaseEngineFactory:      phaseEngineFactory,
 		lookupPreviousRevisions: lookupPreviousRevisions,
 		ownerStrategy:           ownerStrategy,
@@ -136,7 +133,7 @@ func (r *objectSetPhaseReconciler) Reconcile(
 
 	target := &machinery.CreateCollisionError{}
 	if errors.As(err, &target) {
-		_, err := controllers.AddDynamicCacheLabel(ctx, r.uncachedclient, convertToUnstructured(target.Object()))
+		_, err := controllers.AddDynamicCacheLabel(ctx, cache, convertToUnstructured(target.Object()))
 		if err != nil {
 			return res, err
 		}

--- a/internal/controllers/objectsetphases/objectsetphase_reconciler_test.go
+++ b/internal/controllers/objectsetphases/objectsetphase_reconciler_test.go
@@ -79,13 +79,12 @@ func TestPhaseReconciler_Reconcile(t *testing.T) {
 			objectSetPhase.ClientObject().SetUID("test-uid")
 			accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 			accessor := &managedcachemocks.AccessorMock{}
-			uncachedClient := testutil.NewClient()
 			phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 			phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 			phaseResult := &boxcuttermocks.PhaseResultMock{}
 			ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 			// TODO mock client
-			r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+			r := newObjectSetPhaseReconciler(testScheme, accessManager,
 				phaseEngineFactory, lookup, ownerStrategy)
 			accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(accessor, nil)
@@ -140,12 +139,11 @@ func TestPhaseReconciler_ReconcileBackoff(t *testing.T) {
 	objectSetPhase.ClientObject().SetUID("test-uid-backoff")
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 	phaseResult := &boxcuttermocks.PhaseResultMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -186,12 +184,11 @@ func TestPhaseReconciler_Teardown(t *testing.T) {
 			objectSetPhase.ClientObject().SetUID("test-uid-teardown")
 			ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 			accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
-			uncachedClient := testutil.NewClient()
 			accessor := &managedcachemocks.AccessorMock{}
 			phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 			phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 			phaseTeardownResult := &boxcuttermocks.PhaseTeardownResultMock{}
-			r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+			r := newObjectSetPhaseReconciler(testScheme, accessManager,
 				phaseEngineFactory, lookup, ownerStrategy)
 
 			accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -241,9 +238,8 @@ func TestPhaseReconciler_Teardown_OrphanFinalizer(t *testing.T) {
 
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	cleanupDone, err := r.Teardown(context.Background(), objectSetPhase)
@@ -266,9 +262,8 @@ func TestPhaseReconciler_Teardown_AccessManagerError(t *testing.T) {
 	objectSetPhase.ClientObject().SetUID("test-uid-access-mgr-error")
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	expectedErr := assert.AnError
@@ -293,9 +288,8 @@ func TestPhaseReconciler_Teardown_PhaseEngineFactoryError(t *testing.T) {
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -322,10 +316,9 @@ func TestPhaseReconciler_Teardown_PhaseEngineError(t *testing.T) {
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -354,11 +347,10 @@ func TestPhaseReconciler_Teardown_FreeWithUserError(t *testing.T) {
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 	phaseTeardownResult := &boxcuttermocks.PhaseTeardownResultMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -390,10 +382,9 @@ func TestPhaseReconciler_Reconcile_LookupPreviousRevisionsError(t *testing.T) {
 	objectSetPhase.ClientObject().SetName("testPhaseOwner")
 	objectSetPhase.ClientObject().SetUID("test-uid-lookup-error")
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	res, err := r.Reconcile(context.Background(), objectSetPhase)
@@ -414,10 +405,9 @@ func TestPhaseReconciler_Reconcile_AccessManagerError(t *testing.T) {
 	objectSetPhase.ClientObject().SetName("testPhaseOwner")
 	objectSetPhase.ClientObject().SetUID("test-uid-reconcile-access-error")
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	expectedErr := assert.AnError
@@ -443,10 +433,9 @@ func TestPhaseReconciler_Reconcile_PhaseEngineFactoryError(t *testing.T) {
 	objectSetPhase.ClientObject().SetUID("test-uid-reconcile-factory-error")
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -474,11 +463,10 @@ func TestPhaseReconciler_Reconcile_GenericError(t *testing.T) {
 	objectSetPhase.ClientObject().SetUID("test-uid-reconcile-generic-error")
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -532,13 +520,12 @@ func TestPhaseReconciler_Reconcile_WithObjects(t *testing.T) {
 
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 	phaseResult := &boxcuttermocks.PhaseResultMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -604,13 +591,12 @@ func TestPhaseReconciler_Reconcile_PausedState(t *testing.T) {
 
 	accessManager := &managedcachemocks.ObjectBoundAccessManagerMock[client.Object]{}
 	accessor := &managedcachemocks.AccessorMock{}
-	uncachedClient := testutil.NewClient()
 	phaseEngineFactory := &boxcuttermocks.PhaseEngineFactoryMock{}
 	phaseEngine := &boxcuttermocks.PhaseEngineMock{}
 	phaseResult := &boxcuttermocks.PhaseResultMock{}
 	ownerStrategy := &ownerhandlingmocks.OwnerStrategyMock{}
 
-	r := newObjectSetPhaseReconciler(testScheme, accessManager, uncachedClient,
+	r := newObjectSetPhaseReconciler(testScheme, accessManager,
 		phaseEngineFactory, lookup, ownerStrategy)
 
 	accessManager.On("GetWithUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).


### PR DESCRIPTION
fix(controllers/objectsetphases): use correct client to apply cache label to conflicting object

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
https://issues.redhat.com/browse/PKO-384

This change surfaces a new bug though. The reproduced conflict is now ignored and the object is adopted anyways.

**As of now I do not recommend merging this change because the fixed bug is currently our only stop gap to prevent conflicts from just being overridden.**

Reproducer:
1. Set up dev environment with hosted cluster: `./do dev:createhostedcluster`
1. Run package-operator-manager (in new shell): `./do dev:run`
1. Create conflicting object on hosted cluster: `KUBECONFIG=$PWD/.cache/clusters/pko-hs-hc/kubeconfig.yaml kubectl create cm conflict --from-literal key=val`
1. Watch conflicting object on hosted cluster (in new shell): `KUBECONFIG=$PWD/.cache/clusters/pko-hs-hc/kubeconfig.yaml kubectl get cm conflict -o yaml -w --show-managed-fields`
1. Apply ObjectDeployment with conflict:

```bash
KUBECONFIG=$PWD/.cache/clusters/pko/kubeconfig.yaml kubectl apply -f - <<EOF
apiVersion: package-operator.run/v1alpha1
kind: ObjectDeployment
metadata:
  namespace: default-pko-hs-hc
  name: conflict-test
spec:
  selector:
    matchLabels:
      conflict: test
  template:
    metadata:
      labels:
        conflict: test
    spec:
      phases:
      - name: test
        class: hosted-cluster
        objects:
        - object:
            apiVersion: v1
            kind: ConfigMap
            metadata:
              namespace: default
              name: conflict
            data:
              foo: bar
EOF
```

Observerd watch output:

```yaml
apiVersion: v1
data:
  key: val
kind: ConfigMap
metadata:
  creationTimestamp: "2026-03-06T12:51:38Z"
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        .: {}
        f:key: {}
    manager: kubectl-create
    operation: Update
    time: "2026-03-06T12:51:38Z"
  name: conflict
  namespace: default
  resourceVersion: "639"
  uid: aa3a69ea-4f8e-42fd-bfa3-d8c20a89c8dd
---
apiVersion: v1
data:
  foo: bar
  key: val
kind: ConfigMap
metadata:
  annotations:
    package-operator.run/owners: '[{"apiVersion":"package-operator.run/v1alpha1","kind":"ObjectSetPhase","name":"conflict-test-7bc5c9fcbb-test","namespace":"default-pko-hs-hc","uid":"0164b258-8ee8-4168-946e-4e89661d0a28","controller":true}]'
    package-operator.run/revision: "1"
  creationTimestamp: "2026-03-06T12:51:38Z"
  labels:
    app.kubernetes.io/managed-by: boxcutter
    package-operator.run/cache: "True"
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        .: {}
        f:key: {}
    manager: kubectl-create
    operation: Update
    time: "2026-03-06T12:51:38Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        f:foo: {}
      f:metadata:
        f:annotations:
          .: {}
          f:package-operator.run/owners: {}
          f:package-operator.run/revision: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/managed-by: {}
          f:package-operator.run/cache: {}
    manager: remote-phase-manager
    operation: Update
    time: "2026-03-06T12:53:49Z"
  name: conflict
  namespace: default
  resourceVersion: "817"
  uid: aa3a69ea-4f8e-42fd-bfa3-d8c20a89c8dd
```

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.
- [x] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
