### PR TITLE
Introduce `./do dev:IntegrationDirect` to allow partially running integration tests without bootstrapping a full integration test environment

### DIFF
--- a/cmd/build/dev.go
+++ b/cmd/build/dev.go
@@ -84,6 +84,20 @@ func (dev *Dev) Integration(ctx context.Context, args []string) error {
 	return test.Integration(ctx, false, filter)
 }
 
+// IntegrationDirect runs local integration tests in a KinD cluster without setting up the cluster first.
+func (dev *Dev) IntegrationDirect(ctx context.Context, args []string) error {
+	var filter string
+	switch len(args) {
+	case 0:
+		// nothing
+	case 1:
+		filter = args[0]
+	default:
+		return errors.New("only supports a single argument")
+	}
+	return test.IntegrationDirect(ctx, false, filter)
+}
+
 // Lint runs local linters to check the codebase.
 func (dev *Dev) Lint(ctx context.Context, _ []string) error {
 	return lint.glciCheck(ctx)

--- a/cmd/build/test.go
+++ b/cmd/build/test.go
@@ -19,11 +19,22 @@ type Test struct{}
 
 // Integration runs local integration tests in a KinD cluster.
 func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) error {
-	self := run.Meth2(t, t.Integration, jsonOutput, filter)
-	if err := mgr.ParallelDeps(ctx, self,
-		run.Fn1(bootstrap, ctx),
-	); err != nil {
-		return err
+	return t.integration(ctx, true, false, jsonOutput, filter)
+}
+
+// IntegrationDirect runs local integration tests in a KinD cluster without setting up the cluster first.
+func (t Test) IntegrationDirect(ctx context.Context, jsonOutput bool, filter string) error {
+	return t.integration(ctx, false, true, jsonOutput, filter)
+}
+
+func (t Test) integration(ctx context.Context, deps, short, jsonOutput bool, filter string) error {
+	self := run.Meth4(t, t.integration, deps, short, jsonOutput, filter)
+	if deps {
+		if err := mgr.ParallelDeps(ctx, self,
+			run.Fn1(bootstrap, ctx),
+		); err != nil {
+			return err
+		}
 	}
 
 	var f string
@@ -87,7 +98,7 @@ func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) e
 	}
 
 	// standard integration tests
-	goTestCmd := t.makeGoIntTestCmd("integration", f, jsonOutput)
+	goTestCmd := t.makeGoIntTestCmd("integration", f, short, jsonOutput)
 
 	if err := os.MkdirAll(filepath.Join(cacheDir, "integration"), 0o755); err != nil {
 		return err
@@ -110,7 +121,7 @@ func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) e
 		return err
 	}
 
-	goTestHypershiftCmd := t.makeGoIntTestCmd("integration_hypershift", f, jsonOutput)
+	goTestHypershiftCmd := t.makeGoIntTestCmd("integration_hypershift", f, short, jsonOutput)
 
 	if err := os.MkdirAll(filepath.Join(cacheDir, "integration"), 0o755); err != nil {
 		return err
@@ -132,7 +143,7 @@ func (t Test) Integration(ctx context.Context, jsonOutput bool, filter string) e
 	}
 }
 
-func (Test) makeGoIntTestCmd(tags string, filter string, jsonOutput bool) string {
+func (Test) makeGoIntTestCmd(tags string, filter string, short, jsonOutput bool) string {
 	args := []string{
 		"go", "test",
 		"-tags=" + tags,
@@ -143,6 +154,10 @@ func (Test) makeGoIntTestCmd(tags string, filter string, jsonOutput bool) string
 		"-failfast",
 		"-timeout=20m",
 		"-count=1",
+	}
+
+	if short {
+		args = append(args, "-short")
 	}
 
 	if jsonOutput {

--- a/cmd/package-operator-manager/hypershift.go
+++ b/cmd/package-operator-manager/hypershift.go
@@ -53,7 +53,7 @@ func (h *hypershift) Start(ctx context.Context) error {
 			h.log.Info("detected hypershift installation after setup completed, restarting operator")
 			return ErrHypershiftAPIPostSetup
 		case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) ||
-			discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+			errors.Is(err, &discovery.ErrGroupDiscoveryFailed{}):
 			continue
 		default:
 			return fmt.Errorf("hypershiftv1beta1 probing: %w", err)

--- a/cmd/package-operator-manager/main.go
+++ b/cmd/package-operator-manager/main.go
@@ -216,7 +216,7 @@ func (pkoMgr *packageOperatorManager) probeHyperShiftIntegration(
 		}
 
 	case meta.IsNoMatchError(err) || apimachineryerrors.IsNotFound(err) ||
-		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		errors.Is(err, &discovery.ErrGroupDiscoveryFailed{}):
 		ticker := clock.RealClock{}.NewTicker(hyperShiftPollInterval)
 		if err := pkoMgr.mgr.Add(
 			newHypershift(

--- a/integration/package-operator/000_upgrade_test.go
+++ b/integration/package-operator/000_upgrade_test.go
@@ -35,6 +35,14 @@ const (
 )
 
 func TestUpgrade(t *testing.T) {
+	// Skip test if short flag is active.
+	// This allows `./do dev:integrationdirect` to skip the whole test
+	// that tries to reinstall and upgrade pko in-cluster
+	// because PKO is most likely running outside of the cluster.
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 
 	require.NoError(t, deleteExistingPKO(ctx))

--- a/integration/package-operator/environment.go
+++ b/integration/package-operator/environment.go
@@ -2,11 +2,14 @@ package packageoperator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -142,6 +145,7 @@ func initClients(_ context.Context) error {
 		scheme.AddToScheme,
 		apis.AddToScheme,
 		hypershiftv1beta1.AddToScheme,
+		configv1.AddToScheme,
 	}
 	if err := AddToSchemes.AddToScheme(Scheme); err != nil {
 		return fmt.Errorf("could not load schemes: %w", err)
@@ -168,24 +172,21 @@ func initClients(_ context.Context) error {
 }
 
 func findPackageOperatorNamespace(ctx context.Context) string {
-	// discover packageOperator Namespace
-	deploymentList := &appsv1.DeploymentList{}
-	// We can't use a label-selector, because OLM is overriding the deployment labels...
-	if err := Client.List(ctx, deploymentList); err != nil {
-		panic(fmt.Errorf("listing package-operator deployments on the cluster: %w", err))
-	}
-	var packageOperatorDeployments []appsv1.Deployment
-	for _, deployment := range deploymentList.Items {
-		if deployment.Name == "package-operator-manager" {
-			packageOperatorDeployments = append(packageOperatorDeployments, deployment)
-		}
-	}
-	switch len(packageOperatorDeployments) {
-	case 0:
-		panic("no packageOperator deployment found on the cluster")
-	case 1:
-		return packageOperatorDeployments[0].Namespace
+	clusterVersion := &configv1.ClusterVersion{}
+	err := Client.Get(ctx, client.ObjectKey{
+		Name: "version",
+	}, clusterVersion)
+
+	switch {
+	case meta.IsNoMatchError(err) ||
+		apimachineryerrors.IsNotFound(err) ||
+		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		// API not registered in cluster - must be Kubernetes cluster.
+		return "package-operator-system"
+	case err != nil:
+		panic(fmt.Errorf("detecting openshift or kubernetes cluster: %w", err))
 	default:
-		panic("multiple packageOperator deployments found on the cluster")
+		// API registered in cluster - must be OpenShift cluster.
+		return "openshift-package-operator"
 	}
 }

--- a/integration/package-operator/environment.go
+++ b/integration/package-operator/environment.go
@@ -180,7 +180,7 @@ func findPackageOperatorNamespace(ctx context.Context) string {
 	switch {
 	case meta.IsNoMatchError(err) ||
 		apimachineryerrors.IsNotFound(err) ||
-		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		errors.Is(err, &discovery.ErrGroupDiscoveryFailed{}):
 		// API not registered in cluster - must be Kubernetes cluster.
 		return "package-operator-system"
 	case err != nil:

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -176,7 +176,7 @@ func (m *Manager) openShiftEnvironment(ctx context.Context) (
 	switch {
 	case meta.IsNoMatchError(err) ||
 		apimachineryerrors.IsNotFound(err) ||
-		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		errors.Is(err, &discovery.ErrGroupDiscoveryFailed{}):
 		// API not registered in cluster
 		return nil, false, nil
 	case err != nil:
@@ -275,7 +275,7 @@ func (m *Manager) hyperShiftEnvironment() (
 
 	case meta.IsNoMatchError(err) ||
 		apimachineryerrors.IsNotFound(err) ||
-		discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)):
+		errors.Is(err, &discovery.ErrGroupDiscoveryFailed{}):
 		// HyperShift HostedCluster API is NOT present on the cluster.
 		return nil, false, nil
 	}


### PR DESCRIPTION
## Introduce `./do dev:IntegrationDirect` to allow partially running integration tests without bootstrapping a full integration test environment

This can be useful when rapidly iterating on code changes and runnning package-operator-manager outside of the dev cluster with `./do dev:run`.

After this change devs can restart `./do dev:run` and then use `./do dev:integrationdirect` to only run a specific integration-test.

`dev:integrationdirect` will use go tests' short mode to skip the upgrade test, because it will install and upgrade pko inside the integration cluster which is undesirable when running pko-manager out-of-cluster.

Example: `./do dev:integrationdirect TestObjectSet_handover`

---

The PR also contains a change to the routine that detects package-operator's namespace before starting integration tests and now returns hardcoded values for kubernetes and openshift environments:
- kubernetes: `package-operator-system`
- openshift: `openshift-package-operator`

---

The PR also contains a change to all routines that detect if a certain api is installed in the apiserver to use `errors.Is(err, &discovery.ErrGroupDiscoveryFailed{})` instead of `discovery.IsGroupDiscoveryFailedError(errors.Unwrap(err)` to prevent not detecting errors that are wrapped into other errors more than one layer.
It does not do anything useful for now, but it may prevent nasty surprises in the future.

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
