### PR TITLE
Add image dependencies to template engine.

### DIFF
--- a/internal/packages/internal/packagedeploy/deployer.go
+++ b/internal/packages/internal/packagedeploy/deployer.go
@@ -183,15 +183,28 @@ func (l *PackageDeployer) Deploy(
 			images[packageImage.Name] = resolvedImage
 		}
 	}
+	dependencies := map[string]string{}
+	if pkg.ManifestLock != nil {
+		for _, packageImage := range pkg.ManifestLock.Spec.Dependencies {
+			replacedImage := imageprefix.Replace(packageImage.Image, l.imagePrefixOverrides)
+
+			resolvedImage, err := ImageWithDigest(replacedImage, packageImage.Digest)
+			if err != nil {
+				return err
+			}
+			dependencies[packageImage.Name] = resolvedImage
+		}
+	}
 
 	// render package instance
 	pkgInstance, err := packagerender.RenderPackageInstance(
 		ctx, pkg,
 		packagetypes.PackageRenderContext{
-			Package:     tmplCtx.Package,
-			Config:      configuration,
-			Images:      images,
-			Environment: env,
+			Package:      tmplCtx.Package,
+			Config:       configuration,
+			Images:       images,
+			Dependencies: dependencies,
+			Environment:  env,
 		}, l.packageValidators, packagevalidation.DefaultObjectValidators)
 	if err != nil {
 		setInvalidConditionBasedOnLoadError(apiPkg, err)

--- a/internal/packages/internal/packagetypes/types.go
+++ b/internal/packages/internal/packagetypes/types.go
@@ -45,10 +45,11 @@ type PackageInstance struct {
 
 // PackageRenderContext contains all data that is needed to render a Package into a PackageInstance.
 type PackageRenderContext struct {
-	Package     manifests.TemplateContextPackage `json:"package"`
-	Config      map[string]any                   `json:"config"`
-	Images      map[string]string                `json:"images"`
-	Environment manifests.PackageEnvironment     `json:"environment"`
+	Package      manifests.TemplateContextPackage `json:"package"`
+	Config       map[string]any                   `json:"config"`
+	Images       map[string]string                `json:"images"`
+	Dependencies map[string]string                `json:"dependencies"`
+	Environment  manifests.PackageEnvironment     `json:"environment"`
 }
 
 // RawPackage right after import.

--- a/internal/packages/internal/packagevalidation/templatevalidation.go
+++ b/internal/packages/internal/packagevalidation/templatevalidation.go
@@ -94,10 +94,11 @@ func (v TemplateTestValidator) runTestCase(
 	}
 
 	tmplCtx := packagetypes.PackageRenderContext{
-		Package:     testCase.Context.Package,
-		Config:      configuration,
-		Images:      generateStaticImages(pkg.Manifest),
-		Environment: testCase.Context.Environment,
+		Package:      testCase.Context.Package,
+		Config:       configuration,
+		Images:       generateStaticImages(pkg.Manifest),
+		Dependencies: generateStaticDependencies(pkg.Manifest),
+		Environment:  testCase.Context.Environment,
 	}
 	if err := packagerender.RenderTemplates(ctx, pkg, tmplCtx); err != nil {
 		return err
@@ -276,4 +277,13 @@ func generateStaticImages(manifest *manifests.PackageManifest) map[string]string
 		images[v.Name] = staticImage
 	}
 	return images
+}
+
+// generateStaticDependencies generates a static set of dependencies to be used for tests and other purposes.
+func generateStaticDependencies(manifest *manifests.PackageManifest) map[string]string {
+	dependencies := map[string]string{}
+	for _, v := range manifest.Spec.Dependencies {
+		dependencies[v.Image.Name] = staticImage
+	}
+	return dependencies
 }


### PR DESCRIPTION
The dependency resolution feature did not expose the resolved images to the template engine, which prevents users from using the feature. This commit properly adds dependencies as a new top-level property to the template context.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.
- [ ] The commits in this PR follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
      standard.

### Additional Information

<!-- Report any other relevant details below -->
