### PR TITLE
ROSAENG-65550: go-containerregistry 0.21.9 in-cluster HTTP pulls and OCI unpack

### DIFF
--- a/cmd/build/bootstrap.go
+++ b/cmd/build/bootstrap.go
@@ -181,5 +181,7 @@ func printSavedBootstrapJobLogs() {
 		fmt.Fprintf(os.Stderr, "no captured bootstrap job logs at %s\n", path)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "\n===== captured bootstrap job logs =====\n%s\n===== end captured bootstrap job logs =====\n", data)
+	fmt.Fprintln(os.Stderr, "\n===== captured bootstrap job logs =====")
+	fmt.Fprint(os.Stderr, string(data))
+	fmt.Fprintln(os.Stderr, "===== end captured bootstrap job logs =====")
 }

--- a/cmd/build/bootstrap.go
+++ b/cmd/build/bootstrap.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"pkg.package-operator.run/cardboard/run"
+	"pkg.package-operator.run/cardboard/sh"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
@@ -30,7 +34,7 @@ func bootstrap(ctx context.Context) error {
 
 	err = cl.CreateAndWaitFromFiles(ctx, []string{filepath.Join("config", "self-bootstrap-job-local.yaml")})
 	if err != nil {
-		return err
+		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "create-bootstrap-job"))
 	}
 
 	// Bootstrap job is cleaning itself up after completion, so we can't wait for Condition Completed=True.
@@ -42,7 +46,7 @@ func bootstrap(ctx context.Context) error {
 		func(client.Object) (done bool, err error) { return },
 	)
 	if err != nil {
-		return err
+		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "wait-job-gone"))
 	}
 
 	err = cl.Waiter.WaitForCondition(ctx,
@@ -55,8 +59,62 @@ func bootstrap(ctx context.Context) error {
 		metav1.ConditionTrue,
 	)
 	if err != nil {
-		return err
+		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "clusterpackage-available"))
 	}
 
+	return nil
+}
+
+func dumpBootstrapDiagnostics(ctx context.Context, stage string) error {
+	fmt.Fprintf(os.Stderr, "\n===== bootstrap diagnostics (%s) =====\n", stage)
+
+	kubeconfigPath, err := cluster.KubeconfigPath()
+	if err != nil {
+		return fmt.Errorf("kubeconfig path: %w", err)
+	}
+
+	debugDir := filepath.Join(cacheDir, "integration", "bootstrap-debug")
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir bootstrap debug dir: %w", err)
+	}
+
+	kubectl := shr.New(sh.WithEnvironment{"KUBECONFIG": kubeconfigPath})
+	cmds := [][]string{
+		{"get", "ns"},
+		{"get", "all,jobs,events", "-n", "package-operator-system", "-o", "wide"},
+		{"get", "clusterpackage,package", "-A", "-o", "yaml"},
+		{"describe", "clusterpackage", "package-operator"},
+		{"get", "events", "-A", "--sort-by=.lastTimestamp"},
+	}
+	for _, args := range cmds {
+		_ = kubectl.Run(ctx, "kubectl", args...)
+	}
+
+	script := fmt.Sprintf(`
+set +e
+mkdir -p %q
+kubectl get ns > %q/namespaces.txt 2>&1
+kubectl get all,jobs -n package-operator-system -o wide > %q/pko-system-workload.txt 2>&1
+kubectl get clusterpackage,package -A -o yaml > %q/packages.yaml 2>&1
+kubectl describe clusterpackage package-operator > %q/clusterpackage.describe.txt 2>&1
+kubectl get events -A --sort-by=.lastTimestamp > %q/events.txt 2>&1
+kubectl get pods -n package-operator-system --no-headers -o custom-columns=:metadata.name |
+while read -r pod; do
+  [ -z "$pod" ] && continue
+  kubectl logs -n package-operator-system "$pod" --all-containers --prefix --tail=500 \
+    > %q/"$pod".log 2>&1
+  kubectl logs -n package-operator-system "$pod" --all-containers --prefix --previous --tail=200 \
+    > %q/"$pod".previous.log 2>&1
+  echo "----- logs: $pod -----"
+  cat %q/"$pod".log
+done
+`, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir)
+	_ = kubectl.Bash(ctx, script)
+
+	if err := cluster.ExportLogs(filepath.Join(cacheDir, "integration", "logs")); err != nil {
+		fmt.Fprintf(os.Stderr, "kind export logs: %v\n", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "===== end bootstrap diagnostics (%s) =====\n", stage)
 	return nil
 }

--- a/cmd/build/bootstrap.go
+++ b/cmd/build/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,12 @@ func bootstrap(ctx context.Context) error {
 		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "create-bootstrap-job"))
 	}
 
+	// Job ttlSecondsAfterFinished: 0 deletes pods as soon as it finishes/fails.
+	// Snapshot logs while the Job is still around or we lose the panic text.
+	snapCtx, stopSnap := context.WithCancel(ctx)
+	defer stopSnap()
+	go snapshotBootstrapJobLogsLoop(snapCtx)
+
 	// Bootstrap job is cleaning itself up after completion, so we can't wait for Condition Completed=True.
 	// See self-bootstrap-job .spec.ttlSecondsAfterFinished: 0
 	err = cl.Waiter.WaitToBeGone(ctx,
@@ -45,6 +52,7 @@ func bootstrap(ctx context.Context) error {
 		},
 		func(client.Object) (done bool, err error) { return },
 	)
+	stopSnap()
 	if err != nil {
 		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "wait-job-gone"))
 	}
@@ -116,5 +124,62 @@ done
 	}
 
 	fmt.Fprintf(os.Stderr, "===== end bootstrap diagnostics (%s) =====\n", stage)
+	printSavedBootstrapJobLogs()
 	return nil
+}
+
+func snapshotBootstrapJobLogsLoop(ctx context.Context) {
+	_ = snapshotBootstrapJobLogs(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = snapshotBootstrapJobLogs(context.WithoutCancel(ctx))
+			return
+		case <-ticker.C:
+			_ = snapshotBootstrapJobLogs(ctx)
+		}
+	}
+}
+
+func bootstrapDebugDir() string {
+	return filepath.Join(cacheDir, "integration", "bootstrap-debug")
+}
+
+func snapshotBootstrapJobLogs(ctx context.Context) error {
+	kubeconfigPath, err := cluster.KubeconfigPath()
+	if err != nil {
+		return err
+	}
+	debugDir := bootstrapDebugDir()
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		return err
+	}
+	kubectl := shr.New(sh.WithEnvironment{"KUBECONFIG": kubeconfigPath})
+	script := fmt.Sprintf(`
+set +e
+ns=package-operator-system
+kubectl get job,pods,events -n "$ns" -o wide > %q/job-snapshot.txt 2>&1
+: > %q/job-logs.txt
+kubectl get pods -n "$ns" --no-headers -o custom-columns=:metadata.name 2>/dev/null |
+while read -r pod; do
+  [ -z "$pod" ] && continue
+  echo "===== $pod current =====" >> %q/job-logs.txt
+  kubectl logs -n "$ns" "$pod" --all-containers --prefix --tail=200 >> %q/job-logs.txt 2>&1
+  echo "===== $pod previous =====" >> %q/job-logs.txt
+  kubectl logs -n "$ns" "$pod" --all-containers --prefix --previous --tail=200 >> %q/job-logs.txt 2>&1
+done
+`, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir)
+	return kubectl.Bash(ctx, script)
+}
+
+func printSavedBootstrapJobLogs() {
+	path := filepath.Join(bootstrapDebugDir(), "job-logs.txt")
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "no captured bootstrap job logs at %s\n", path)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n===== captured bootstrap job logs =====\n%s\n===== end captured bootstrap job logs =====\n", data)
 }

--- a/cmd/build/bootstrap.go
+++ b/cmd/build/bootstrap.go
@@ -2,16 +2,11 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
 	"path/filepath"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"pkg.package-operator.run/cardboard/run"
-	"pkg.package-operator.run/cardboard/sh"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "package-operator.run/apis/core/v1alpha1"
@@ -35,14 +30,8 @@ func bootstrap(ctx context.Context) error {
 
 	err = cl.CreateAndWaitFromFiles(ctx, []string{filepath.Join("config", "self-bootstrap-job-local.yaml")})
 	if err != nil {
-		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "create-bootstrap-job"))
+		return err
 	}
-
-	// Job ttlSecondsAfterFinished: 0 deletes pods as soon as it finishes/fails.
-	// Snapshot logs while the Job is still around or we lose the panic text.
-	snapCtx, stopSnap := context.WithCancel(ctx)
-	defer stopSnap()
-	go snapshotBootstrapJobLogsLoop(snapCtx)
 
 	// Bootstrap job is cleaning itself up after completion, so we can't wait for Condition Completed=True.
 	// See self-bootstrap-job .spec.ttlSecondsAfterFinished: 0
@@ -52,9 +41,8 @@ func bootstrap(ctx context.Context) error {
 		},
 		func(client.Object) (done bool, err error) { return },
 	)
-	stopSnap()
 	if err != nil {
-		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "wait-job-gone"))
+		return err
 	}
 
 	err = cl.Waiter.WaitForCondition(ctx,
@@ -67,121 +55,8 @@ func bootstrap(ctx context.Context) error {
 		metav1.ConditionTrue,
 	)
 	if err != nil {
-		return errors.Join(err, dumpBootstrapDiagnostics(ctx, "clusterpackage-available"))
+		return err
 	}
 
 	return nil
-}
-
-func dumpBootstrapDiagnostics(ctx context.Context, stage string) error {
-	fmt.Fprintf(os.Stderr, "\n===== bootstrap diagnostics (%s) =====\n", stage)
-
-	kubeconfigPath, err := cluster.KubeconfigPath()
-	if err != nil {
-		return fmt.Errorf("kubeconfig path: %w", err)
-	}
-
-	debugDir := filepath.Join(cacheDir, "integration", "bootstrap-debug")
-	if err := os.MkdirAll(debugDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir bootstrap debug dir: %w", err)
-	}
-
-	kubectl := shr.New(sh.WithEnvironment{"KUBECONFIG": kubeconfigPath})
-	cmds := [][]string{
-		{"get", "ns"},
-		{"get", "all,jobs,events", "-n", "package-operator-system", "-o", "wide"},
-		{"get", "clusterpackage,package", "-A", "-o", "yaml"},
-		{"describe", "clusterpackage", "package-operator"},
-		{"get", "events", "-A", "--sort-by=.lastTimestamp"},
-	}
-	for _, args := range cmds {
-		_ = kubectl.Run(ctx, "kubectl", args...)
-	}
-
-	script := fmt.Sprintf(`
-set +e
-mkdir -p %q
-kubectl get ns > %q/namespaces.txt 2>&1
-kubectl get all,jobs -n package-operator-system -o wide > %q/pko-system-workload.txt 2>&1
-kubectl get clusterpackage,package -A -o yaml > %q/packages.yaml 2>&1
-kubectl describe clusterpackage package-operator > %q/clusterpackage.describe.txt 2>&1
-kubectl get events -A --sort-by=.lastTimestamp > %q/events.txt 2>&1
-kubectl get pods -n package-operator-system --no-headers -o custom-columns=:metadata.name |
-while read -r pod; do
-  [ -z "$pod" ] && continue
-  kubectl logs -n package-operator-system "$pod" --all-containers --prefix --tail=500 \
-    > %q/"$pod".log 2>&1
-  kubectl logs -n package-operator-system "$pod" --all-containers --prefix --previous --tail=200 \
-    > %q/"$pod".previous.log 2>&1
-  echo "----- logs: $pod -----"
-  cat %q/"$pod".log
-done
-`, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir)
-	_ = kubectl.Bash(ctx, script)
-
-	if err := cluster.ExportLogs(filepath.Join(cacheDir, "integration", "logs")); err != nil {
-		fmt.Fprintf(os.Stderr, "kind export logs: %v\n", err)
-	}
-
-	fmt.Fprintf(os.Stderr, "===== end bootstrap diagnostics (%s) =====\n", stage)
-	printSavedBootstrapJobLogs()
-	return nil
-}
-
-func snapshotBootstrapJobLogsLoop(ctx context.Context) {
-	_ = snapshotBootstrapJobLogs(ctx)
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			_ = snapshotBootstrapJobLogs(context.WithoutCancel(ctx))
-			return
-		case <-ticker.C:
-			_ = snapshotBootstrapJobLogs(ctx)
-		}
-	}
-}
-
-func bootstrapDebugDir() string {
-	return filepath.Join(cacheDir, "integration", "bootstrap-debug")
-}
-
-func snapshotBootstrapJobLogs(ctx context.Context) error {
-	kubeconfigPath, err := cluster.KubeconfigPath()
-	if err != nil {
-		return err
-	}
-	debugDir := bootstrapDebugDir()
-	if err := os.MkdirAll(debugDir, 0o755); err != nil {
-		return err
-	}
-	kubectl := shr.New(sh.WithEnvironment{"KUBECONFIG": kubeconfigPath})
-	script := fmt.Sprintf(`
-set +e
-ns=package-operator-system
-kubectl get job,pods,events -n "$ns" -o wide > %q/job-snapshot.txt 2>&1
-: > %q/job-logs.txt
-kubectl get pods -n "$ns" --no-headers -o custom-columns=:metadata.name 2>/dev/null |
-while read -r pod; do
-  [ -z "$pod" ] && continue
-  echo "===== $pod current =====" >> %q/job-logs.txt
-  kubectl logs -n "$ns" "$pod" --all-containers --prefix --tail=200 >> %q/job-logs.txt 2>&1
-  echo "===== $pod previous =====" >> %q/job-logs.txt
-  kubectl logs -n "$ns" "$pod" --all-containers --prefix --previous --tail=200 >> %q/job-logs.txt 2>&1
-done
-`, debugDir, debugDir, debugDir, debugDir, debugDir, debugDir)
-	return kubectl.Bash(ctx, script)
-}
-
-func printSavedBootstrapJobLogs() {
-	path := filepath.Join(bootstrapDebugDir(), "job-logs.txt")
-	data, err := os.ReadFile(path)
-	if err != nil || len(data) == 0 {
-		fmt.Fprintf(os.Stderr, "no captured bootstrap job logs at %s\n", path)
-		return
-	}
-	fmt.Fprintln(os.Stderr, "\n===== captured bootstrap job logs =====")
-	fmt.Fprint(os.Stderr, string(data))
-	fmt.Fprintln(os.Stderr, "===== end captured bootstrap job logs =====")
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	err := errors.Join(
 		// Required by cardboard itself.
-		mgr.RegisterGoTool(ctx, "crane", "github.com/google/go-containerregistry/cmd/crane", "0.21.7"),
+		mgr.RegisterGoTool(ctx, "crane", "github.com/google/go-containerregistry/cmd/crane", "0.21.9"),
 		// Our deps
 		mgr.RegisterGoTool(ctx, "gotestfmt", "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt", "2.5.0"),
 		mgr.RegisterGoTool(ctx, "controller-gen", "sigs.k8s.io/controller-tools/cmd/controller-gen", "0.20.1"),

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/gobwas/glob v0.2.3
 	github.com/google/cel-go v0.31.0
-	github.com/google/go-containerregistry v0.21.5
+	github.com/google/go-containerregistry v0.21.9
 	github.com/joeycumines/go-dotnotation v0.0.0-20180131115956-2d3612e36c5d
 	github.com/json-iterator/go v1.1.12
 	github.com/onsi/ginkgo/v2 v2.32.1
@@ -68,7 +68,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/console v1.0.5 // indirect
-	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/docker/cli v29.7.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
@@ -113,7 +112,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
@@ -129,7 +127,6 @@ require (
 	github.com/sirupsen/logrus v1.10.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/vbatts/tar-split v0.12.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
-github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
@@ -144,8 +142,8 @@ github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4y
 github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-containerregistry v0.21.5 h1:KTJG9Pn/jC0VdZR6ctV3/jcN+q6/Iqlx0sTVz3ywZlM=
-github.com/google/go-containerregistry v0.21.5/go.mod h1:ySvMuiWg+dOsRW0Hw8GYwfMwBlNRTmpYBFJPlkco5zU=
+github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/216WGQq2dokuLs=
+github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -205,8 +203,6 @@ github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3v
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -283,8 +279,6 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
-github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
-github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/internal/packages/internal/packageimport/oci.go
+++ b/internal/packages/internal/packageimport/oci.go
@@ -99,7 +99,7 @@ func appendFilesFromLayer(
 
 		data, err := io.ReadAll(tarReader)
 		if err != nil {
-			return fmt.Errorf("read file header from layer: %w", err)
+			return fmt.Errorf("read file contents from layer: %w", err)
 		}
 
 		files[pkgPath] = data

--- a/internal/packages/internal/packageimport/oci.go
+++ b/internal/packages/internal/packageimport/oci.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-logr/logr"
 	containerregistrypkgv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 
 	"package-operator.run/internal/packages/internal/packagetypes"
 )
@@ -21,41 +21,20 @@ func FromOCI(ctx context.Context, image containerregistrypkgv1.Image) (
 	rawPkg *packagetypes.RawPackage, err error,
 ) {
 	files := packagetypes.Files{}
-	reader := mutate.Extract(image)
 	verboseLog := logr.FromContextOrDiscard(ctx).V(1)
 
-	defer func() {
-		if cErr := reader.Close(); err == nil && cErr != nil {
-			err = cErr
-		}
-	}()
-	tarReader := tar.NewReader(reader)
+	layers, err := image.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("read image layers: %w", err)
+	}
 
-	for {
-		hdr, err := tarReader.Next()
-		if err != nil && errors.Is(err, io.EOF) {
-			break
-		}
-
-		path, err := stripOCIPathPrefix(hdr.Name)
-		if err != nil {
+	// Read layers in order so later layers override earlier ones. Do not use
+	// mutate.Extract: since go-containerregistry v0.21.8 a "." tar entry is
+	// treated as a root whiteout and hides every package file.
+	for _, layer := range layers {
+		if err := appendFilesFromLayer(verboseLog, layer, files); err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(path, "../") {
-			continue
-		}
-
-		if isFilePathToBeExcluded(path) {
-			verboseLog.Info("skipping file in source", "path", path)
-			continue
-		}
-
-		data, err := io.ReadAll(tarReader)
-		if err != nil {
-			return nil, fmt.Errorf("read file header from layer: %w", err)
-		}
-
-		files[path] = data
 	}
 
 	if len(files) == 0 {
@@ -71,6 +50,62 @@ func FromOCI(ctx context.Context, image containerregistrypkgv1.Image) (
 		Files:  files,
 		Labels: cf.Config.Labels,
 	}, nil
+}
+
+func appendFilesFromLayer(
+	verboseLog logr.Logger, layer containerregistrypkgv1.Layer, files packagetypes.Files,
+) (err error) {
+	reader, err := layer.Uncompressed()
+	if err != nil {
+		return fmt.Errorf("read layer contents: %w", err)
+	}
+	defer func() {
+		if cErr := reader.Close(); err == nil && cErr != nil {
+			err = cErr
+		}
+	}()
+
+	tarReader := tar.NewReader(reader)
+	for {
+		hdr, nextErr := tarReader.Next()
+		if nextErr != nil {
+			if errors.Is(nextErr, io.EOF) {
+				break
+			}
+			return fmt.Errorf("read file header from layer: %w", nextErr)
+		}
+
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+
+		name := path.Clean(strings.ReplaceAll(hdr.Name, "\\", "/"))
+		if name == "." || name == ".." || strings.HasPrefix(name, "../") {
+			continue
+		}
+
+		pkgPath, err := stripOCIPathPrefix(hdr.Name)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(pkgPath, "../") {
+			continue
+		}
+
+		if isFilePathToBeExcluded(pkgPath) {
+			verboseLog.Info("skipping file in source", "path", pkgPath)
+			continue
+		}
+
+		data, err := io.ReadAll(tarReader)
+		if err != nil {
+			return fmt.Errorf("read file header from layer: %w", err)
+		}
+
+		files[pkgPath] = data
+	}
+
+	return nil
 }
 
 func stripOCIPathPrefix(path string) (string, error) {

--- a/internal/packages/internal/packageimport/oci_test.go
+++ b/internal/packages/internal/packageimport/oci_test.go
@@ -46,3 +46,20 @@ func TestFromOCI_EmptyImage(t *testing.T) {
 	_, err := FromOCI(ctx, image)
 	require.EqualError(t, err, packagetypes.ErrEmptyPackage.Error())
 }
+
+func TestFromOCI_DotTarEntry(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{"test": "test123"}
+	image := testutil.BuildImage(t, map[string][]byte{
+		".": []byte{},
+		packagetypes.OCIPathPrefix + "/file.yaml": []byte(`test: test`),
+	}, labels)
+
+	ctx := logr.NewContext(context.Background(), testr.New(t))
+	rawPkg, err := FromOCI(ctx, image)
+	require.NoError(t, err)
+	assert.Equal(t, packagetypes.Files{
+		"file.yaml": []byte(`test: test`),
+	}, rawPkg.Files)
+}

--- a/internal/packages/internal/packageimport/oci_test.go
+++ b/internal/packages/internal/packageimport/oci_test.go
@@ -51,10 +51,11 @@ func TestFromOCI_DotTarEntry(t *testing.T) {
 	t.Parallel()
 
 	labels := map[string]string{"test": "test123"}
-	image := testutil.BuildImage(t, map[string][]byte{
+	layer := map[string][]byte{
 		".": []byte{},
-		packagetypes.OCIPathPrefix + "/file.yaml": []byte(`test: test`),
-	}, labels)
+	}
+	layer[packagetypes.OCIPathPrefix+"/file.yaml"] = []byte(`test: test`)
+	image := testutil.BuildImage(t, layer, labels)
 
 	ctx := logr.NewContext(context.Background(), testr.New(t))
 	rawPkg, err := FromOCI(ctx, image)

--- a/internal/packages/internal/packageimport/oci_test.go
+++ b/internal/packages/internal/packageimport/oci_test.go
@@ -52,7 +52,7 @@ func TestFromOCI_DotTarEntry(t *testing.T) {
 
 	labels := map[string]string{"test": "test123"}
 	layer := map[string][]byte{
-		".": []byte{},
+		".": {},
 	}
 	layer[packagetypes.OCIPathPrefix+"/file.yaml"] = []byte(`test: test`)
 	image := testutil.BuildImage(t, layer, labels)

--- a/internal/packages/internal/packageimport/registry.go
+++ b/internal/packages/internal/packageimport/registry.go
@@ -22,7 +22,10 @@ func FromRegistryInCluster(
 	if err != nil {
 		return nil, fmt.Errorf("creating keychain: %w", err)
 	}
-	opts = append(opts, crane.WithAuthFromKeychain(chain))
+	// go-containerregistry v0.21.9 only treats *.localhost as HTTP. PKO rewrites
+	// pulls to *.svc.cluster.local HTTP registries (CI/kind). crane.Insecure still
+	// prefers HTTPS when the registry speaks TLS.
+	opts = append(opts, crane.WithAuthFromKeychain(chain), crane.Insecure)
 	return FromRegistry(ctx, ref, opts...)
 }
 

--- a/internal/packages/internal/packageimport/registry.go
+++ b/internal/packages/internal/packageimport/registry.go
@@ -23,8 +23,9 @@ func FromRegistryInCluster(
 		return nil, fmt.Errorf("creating keychain: %w", err)
 	}
 	// go-containerregistry v0.21.9 only treats *.localhost as HTTP. PKO rewrites
-	// pulls to *.svc.cluster.local HTTP registries (CI/kind). crane.Insecure still
-	// prefers HTTPS when the registry speaks TLS.
+	// pulls to *.svc.cluster.local HTTP registries (CI/kind). crane.Insecure sets
+	// name.Insecure so Scheme() is http (ping tries HTTPS first, then HTTP). The
+	// default transport also skips TLS certificate verification.
 	opts = append(opts, crane.WithAuthFromKeychain(chain), crane.Insecure)
 	return FromRegistry(ctx, ref, opts...)
 }


### PR DESCRIPTION
## Summary

Completes the `go-containerregistry` **0.21.5 → 0.21.9** bump from #2651 / [ROSAENG-65550](https://redhat.atlassian.net/browse/ROSAENG-65550).

### What actually broke CI

Integration failed in **bootstrap**, before unpack. The manager image pulled fine (kubelet + containerd HTTP mirror). The process then **panicked in ~50ms** (`exit 2`):

```
panic: init: crdsFromPackage: Get "https://dev-registry.dev-registry.svc.cluster.local:5001/v2/": http: server gave HTTP response to HTTPS client
```

PKO rewrites `dev.package-operator.run` to `dev-registry.dev-registry.svc.cluster.local:5001` (plain HTTP). In **v0.21.5**, `reLocal` was `.*\.local(?:host)?`, so `*.svc.cluster.local` was treated as HTTP. In **v0.21.9** it is only `.*\.localhost`, so that host is **HTTPS-only**. Unit tests never hit this registry, so they stayed green.

**Fix:** pass `crane.Insecure` on in-cluster pulls (`FromRegistryInCluster`). Crane still prefers HTTPS when the registry speaks TLS. Reproduced locally with `./do Dev:Bootstrap` on kind.

### Also in this PR

- Unpack package files from image layers instead of `mutate.Extract`. In v0.21.8 a `.` tar entry is a root whiteout and would hide everything under `package/`. That is a real library change, but it was **not** the panic we saw in kind/CI.
- Pin the cardboard `crane` CLI to 0.21.9.

## Test plan

- [x] Local kind `Dev:Bootstrap` — ClusterPackage Available after `crane.Insecure`
- [x] GitHub `lint-unit-int` on the fix commit
- [ ] Re-check `lint-unit-int` after dropping temporary bootstrap diagnostic dumps